### PR TITLE
Add explicit require for eieio

### DIFF
--- a/majutsu-base.el
+++ b/majutsu-base.el
@@ -15,6 +15,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'eieio)
 (require 'seq)
 (require 'subr-x)
 

--- a/majutsu-op.el
+++ b/majutsu-op.el
@@ -14,6 +14,7 @@
 ;;; Code:
 
 (require 'majutsu)
+(require 'eieio)
 
 ;;; majutsu-undo
 


### PR DESCRIPTION
It looks like majutsu depends on eieio but doesn't `require` it explicitly. I can't load majutsu without this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **维护更新**
  * 添加了内部依赖以改进系统架构。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->