### PR TITLE
Add key binding for majutsu-edit-changeset in majutsu-mode-map

### DIFF
--- a/majutsu-mode.el
+++ b/majutsu-mode.el
@@ -74,6 +74,7 @@ afterward."
   "s"   'majutsu-squash
   "S"   'majutsu-split
   "d"   'majutsu-diff
+  "e"   'majutsu-edit-changeset
   "r"   'majutsu-rebase
   "V"   'majutsu-revert
   "b"   'majutsu-bookmark


### PR DESCRIPTION
majutsu-edit-changeset is already bound to e in majutsu-evil.el and in majutsu-dispatch, but was missing from majutsu-mode-map for non-evil users. This adds it directly, making the keymap consistent with the evil integration.

Closes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut `e` to edit changesets

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0WD0/majutsu/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->