### PR TITLE
Add revision headers and description to single-revision diff buffers

### DIFF
--- a/docs/majutsu.org
+++ b/docs/majutsu.org
@@ -308,6 +308,11 @@ Majutsu now provides both default copy filtering and explicit semantic copy comm
 This keeps ordinary Emacs copying predictable while still offering precise log-aware copy operations when you want semantic rather than purely visual text.
 
 ** Diffing
+Diff buffers for a single target revision include revision headers and the
+revision description as collapsible sections before the diff, similar to Magit
+revision buffers.  The diff section remains unchanged and keeps its normal
+hunk/file navigation and editing commands.
+
 *** Diff Transient
 - Key: d (majutsu-diff) ::
   Open the Diff transient.

--- a/docs/majutsu.org
+++ b/docs/majutsu.org
@@ -385,6 +385,16 @@ If you diff =-r A::D | B::E=, there are two heads (D, E) and two roots (A, B). T
 
 *** Diff Buffer
 The diff buffer is highly interactive:
+
+For a diff of exactly one change, Majutsu displays collapsible revision
+headers and the change description above the diff.  This includes the default
+working-copy diff and an explicit =-r= or =--revisions= revset that resolves to
+one change.  The metadata is omitted for =--from= / =--to= ranges and revsets
+that resolve to zero or multiple changes.  Bookmark labels use structured jj
+template fields available in every supported jj version, so remote-only
+bookmarks and names containing spaces, sigils, or =@= are preserved.  Control
+characters are escaped when rendered to keep the collapsible heading on one line.
+
 - Key: RET (majutsu-diff-visit-file) :: Visit the appropriate version of the file at point. For working copy diffs, added/context lines visit the workspace file while removed lines visit the parent-side blob. For committed changes, it visits the blob at the corresponding side.
 - Key: C-j / C-<return> (majutsu-diff-visit-workspace-file) :: Visit the workspace file, regardless of diff type. Note: when Evil mode is active, ~C-j~ may be overridden by Evil's section navigation; use ~C-<return>~ instead, which is unaffected.
 - Key: - (majutsu-diff-less-context) :: Decrease the context for diff hunks by COUNT lines.

--- a/docs/majutsu.texi
+++ b/docs/majutsu.texi
@@ -773,6 +773,11 @@ This keeps ordinary Emacs copying predictable while still offering precise log-a
 @node Diffing
 @section Diffing
 
+Diff buffers for a single target revision include revision headers and the
+revision description as collapsible sections before the diff@comma{} similar to Magit
+revision buffers.  The diff section remains unchanged and keeps its normal
+hunk/file navigation and editing commands.
+
 @menu
 * Diff Transient::
 * Diff Buffer: Diff Buffer (1). 

--- a/docs/majutsu.texi
+++ b/docs/majutsu.texi
@@ -908,6 +908,16 @@ If you diff @samp{-r A::D | B::E}@comma{} there are two heads (D@comma{} E) and 
 @subsection Diff Buffer
 
 The diff buffer is highly interactive:
+
+For a diff of exactly one change@comma{} Majutsu displays collapsible revision
+headers and the change description above the diff.  This includes the default
+working-copy diff and an explicit @samp{-r} or @samp{--revisions} revset that resolves to
+one change.  The metadata is omitted for @samp{--from} / @samp{--to} ranges and revsets
+that resolve to zero or multiple changes.  Bookmark labels use structured jj
+template fields available in every supported jj version@comma{} so remote-only
+bookmarks and names containing spaces@comma{} sigils@comma{} or @samp{@@} are preserved.  Control
+characters are escaped when rendered to keep the collapsible heading on one line.
+
 @table @asis
 @item @kbd{@key{RET}} (@code{majutsu-diff-visit-file})
 @kindex RET

--- a/majutsu-diff.el
+++ b/majutsu-diff.el
@@ -531,7 +531,12 @@ ARGS are the diff arguments used to produce DIFF-OUTPUT."
                       "committer.email() ++ \"\\0\""
                       "committer.timestamp().format(\"%a %b %e %T %Y %z\") ++ \"\\0\"")
                     " ++ "))
-         (fields (majutsu-jj-items "log" "--no-graph" "-r" rev "-T" template)))
+         (fields (with-temp-buffer
+                   (majutsu-jj-insert "log" "--no-graph" "-r" rev "-T" template)
+                   ;; Preserve empty fields.  `majutsu-jj-items' intentionally
+                   ;; drops them, which shifts header values for unbookmarked
+                   ;; revisions.
+                   (butlast (split-string (buffer-string) "\0")))))
     (pcase-let ((`(,bookmarks ,remote-bookmarks ,commit-id
                   ,author-name ,author-email ,author-date
                   ,committer-name ,committer-email ,committer-date)
@@ -546,17 +551,28 @@ ARGS are the diff arguments used to produce DIFF-OUTPUT."
             :committer-email committer-email
             :committer-date committer-date))))
 
