### PR TITLE
Fix transient entry for `majutsu-absorb`

### DIFF
--- a/majutsu.el
+++ b/majutsu.el
@@ -58,7 +58,7 @@ Instead of invoking this alias for `majutsu-log' using
     ("R" "Restore"           majutsu-restore)]
    [("s" "Squash"            majutsu-squash)
     ("S" "Split"             majutsu-split)
-    ("A" "Absorb"            majutsu-absorb)
+    ("a" "Absorb"            majutsu-absorb)
     ("y" "Duplicate"         majutsu-duplicate)
     ("Y" "Duplicate (dwim)"  majutsu-duplicate-dwim)
     ("Z" "Workspaces"        majutsu-workspace)


### PR DESCRIPTION
`A` is mapped to `majutsu-new-with-after`; `a` is mapped to `majutsu-absorb`. Updates `majutsu-dispatch` to show the correct key for absorb.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the keyboard shortcut for the absorb command from uppercase to lowercase for easier access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0WD0/majutsu/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->