### PR TITLE
Add key binding for majutsu-edit-changeset in majutsu-mode-map

### DIFF
--- a/majutsu-mode.el
+++ b/majutsu-mode.el
@@ -74,6 +74,7 @@ afterward."
   "s"   'majutsu-squash
   "S"   'majutsu-split
   "d"   'majutsu-diff
+  "e"   'majutsu-edit-changeset
   "r"   'majutsu-rebase
   "V"   'majutsu-revert
   "b"   'majutsu-bookmark


### PR DESCRIPTION
majutsu-edit-changeset is already bound to e in majutsu-evil.el and in majutsu-dispatch, but was missing from majutsu-mode-map for non-evil users. This adds it directly, making the keymap consistent with the evil integration.

Closes #52

_Re-submission of #53 (I hadn't ever submitted a PR before and didn't realize I needed to wait until **after** the PR is (hopefully) merged)._