+(defun majutsu-diff--propertize-ref (ref face)
+  "Return REF propertized like a Magit ref label using FACE."
+  (propertize ref 'font-lock-face face))
+
 (defun majutsu-diff--format-refs (fields)
   "Return a display string for revision refs in FIELDS."
   (string-join (delete-dups
-                (append (split-string (or (plist-get fields :bookmarks) "") " " t)
+                (append (mapcar (lambda (ref)
+                                  (majutsu-diff--propertize-ref
+                                   ref 'magit-branch-local))
+                                (split-string (or (plist-get fields :bookmarks) "")
+                                              " " t))
                         (delq nil
                               (mapcar (lambda (ref)
                                         (if (string-match "\\`\\([^@]+\\)@\\(.+\\)\\'" ref)
                                             (unless (string= (match-string 2 ref) "git")
-                                              (format "%s/%s" (match-string 2 ref)
-                                                      (match-string 1 ref)))
-                                          ref))
+                                              (majutsu-diff--propertize-ref
+                                               (format "%s/%s" (match-string 2 ref)
+                                                       (match-string 1 ref))
+                                               'magit-branch-remote))
+                                          (majutsu-diff--propertize-ref
+                                           ref 'magit-branch-remote)))
                                       (split-string (or (plist-get fields :remote-bookmarks) "")
                                                     " " t)))))
                " "))
@@ -569,7 +585,9 @@ ARGS are the diff arguments used to produce DIFF-OUTPUT."
       (let ((refs (majutsu-diff--format-refs fields)))
         (unless (string-empty-p refs)
           (insert refs " ")))
-      (insert (plist-get fields :commit-id) "\n")
+      (insert (propertize (plist-get fields :commit-id)
+                          'font-lock-face 'magit-hash)
+              "\n")
       (insert (format "Author:     %s <%s>\n"
                       (plist-get fields :author-name)
                       (plist-get fields :author-email)))

--- a/majutsu-diff.el
+++ b/majutsu-diff.el
@@ -49,7 +49,9 @@
 ;;;; Diff Mode
 
 (defcustom majutsu-diff-sections-hook
-  (list #'majutsu-insert-diff
+  (list #'majutsu-insert-diff-revision-headers
+        #'majutsu-insert-diff-revision-message
+        #'majutsu-insert-diff
         ;; #'majutsu-insert-xref-buttons
         )
   "Hook run to insert sections into a `majutsu-diff-mode' buffer."
@@ -506,6 +508,100 @@ ARGS are the diff arguments used to produce DIFF-OUTPUT."
       (narrow-to-region start (point))
       (goto-char (point-min))
       (majutsu-diff-wash-diffs args))))
+
+(defun majutsu-diff--message-revision ()
+  "Return the single revision whose message should be shown, or nil."
+  (let* ((revs (majutsu-diff--revisions))
+         (rev (cdr revs)))
+    (when (= (length (majutsu-jj-items "log" "--no-graph" "-r" rev
+                                      "-T" "change_id ++ \"\\0\""))
+             1)
+      rev)))
+
+(defun majutsu-diff--revision-header-fields (rev)
+  "Return header fields for REV as a plist."
+  (let* ((template (string-join
+                    '("bookmarks ++ \"\\0\""
+                      "remote_bookmarks ++ \"\\0\""
+                      "commit_id ++ \"\\0\""
+                      "author.name() ++ \"\\0\""
+                      "author.email() ++ \"\\0\""
+                      "author.timestamp().format(\"%a %b %e %T %Y %z\") ++ \"\\0\""
+                      "committer.name() ++ \"\\0\""
+                      "committer.email() ++ \"\\0\""
+                      "committer.timestamp().format(\"%a %b %e %T %Y %z\") ++ \"\\0\"")
+                    " ++ "))
+         (fields (majutsu-jj-items "log" "--no-graph" "-r" rev "-T" template)))
+    (pcase-let ((`(,bookmarks ,remote-bookmarks ,commit-id
+                  ,author-name ,author-email ,author-date
+                  ,committer-name ,committer-email ,committer-date)
+                 fields))
+      (list :bookmarks bookmarks
+            :remote-bookmarks remote-bookmarks
+            :commit-id commit-id
+            :author-name author-name
+            :author-email author-email
+            :author-date author-date
+            :committer-name committer-name
+            :committer-email committer-email
+            :committer-date committer-date))))
+
+(defun majutsu-diff--format-refs (fields)
+  "Return a display string for revision refs in FIELDS."
+  (string-join (delete-dups
+                (append (split-string (or (plist-get fields :bookmarks) "") " " t)
+                        (delq nil
+                              (mapcar (lambda (ref)
+                                        (if (string-match "\\`\\([^@]+\\)@\\(.+\\)\\'" ref)
+                                            (unless (string= (match-string 2 ref) "git")
+                                              (format "%s/%s" (match-string 2 ref)
+                                                      (match-string 1 ref)))
+                                          ref))
+                                      (split-string (or (plist-get fields :remote-bookmarks) "")
+                                                    " " t)))))
+               " "))
+
+(defun majutsu-insert-diff-revision-headers ()
+  "Insert revision metadata into a diff buffer."
+  (when-let* ((rev (majutsu-diff--message-revision))
+              (fields (majutsu-diff--revision-header-fields rev)))
+    (magit-insert-section (commit-headers)
+      (let ((refs (majutsu-diff--format-refs fields)))
+        (unless (string-empty-p refs)
+          (insert refs " ")))
+      (insert (plist-get fields :commit-id) "\n")
+      (insert (format "Author:     %s <%s>\n"
+                      (plist-get fields :author-name)
+                      (plist-get fields :author-email)))
+      (insert (format "AuthorDate: %s\n"
+                      (plist-get fields :author-date)))
+      (insert (format "Commit:     %s <%s>\n"
+                      (plist-get fields :committer-name)
+                      (plist-get fields :committer-email)))
+      (insert (format "CommitDate: %s\n\n"
+                      (plist-get fields :committer-date))))))
+
+(defun majutsu-insert-diff-revision-message ()
+  "Insert the described revision's message into a diff buffer."
+  (when-let* ((rev (majutsu-diff--message-revision))
+              (message (with-temp-buffer
+                         (majutsu-jj-insert "log" "--no-graph" "-r" rev
+                                            "-T" "description ++ \"\\n\"")
+                         (string-trim-right (buffer-string)))))
+    (magit-insert-section
+        ( commit-message nil nil
+          :heading-highlight-face 'magit-diff-revision-summary-highlight)
+      (if (string-empty-p message)
+          (save-excursion (insert "(no description)\n\n"))
+        (save-excursion
+          (insert message)
+          (unless (bolp)
+            (insert "\n"))
+          (insert "\n")))
+      (add-face-text-property (point) (progn (forward-line) (point))
+                              'magit-diff-revision-summary t)
+      (magit-insert-heading)
+      (goto-char (point-max)))))
 
 (defun majutsu-insert-diff ()
   "Insert a diff section and wash it."

--- a/majutsu-diff.el
+++ b/majutsu-diff.el
@@ -33,6 +33,7 @@
 (require 'json)
 (require 'magit-diff)      ; for faces/font-lock keywords
 (require 'diff-mode)
+(require 'json)
 (require 'smerge-mode)
 
 (declare-function majutsu-read-revset "majutsu-jj" (prompt &optional default completion-args))
@@ -52,7 +53,9 @@
 ;;;; Diff Mode
 
 (defcustom majutsu-diff-sections-hook
-  (list #'majutsu-insert-diff
+  (list #'majutsu-insert-diff-revision-headers
+        #'majutsu-insert-diff-revision-message
+        #'majutsu-insert-diff
         ;; #'majutsu-insert-xref-buttons
         )
   "Hook run to insert sections into a `majutsu-diff-mode' buffer."
@@ -206,6 +209,12 @@ These are the only arguments that are remembered per diff buffer.")
 
 (defvar-local majutsu-diff-backend 'git
   "Backend used to render the current diff buffer.")
+
+(defvar-local majutsu-diff--revision-metadata-cache nil
+  "Cached revision metadata for the current diff arguments.
+The value is (KEY . METADATA).  A nil METADATA value is cached too, so
+zero-match, multi-match, and failed queries are not repeated by section
+inserters during the same refresh.")
 
 (defun majutsu-diff--backend-from-args (args)
   "Return diff backend inferred from ARGS."
@@ -778,6 +787,225 @@ ARGS are the diff arguments used to produce DIFF-OUTPUT."
       (narrow-to-region start (point))
       (goto-char (point-min))
       (majutsu-diff-wash-diffs args))))
+
+(defconst majutsu-diff--revision-metadata-field-count 11
+  "Number of elements emitted in each revision metadata JSON record.")
+
+(defun majutsu-diff--range-option (long &optional short)
+  "Return LONG (or SHORT) option value from the current diff range.
+Both `--option=VALUE' and the two-argument `--option VALUE' forms are
+accepted.  Return the symbol `missing' when the option is absent, and an
+empty string when it is present without a value."
+  (let ((args majutsu-buffer-diff-range)
+        (value 'missing))
+    (while (and args (eq value 'missing))
+      (let ((arg (pop args)))
+        (cond
+         ((or (equal arg long) (and short (equal arg short)))
+          (setq value (if (and args (stringp (car args)))
+                          (pop args)
+                        "")))
+         ((and (stringp arg)
+               (string-prefix-p (concat long "=") arg))
+          (setq value (substring arg (1+ (length long))))))))
+    value))
+
+(defun majutsu-diff--metadata-revision ()
+  "Return the revision eligible for display metadata, or nil.
+Metadata is only appropriate for a single-revision change diff: the
+project default (working-copy revision `@') or an explicit `-r' /
+`--revisions' revset.  Explicit `--from' or `--to' ranges never qualify;
+the metadata query later rejects revsets resolving to zero or many changes."
+  (let ((from (majutsu-diff--range-option "--from"))
+        (to (majutsu-diff--range-option "--to"))
+        (revisions (majutsu-diff--range-option "--revisions" "-r")))
+    (cond
+     ((or (not (eq from 'missing)) (not (eq to 'missing))) nil)
+     ((null majutsu-buffer-diff-range) "@")
+     ((and (stringp revisions) (not (string-empty-p revisions))) revisions)
+     (t nil))))
+
+(defun majutsu-diff--parse-revision-metadata (output)
+  "Parse one JSON metadata record from OUTPUT.
+Return a plist, or nil for malformed output and revsets resolving to zero
+or multiple changes.  The complete record is JSON, so descriptions and ref
+names containing NUL or other control characters remain unambiguous."
+  (condition-case nil
+      (let ((record (json-parse-string output :array-type 'array
+                                       :null-object :null)))
+        (when (and (vectorp record)
+                   (= (length record)
+                      majutsu-diff--revision-metadata-field-count))
+          (pcase-let ((`[,change-id ,local ,remote ,commit-id
+                        ,author-name ,author-email ,author-date
+                        ,committer-name ,committer-email ,committer-date
+                        ,description]
+                       record))
+            (when (and (seq-every-p
+                        #'stringp
+                        (list change-id commit-id
+                              author-name author-email author-date
+                              committer-name committer-email committer-date
+                              description))
+                       (vectorp local)
+                       (seq-every-p #'stringp local)
+                       (vectorp remote)
+                       (seq-every-p
+                        (lambda (pair)
+                          (and (vectorp pair)
+                               (= (length pair) 2)
+                               (stringp (aref pair 0))
+                               (stringp (aref pair 1))))
+                        remote))
+              (list :change-id change-id
+                    :local-bookmarks (append local nil)
+                    :remote-bookmarks
+                    (mapcar (lambda (pair) (append pair nil)) remote)
+                    :commit-id commit-id
+                    :author-name author-name
+                    :author-email author-email
+                    :author-date author-date
+                    :committer-name committer-name
+                    :committer-email committer-email
+                    :committer-date committer-date
+                    :description description)))))
+    (error nil)))
+
+(defun majutsu-diff--query-revision-metadata (rev)
+  "Query all display metadata for REV with one `jj log' invocation.
+Return nil if the command fails or REV does not resolve to exactly one
+change."
+  (let ((majutsu-jj-global-arguments
+         (cons "--color=never"
+               (seq-remove (lambda (arg) (string-prefix-p "--color" arg))
+                           majutsu-jj-global-arguments)))
+        (template
+         (string-join
+          '("\"[\""
+            "json(change_id)"
+            "\",\""
+            "json(local_bookmarks.map(|ref| ref.name()))"
+            "\",\""
+            "\"[\" ++ remote_bookmarks.map(|ref| \"[\" ++ json(ref.name()) ++ \",\" ++ json(ref.remote()) ++ \"]\").join(\",\") ++ \"]\""
+            "\",\""
+            "json(commit_id)"
+            "\",\""
+            "json(author.name())"
+            "\",\""
+            "json(author.email())"
+            "\",\""
+            "json(author.timestamp().format(\"%a %b %e %T %Y %z\"))"
+            "\",\""
+            "json(committer.name())"
+            "\",\""
+            "json(committer.email())"
+            "\",\""
+            "json(committer.timestamp().format(\"%a %b %e %T %Y %z\"))"
+            "\",\""
+            "json(description)"
+            "\"]\\n\"")
+          " ++ ")))
+    (condition-case nil
+        (with-temp-buffer
+          (when (zerop (majutsu-jj-insert
+                        "log" "--no-graph" "-r" rev "-T" template))
+            (majutsu-diff--parse-revision-metadata (buffer-string))))
+      (error nil))))
+
+(defun majutsu-diff--revision-metadata ()
+  "Return cached metadata for the current single-revision diff.
+The cache key includes formatting arguments, range arguments, and the
+selected revision.  Consequently changing any diff argument or revision
+invalidates the cache while the two metadata section inserters share one
+query."
+  (let* ((rev (majutsu-diff--metadata-revision))
+         (key (list (copy-sequence majutsu-buffer-diff-args)
+                    (copy-sequence majutsu-buffer-diff-range)
+                    rev)))
+    (if (and majutsu-diff--revision-metadata-cache
+             (equal key (car majutsu-diff--revision-metadata-cache)))
+        (cdr majutsu-diff--revision-metadata-cache)
+      (let ((metadata (and rev (majutsu-diff--query-revision-metadata rev))))
+        (setq majutsu-diff--revision-metadata-cache (cons key metadata))
+        metadata))))
+
+(defun majutsu-diff--propertize-ref (ref face)
+  "Return REF propertized like a Magit ref label using FACE."
+  (let ((display
+         (apply #'concat
+                (mapcar
+                 (lambda (char)
+                   (pcase char
+                     (?\\ "\\\\")
+                     (?\n "\\n")
+                     (?\r "\\r")
+                     (?\t "\\t")
+                     ((pred (lambda (value)
+                              (or (< value 32) (= value 127))))
+                      (format "\\x%02X" char))
+                     (_ (char-to-string char))))
+                 (string-to-list ref)))))
+    (propertize display 'font-lock-face face 'help-echo ref)))
+
+(defun majutsu-diff--format-refs (fields)
+  "Return Magit-style local and remote ref labels from FIELDS.
+The synthetic `git' remote used by jj's Git backend is omitted."
+  (string-join
+   (delete-dups
+    (append
+     (mapcar (lambda (ref)
+               (majutsu-diff--propertize-ref ref 'magit-branch-local))
+             (plist-get fields :local-bookmarks))
+     (delq nil
+           (mapcar
+            (lambda (ref)
+              (pcase-let ((`(,name ,remote) ref))
+                (unless (string= remote "git")
+                  (majutsu-diff--propertize-ref
+                   (format "%s/%s" remote name)
+                   'magit-branch-remote))))
+            (plist-get fields :remote-bookmarks)))))
+   " "))
+
+(defun majutsu-insert-diff-revision-headers ()
+  "Insert collapsible revision headers for a single-change diff."
+  (when-let* ((fields (majutsu-diff--revision-metadata)))
+    (magit-insert-section (commit-headers)
+      (let ((refs (majutsu-diff--format-refs fields)))
+        (magit-insert-heading
+          (unless (string-empty-p refs) (concat refs " "))
+          (propertize (plist-get fields :commit-id)
+                      'font-lock-face 'magit-hash)))
+      (insert (format "Author:     %s <%s>\n"
+                      (plist-get fields :author-name)
+                      (plist-get fields :author-email)))
+      (insert (format "AuthorDate: %s\n" (plist-get fields :author-date)))
+      (insert (format "Commit:     %s <%s>\n"
+                      (plist-get fields :committer-name)
+                      (plist-get fields :committer-email)))
+      (insert (format "CommitDate: %s\n\n"
+                      (plist-get fields :committer-date))))))
+
+(defun majutsu-insert-diff-revision-message ()
+  "Insert a collapsible revision message for a single-change diff."
+  (when-let* ((fields (majutsu-diff--revision-metadata)))
+    (let ((message (plist-get fields :description)))
+      (magit-insert-section
+          (commit-message nil nil
+            :heading-highlight-face 'magit-diff-revision-summary-highlight)
+        (if (string-empty-p message)
+            (progn
+              (magit-insert-heading "(no description)")
+              (insert "\n"))
+          (save-excursion
+            (insert message)
+            (unless (bolp) (insert "\n")))
+          (magit--add-face-text-property
+           (point) (progn (forward-line) (point))
+           'magit-diff-revision-summary t)
+          (magit-insert-heading)
+          (goto-char (point-max)))
+        (insert "\n")))))
 
 (defun majutsu-insert-diff ()
   "Insert a diff section and wash it."
@@ -1705,6 +1933,9 @@ With prefix STYLE, cycle between `all' and `t'."
   "Refresh the current diff buffer."
   (interactive)
   (when majutsu-buffer-diff-args
+    ;; Metadata is refreshed once per buffer refresh, then shared by the
+    ;; header and message inserters through the argument-keyed cache.
+    (setq majutsu-diff--revision-metadata-cache nil)
     (let* ((backend (majutsu-diff--sync-backend))
            (majutsu-jj-global-arguments
             (cons (if (eq backend 'color-words) "--color=debug" "--color=never")

--- a/test/majutsu-diff-test.el
+++ b/test/majutsu-diff-test.el
@@ -319,6 +319,248 @@
         (should (equal heading
                        "jj diff --git --from=A --to=B -- src/a.el"))))))
 
+(defun majutsu-diff-test--metadata-output (&optional description change-id)
+  "Return one JSON metadata record for tests.
+Use DESCRIPTION and CHANGE-ID when non-nil."
+  (json-serialize
+   (vector (or change-id "change-id")
+           (vector "local")
+           (vector (vector "tracked" "origin")
+                   (vector "ignored" "git"))
+           "0123456789abcdef"
+           "Arthur Heymans" "arthur@example.test" "author date"
+           "Committer" "committer@example.test" "commit date"
+           (or description "Summary\n\nBody"))))
+
+(defun majutsu-diff-test--metadata (&optional description)
+  "Return parsed test metadata with DESCRIPTION."
+  (majutsu-diff--parse-revision-metadata
+   (majutsu-diff-test--metadata-output description)))
+
+(ert-deftest majutsu-diff-metadata-revision/default-and-explicit-single ()
+  "Default diffs and explicit revision options select a metadata revset."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-range nil)
+    (should (equal (majutsu-diff--metadata-revision) "@"))
+    (setq-local majutsu-buffer-diff-range '("-r" "mine"))
+    (should (equal (majutsu-diff--metadata-revision) "mine"))
+    (setq-local majutsu-buffer-diff-range '("--revisions=mine"))
+    (should (equal (majutsu-diff--metadata-revision) "mine"))
+    (setq-local majutsu-buffer-diff-range '("--revisions" "mine"))
+    (should (equal (majutsu-diff--metadata-revision) "mine"))))
+
+(ert-deftest majutsu-diff-metadata-revision/ranges-and-empty-do-not-qualify ()
+  "From/to ranges and an empty revision option never select TO metadata."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (dolist (range '(("--from=A" "--to=B")
+                     ("--from" "A")
+                     ("--to=B")
+                     ("--revisions=")
+                     ("-r" "")))
+      (setq-local majutsu-buffer-diff-range range)
+      (should-not (majutsu-diff--metadata-revision)))))
+
+(ert-deftest majutsu-diff-parse-revision-metadata/preserves-empty-fields ()
+  "JSON parsing preserves empty structured refs and scalar fields."
+  (let* ((output (json-serialize
+                  ["change" [] [] "commit" "" "" "author date"
+                   "" "" "commit date" ""]))
+         (fields (majutsu-diff--parse-revision-metadata output)))
+    (should fields)
+    (should-not (plist-get fields :local-bookmarks))
+    (should-not (plist-get fields :remote-bookmarks))
+    (should (equal (plist-get fields :author-name) ""))
+    (should (equal (plist-get fields :description) ""))))
+
+(ert-deftest majutsu-diff-parse-revision-metadata/preserves-nul-description ()
+  "The complete JSON record transports NUL inside a description safely."
+  (let* ((description (concat "Summary" (string 0) "Body"))
+         (fields (majutsu-diff--parse-revision-metadata
+                  (majutsu-diff-test--metadata-output description))))
+    (should fields)
+    (should (equal (plist-get fields :description) description))))
+
+(ert-deftest majutsu-diff-parse-revision-metadata/rejects-malformed-bookmarks ()
+  "Malformed JSON and remote entries without exact name/remote pairs fail."
+  (should-not (majutsu-diff--parse-revision-metadata "not-json"))
+  (dolist (case (list (list nil (vector))
+                      (list (vector 1) (vector))
+                      (list (vector) (vector (vector "name")))
+                      (list (vector) (vector (vector "name" nil)))))
+    (let ((record (json-parse-string
+                   (majutsu-diff-test--metadata-output)
+                   :array-type 'array)))
+      (aset record 1 (car case))
+      (aset record 2 (cadr case))
+      (should-not (majutsu-diff--parse-revision-metadata
+                   (json-serialize record))))))
+
+(ert-deftest majutsu-diff-parse-revision-metadata/rejects-zero-and-two-matches ()
+  "Only one complete metadata record is accepted."
+  (should-not (majutsu-diff--parse-revision-metadata ""))
+  (let ((record (majutsu-diff-test--metadata-output)))
+    (should-not (majutsu-diff--parse-revision-metadata
+                 (concat record "\n" record)))))
+
+(ert-deftest majutsu-diff-revision-metadata/multi-revset-does-not-display ()
+  "A `--revisions' revset resolving to two changes has no metadata."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-args '("--git")
+                majutsu-buffer-diff-range '("--revisions=A|B"))
+    (let ((record (concat (majutsu-diff-test--metadata-output) "\n")))
+      (cl-letf (((symbol-function 'majutsu-jj-insert)
+                 (lambda (&rest _args)
+                   (insert record record)
+                   0)))
+        (should-not (majutsu-diff--revision-metadata))))))
+
+(ert-deftest majutsu-diff-query-revision-metadata/uses-local-bookmarks ()
+  "Query exact local and remote bookmark components as structured JSON."
+  (let (seen-args)
+    (cl-letf (((symbol-function 'majutsu-jj-insert)
+               (lambda (&rest args)
+                 (setq seen-args args)
+                 1)))
+      (should-not (majutsu-diff--query-revision-metadata "@")))
+    (let ((template (cadr (member "-T" seen-args))))
+      (should (stringp template))
+      (should (string-search
+               "json(local_bookmarks.map(|ref| ref.name()))" template))
+      (should (string-search "remote_bookmarks.map(|ref|" template))
+      (should (string-search "json(ref.name())" template))
+      (should (string-search "json(ref.remote())" template))
+      (should (string-search "json(description)" template))
+      (should-not (string-search "\\0" template)))))
+
+(ert-deftest majutsu-diff-format-refs/filters-git-and-applies-faces ()
+  "Ref formatting hides synthetic git and escapes controls to one line."
+  (let* ((refs (majutsu-diff--format-refs
+                '(:local-bookmarks
+                  ("local" "feature space" "literal@local" "sigil*?"
+                   "line\nname" "line\\nname")
+                  :remote-bookmarks
+                  (("tracked" "origin")
+                   ("ignored" "git")
+                   ("remote only@mark" "up\rstream"))))))
+    (should (equal (substring-no-properties refs)
+                   (concat "local feature space literal@local sigil*? "
+                           "line\\nname line\\\\nname origin/tracked "
+                           "up\\rstream/remote only@mark")))
+    (should-not (string-match-p "[\n\r]" refs))
+    (should (eq (get-text-property 0 'font-lock-face refs)
+                'magit-branch-local))
+    (should (eq (get-text-property (string-match "origin" refs)
+                                   'font-lock-face refs)
+                'magit-branch-remote))))
+
+(ert-deftest majutsu-diff-revision-message/summary-face-survives-font-lock ()
+  "The revision summary uses Magit's managed font-lock face."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (let ((inhibit-read-only t)
+          (magit-section-inhibit-markers t)
+          (metadata (majutsu-diff-test--metadata)))
+      (cl-letf (((symbol-function 'majutsu-diff--revision-metadata)
+                 (lambda () metadata)))
+        (magit-insert-section (diffbuf)
+          (majutsu-insert-diff-revision-message)))
+      (font-lock-ensure)
+      (goto-char (point-min))
+      (search-forward "Summary")
+      (let ((face (get-text-property (1- (point)) 'font-lock-face)))
+        (should (if (listp face)
+                    (memq 'magit-diff-revision-summary face)
+                  (eq face 'magit-diff-revision-summary)))))))
+
+(ert-deftest majutsu-diff-revision-sections/render-empty-message-and-headings ()
+  "Headers and an empty message are represented by toggleable sections."
+  (with-temp-buffer
+    (magit-section-mode)
+    (let ((inhibit-read-only t)
+          (magit-section-inhibit-markers t)
+          (metadata (majutsu-diff-test--metadata "")))
+      (cl-letf (((symbol-function 'majutsu-diff--revision-metadata)
+                 (lambda () metadata)))
+        (magit-insert-section (diffbuf)
+          (majutsu-insert-diff-revision-headers)
+          (majutsu-insert-diff-revision-message)))
+      (let ((children (oref magit-root-section children)))
+        (should (equal (mapcar (lambda (section) (oref section type)) children)
+                       '(commit-headers commit-message)))
+        (dolist (section children)
+          (should (oref section content))
+          (magit-section-hide section)
+          (should (oref section hidden)))
+        (should (string-match-p "(no description)" (buffer-string)))))))
+
+(ert-deftest majutsu-diff-revision-metadata/cache-key-invalidates-on-args-and-rev ()
+  "Metadata is shared until formatting arguments or revision change."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-args '("--git")
+                majutsu-buffer-diff-range '("-r" "A"))
+    (let ((count 0))
+      (cl-letf (((symbol-function 'majutsu-diff--query-revision-metadata)
+                 (lambda (_rev)
+                   (cl-incf count)
+                   (majutsu-diff-test--metadata))))
+        (majutsu-diff--revision-metadata)
+        (majutsu-diff--revision-metadata)
+        (should (= count 1))
+        (setq-local majutsu-buffer-diff-args '("--git" "--stat"))
+        (majutsu-diff--revision-metadata)
+        (should (= count 2))
+        (setq-local majutsu-buffer-diff-range '("-r" "B"))
+        (majutsu-diff--revision-metadata)
+        (should (= count 3))))))
+
+(ert-deftest majutsu-diff-refresh/queries-once-and-runs-hooks-in-order ()
+  "One refresh shares one query across headers and message, before diff."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-args '("--git")
+                majutsu-buffer-diff-range '("-r" "A"))
+    (let ((count 0)
+          order)
+      (cl-letf (((symbol-function 'majutsu-diff--query-revision-metadata)
+                 (lambda (_rev)
+                   (cl-incf count)
+                   (majutsu-diff-test--metadata)))
+                ((symbol-function 'majutsu-insert-diff-revision-headers)
+                 (lambda ()
+                   (push 'headers order)
+                   (majutsu-diff--revision-metadata)))
+                ((symbol-function 'majutsu-insert-diff-revision-message)
+                 (lambda ()
+                   (push 'message order)
+                   (majutsu-diff--revision-metadata)))
+                ((symbol-function 'majutsu-insert-diff)
+                 (lambda () (push 'diff order))))
+        (majutsu-diff-refresh-buffer))
+      (should (= count 1))
+      (should (equal (nreverse order) '(headers message diff))))))
+
+(ert-deftest majutsu-diff-refresh/metadata-failure-does-not-block-diff ()
+  "A failed metadata query is cached as nil and diff insertion continues."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-args '("--git")
+                majutsu-buffer-diff-range '("-r" "missing"))
+    (let ((count 0)
+          diff-inserted)
+      (cl-letf (((symbol-function 'majutsu-jj-insert)
+                 (lambda (&rest _args)
+                   (cl-incf count)
+                   1))
+                ((symbol-function 'majutsu-insert-diff)
+                 (lambda () (setq diff-inserted t))))
+        (majutsu-diff-refresh-buffer))
+      (should (= count 1))
+      (should diff-inserted))))
+
 (ert-deftest majutsu-diff-remembered-args-filters-only-formatting-options ()
   "Only diff formatting options should be remembered per buffer."
   (should (equal (majutsu-diff--remembered-args


### PR DESCRIPTION
Diff buffers scoped to a single target revision now display revision metadata (commit ID, author, committer, bookmarks, remote bookmarks) and the revision description as collapsible Magit sections before the diff content, mirroring the layout of Magit revision buffers.

Key changes:
- Added `majutsu-insert-diff-revision-headers` to render commit metadata (author, committer, dates, refs) as a collapsible `commit-headers` section
- Added `majutsu-insert-diff-revision-message` to render the revision description as a collapsible `commit-message` section with summary highlighting
- Added `majutsu-diff--message-revision` to determine whether the current diff targets a single revision (and thus should show headers/message)
- Added `majutsu-diff--revision-header-fields` to fetch and parse revision metadata via a NUL-delimited `jj log` template, preserving empty fields correctly
- Added `majutsu-diff--format-refs` to format local bookmarks and remote bookmarks (excluding the `git` remote) with appropriate Magit faces
- Prepended the two new section inserters to `majutsu-diff-sections-hook` so they appear before the diff
- Updated both `.org` and `.texi` documentation to describe the new behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diff buffers now display revision headers and descriptions as collapsible sections before the diff content, while preserving existing diff navigation and editing behavior.

* **Documentation**
  * Updated manual to document the new diff buffer layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->