### PR TITLE
fix: silence clean-compile warnings for majutsu-read-files and majutsu-tpl

### DIFF
--- a/majutsu-diff.el
+++ b/majutsu-diff.el
@@ -34,6 +34,7 @@
 (require 'smerge-mode)
 
 (declare-function majutsu-find-file "majutsu-file" (revset path))
+(declare-function majutsu-read-files "majutsu-file" (prompt initial-input history &optional list-fn))
 (declare-function majutsu-color-words-line-info-at-point "majutsu-color-words" ())
 (declare-function majutsu-color-words-side-at-point "majutsu-color-words" (&optional pos))
 (declare-function majutsu-color-words-column-at-point "majutsu-color-words" (goto-from &optional pos info))

--- a/majutsu-jj.el
+++ b/majutsu-jj.el
@@ -29,6 +29,8 @@
 (require 'with-editor)
 (require 'majutsu-base)
 
+(eval-when-compile (require 'majutsu-template))
+
 (autoload 'majutsu-process-file "majutsu-process" nil nil)
 
 ;;; Options


### PR DESCRIPTION
## Summary

Two files reference symbols from other majutsu modules without any `require` or `declare-function`, so clean-compile warns:

```
majutsu-diff.el:1481:13: Warning: the function 'majutsu-read-files' is not known to be defined.
majutsu-jj.el:359:39:   Warning: the function 'majutsu-tpl' is not known to be defined.
```

## Changes

Two small, independent commits:

1. **`fix(diff)`** — `majutsu-read-files` lives in `majutsu-file.el`. Add a `declare-function` alongside the existing declaration for `majutsu-find-file`.
2. **`fix(jj)`** — `majutsu-tpl` is a macro in `majutsu-template.el`. `declare-function` is insufficient for macros (the caller would be compiled as a function call instead of having the macro expanded), so pull it in with `(eval-when-compile (require 'majutsu-template))`.

Both fixes follow idioms already present in the repo: `majutsu-diff.el` relies on `declare-function` for cross-file references (`majutsu-find-file`, the `majutsu-color-words-*` helpers), and `eval-when-compile` is the standard way to make macros visible to the compiler without a runtime require.

## Verification

Rebuilt the package from scratch against Emacs 30.2.50 with native-comp and the same deps used in production. Before, boot produced the two warnings quoted above; after, boot is clean and neither warning appears.

```sh
rm -rf .local/straight/build-30.2.50/majutsu
doom sync --rebuild
# no majutsu warnings in the output
```

## Test plan

- [x] Clean rebuild of majutsu produces no warnings for `majutsu-read-files` or `majutsu-tpl`
- [x] `majutsu-tpl` still expands correctly at compile time (log/op views continue to render the jj graph — verified interactively)
- [x] No new warnings introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal module declarations and build-time dependencies for better code organization and compilation efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->