### PR TITLE
Fix majutsu-new with -r

### DIFF
--- a/majutsu-new.el
+++ b/majutsu-new.el
@@ -74,7 +74,7 @@ With prefix ARG, open the new transient for interactive selection."
   :selection-face '(:background "dark orange" :foreground "black")
   :selection-type 'multi
   :key "-r"
-  :argument "-r"
+  :argument ""
   :multi-value 'repeat
   :reader #'majutsu-diff--transient-read-revset)
 
@@ -108,7 +108,7 @@ With prefix ARG, open the new transient for interactive selection."
   :selection-key 'parent
   :selection-type 'multi
   :key "p"
-  :argument "-r"
+  :argument ""
   :multi-value 'repeat)
 
 (transient-define-argument majutsu-new:after ()


### PR DESCRIPTION
If you try to specify the target revision with `-r` on majutsu-new, it produces an error.

`jj new -rfoo` isn't valid - it has to be one of `jj new -r foo` or `jj new foo`, at least in jj 0.36.

(AFAICT the canonical form is simply `jj new foo` - the -r flag isn't even documented.)

---

I suspect this is not the best fix - I can't find anyone using `(transient-define-argument ... :argument "")`. If you know the correct way of dealing with this in transient, feel free to discard this PR and start fresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 修复

* 调整了特定命令的参数处理机制，改进了参数接收方式。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->