### PR TITLE
Highlight overlong JJ descriptions and auto-fill body

### DIFF
--- a/docs/majutsu.org
+++ b/docs/majutsu.org
@@ -938,6 +938,8 @@ Evil bindings are available in normal state:
 
 ** Description Options
 - User Option: majutsu-jjdescription-major-mode :: Major mode used for editing JJ description buffers (default: ~text-mode~).
+- User Option: majutsu-jjdescription-summary-max-length :: Column beyond which summary line characters are highlighted (default: 68, same as Magit). Set to ~nil~ to disable this highlighting; zero highlights the entire nonempty summary.
+- User Option: majutsu-jjdescription-fill-column :: Local ~fill-column~ used in JJ description buffers (default: 72). A positive integer enables Auto Fill for the body but never folds the summary line; filling is delegated to the selected major mode, so constructs that mode protects (such as Org headings, tables, and blocks) remain intact. Set this option to ~nil~ to disable Auto Fill and leave the buffer's current ~fill-column~ unchanged.
 - User Option: majutsu-jjdescription-comment-prefix :: Comment prefix used in JJ description buffers (default: ="JJ:"=).
 - User Option: majutsu-jjdescription-change-id-face :: Face used for JJ Change ID values.
 - User Option: global-majutsu-jjdescription-mode :: Global minor mode to enable JJ description buffer enhancements.

--- a/docs/majutsu.org
+++ b/docs/majutsu.org
@@ -833,6 +833,8 @@ Evil bindings are available in normal state:
 
 ** Description Options
 - User Option: majutsu-jjdescription-major-mode :: Major mode used for editing JJ description buffers (default: ~text-mode~).
+- User Option: majutsu-jjdescription-summary-max-length :: Column beyond which summary line characters are highlighted (default: 68, same as Magit).
+- User Option: majutsu-jjdescription-fill-column :: Local ~fill-column~ used in JJ description buffers (default mirrors ~git-commit-fill-column~, or 72).
 - User Option: majutsu-jjdescription-comment-prefix :: Comment prefix used in JJ description buffers (default: ="JJ:"=).
 - User Option: majutsu-jjdescription-change-id-face :: Face used for JJ Change ID values.
 - User Option: global-majutsu-jjdescription-mode :: Global minor mode to enable JJ description buffer enhancements.

--- a/docs/majutsu.texi
+++ b/docs/majutsu.texi
@@ -2234,6 +2234,14 @@ Normal hook run after refreshing.
 Major mode used for editing JJ description buffers (default: @code{text-mode}).
 @end defopt
 
+@defopt majutsu-jjdescription-summary-max-length
+Column beyond which summary line characters are highlighted (default: 68@comma{} same as Magit).
+@end defopt
+
+@defopt majutsu-jjdescription-fill-column
+Local @code{fill-column} used in JJ description buffers (default mirrors @code{git-commit-fill-column}@comma{} or 72).
+@end defopt
+
 @defopt majutsu-jjdescription-comment-prefix
 Comment prefix used in JJ description buffers (default: @samp{"JJ:"}).
 @end defopt

--- a/docs/majutsu.texi
+++ b/docs/majutsu.texi
@@ -2416,6 +2416,14 @@ Normal hook run after refreshing.
 Major mode used for editing JJ description buffers (default: @code{text-mode}).
 @end defopt
 
+@defopt majutsu-jjdescription-summary-max-length
+Column beyond which summary line characters are highlighted (default: 68@comma{} same as Magit). Set to @code{nil} to disable this highlighting; zero highlights the entire nonempty summary.
+@end defopt
+
+@defopt majutsu-jjdescription-fill-column
+Local @code{fill-column} used in JJ description buffers (default: 72). A positive integer enables Auto Fill for the body but never folds the summary line; filling is delegated to the selected major mode@comma{} so constructs that mode protects (such as Org headings@comma{} tables@comma{} and blocks) remain intact. Set this option to @code{nil} to disable Auto Fill and leave the buffer's current @code{fill-column} unchanged.
+@end defopt
+
 @defopt majutsu-jjdescription-comment-prefix
 Comment prefix used in JJ description buffers (default: @samp{"JJ:"}).
 @end defopt

--- a/majutsu-jjdescription.el
+++ b/majutsu-jjdescription.el
@@ -79,6 +79,61 @@ When nil, do not override whatever `auto-mode-alist' selects."
   :group 'majutsu
   :type 'string)
 
+(defcustom majutsu-jjdescription-summary-max-length 68
+  "Column beyond which summary line characters are highlighted.
+
+This uses the same default as `git-commit-summary-max-length'.
+Set to nil to disable overlong summary highlighting."
+  :group 'majutsu
+  :type '(choice (const :tag "Disable" nil)
+                 (natnum :tag "Column")))
+
+(defun majutsu-jjdescription--positive-integer-p (value)
+  "Return non-nil when VALUE is a positive integer."
+  (and (integerp value) (> value 0)))
+
+(defcustom majutsu-jjdescription-fill-column 72
+  "Column used as `fill-column' in JJ description buffers.
+
+The value must be a positive integer.  Set it to nil to disable Auto Fill;
+in that case the buffer's existing `fill-column' is left unchanged."
+  :group 'majutsu
+  :type '(choice (const :tag "Disable Auto Fill" nil)
+                 (restricted-sexp
+                  :tag "Column"
+                  :value 72
+                  :match-alternatives
+                  (majutsu-jjdescription--positive-integer-p)
+                  :type-error "This field should contain a positive integer")))
+
+(defun majutsu-jjdescription-setup-auto-fill ()
+  "Configure Auto Fill in JJ descriptions, except on the summary line."
+  (cond
+   ((null majutsu-jjdescription-fill-column)
+    (auto-fill-mode -1))
+   ((majutsu-jjdescription--positive-integer-p
+     majutsu-jjdescription-fill-column)
+    (auto-fill-mode 1)
+    (setq-local comment-auto-fill-only-comments nil)
+    (setq-local auto-fill-function
+                #'majutsu-jjdescription--auto-fill-except-summary))
+   (t
+    (error "`majutsu-jjdescription-fill-column' must be nil or a positive integer"))))
+
+(defun majutsu-jjdescription--auto-fill-except-summary ()
+  "Run the major mode's Auto Fill function outside the summary line."
+  (unless (eq (line-beginning-position)
+              (car-safe (majutsu-jjdescription--summary-range)))
+    (when (functionp normal-auto-fill-function)
+      (funcall normal-auto-fill-function))))
+
+(defun majutsu-jjdescription-setup-line-length ()
+  "Configure filling and summary length behavior in the current buffer."
+  (when (majutsu-jjdescription--positive-integer-p
+         majutsu-jjdescription-fill-column)
+    (setq-local fill-column majutsu-jjdescription-fill-column))
+  (majutsu-jjdescription-setup-auto-fill))
+
 (with-eval-after-load 'recentf
   (add-to-list 'recentf-exclude majutsu-jjdescription-regexp))
 
@@ -242,8 +297,14 @@ Added to `font-lock-extend-region-functions'."
       (let ((ranges (delq nil (list majutsu-jjdescription--summary-range
                                     majutsu-jjdescription--summary-last-range))))
         (when ranges
-          (let ((summary-beg (apply #'min (mapcar #'car ranges)))
-                (summary-end (apply #'max (mapcar #'cdr ranges))))
+          (let* ((buffer-beg (point-min))
+                 (buffer-end (point-max))
+                 (summary-beg
+                  (max buffer-beg
+                       (min buffer-end (apply #'min (mapcar #'car ranges)))))
+                 (summary-end
+                  (max summary-beg
+                       (min buffer-end (apply #'max (mapcar #'cdr ranges))))))
             (when (or (< summary-beg font-lock-beg summary-end)
                       (< summary-beg font-lock-end summary-end))
               (setq font-lock-beg (min font-lock-beg summary-beg))
@@ -264,6 +325,22 @@ Added to `font-lock-extend-region-functions'."
     (let ((beg (car majutsu-jjdescription--summary-range))
           (end (cdr majutsu-jjdescription--summary-range)))
       (when (and (< beg limit) (< (point) end))
+        (goto-char end)
+        (set-match-data (list beg end))
+        t))))
+
+(defun majutsu-jjdescription--overlong-summary-matcher (limit)
+  "Match the configured overlong part of the real summary before LIMIT."
+  (majutsu-jjdescription--refresh-summary-range)
+  (when (and (integerp majutsu-jjdescription-summary-max-length)
+             (>= majutsu-jjdescription-summary-max-length 0)
+             majutsu-jjdescription--summary-range)
+    (let* ((summary-beg (car majutsu-jjdescription--summary-range))
+           (summary-end (cdr majutsu-jjdescription--summary-range))
+           (beg (+ summary-beg majutsu-jjdescription-summary-max-length))
+           (end (min summary-end limit)))
+      (setq beg (max beg (point)))
+      (when (< beg end)
         (goto-char end)
         (set-match-data (list beg end))
         t))))
@@ -302,6 +379,11 @@ Added to `font-lock-extend-region-functions'."
         (ignore-rest-re (majutsu-jjdescription--ignore-rest-line-re)))
     `((majutsu-jjdescription--summary-matcher
        (0 '(face git-commit-summary font-lock-face git-commit-summary) t))
+      ,@(when (and (integerp majutsu-jjdescription-summary-max-length)
+                   (>= majutsu-jjdescription-summary-max-length 0))
+          `((majutsu-jjdescription--overlong-summary-matcher
+             (0 '(face git-commit-overlong-summary
+                  font-lock-face git-commit-overlong-summary) t))))
       (,comment-line-re
        (0 '(face font-lock-comment-face font-lock-face font-lock-comment-face) append))
       (,ignore-rest-re
@@ -568,13 +650,20 @@ available to `majutsu-jjdescription-setup' in `find-file-hook'."
                                 (majutsu-convert-filename-for-jj buffer-file-name))
                                "\\'")
                        majutsu-jjdescription-major-mode)))
+          ;; `normal-mode' runs this global hook while selecting the requested
+          ;; mode.  Defer Majutsu's refresh until below so Auto Fill setup and
+          ;; user hooks run exactly once for this complete setup operation.
+          (after-change-major-mode-hook
+           (remove #'majutsu-jjdescription-setup-font-lock-in-buffer
+                   after-change-major-mode-hook))
           ;; Pre-enable modes so hooks can see them
           (majutsu-jjdescription-mode t)
           (with-editor-mode t))
       (normal-mode t)))
 
-  ;; Setup comments
+  ;; Setup comments and line length.
   (majutsu-jjdescription-setup-comments)
+  (majutsu-jjdescription-setup-line-length)
 
   ;; Ensure with-editor-mode is enabled
   (unless with-editor-mode
@@ -601,10 +690,11 @@ available to `majutsu-jjdescription-setup' in `find-file-hook'."
     (majutsu-jjdescription-setup)))
 
 (defun majutsu-jjdescription-setup-font-lock-in-buffer ()
-  "Refresh JJ description font-lock after major-mode changes."
+  "Refresh JJ description setup after major-mode changes."
   (when (and buffer-file-name
              (string-match-p majutsu-jjdescription-regexp buffer-file-name))
     (majutsu-jjdescription-setup-comments)
+    (majutsu-jjdescription-setup-line-length)
     (majutsu-jjdescription-setup-font-lock)))
 
 (defun majutsu-jjdescription--set-global-hooks (enable)

--- a/majutsu-jjdescription.el
+++ b/majutsu-jjdescription.el
@@ -79,6 +79,41 @@ When nil, do not override whatever `auto-mode-alist' selects."
   :group 'majutsu
   :type 'string)
 
+(defcustom majutsu-jjdescription-summary-max-length 68
+  "Column beyond which summary line characters are highlighted.
+
+This uses the same default as `git-commit-summary-max-length'.
+Set to nil to disable overlong summary highlighting."
+  :group 'majutsu
+  :type '(choice (const :tag "Disable" nil)
+                 (natnum :tag "Column")))
+
+(defcustom majutsu-jjdescription-fill-column
+  (if (boundp 'git-commit-fill-column)
+      git-commit-fill-column
+    72)
+  "Column used as `fill-column' in JJ description buffers.
+
+This mirrors `git-commit-fill-column' for JJ description buffers.
+Set to nil to leave `fill-column' unchanged."
+  :group 'majutsu
+  :type '(choice (const :tag "Use default fill-column" nil)
+                 (integer :tag "Column")))
+
+(defun majutsu-jjdescription-setup-auto-fill ()
+  "Turn on Auto Fill mode in JJ description buffers.
+Ensure auto filling happens everywhere except in the summary line."
+  (auto-fill-mode 1)
+  (setq-local comment-auto-fill-only-comments nil)
+  (setq-local auto-fill-function
+              #'majutsu-jjdescription--auto-fill-except-summary))
+
+(defun majutsu-jjdescription--auto-fill-except-summary ()
+  "Do not auto-fill the summary line."
+  (unless (eq (line-beginning-position)
+              (car-safe (majutsu-jjdescription--summary-range)))
+    (do-auto-fill)))
+
 (with-eval-after-load 'recentf
   (add-to-list 'recentf-exclude majutsu-jjdescription-regexp))
 
@@ -268,6 +303,16 @@ Added to `font-lock-extend-region-functions'."
         (set-match-data (list beg end))
         t))))
 
+(defun majutsu-jjdescription--summary-regexp ()
+  "Return regexp matching summary parts like `git-commit-summary-regexp'."
+  (concat
+   ;; Leading empty lines and comments.
+   (format "\\`\\(?:^\\(?:\\s-*\\|%s.*\\)\n\\)*"
+           (regexp-quote (majutsu-jjdescription--comment-prefix)))
+   ;; Summary line before and after the configured maximum length.
+   (format "\\(.\\{0,%d\\}\\)\\(.*\\)"
+           (or majutsu-jjdescription-summary-max-length most-positive-fixnum))))
+
 (defun majutsu-jjdescription--ignore-rest-comment-matcher (limit)
   "Match text after ignore-rest as comments before LIMIT."
   (majutsu-jjdescription--refresh-ignore-rest-pos)
@@ -302,6 +347,10 @@ Added to `font-lock-extend-region-functions'."
         (ignore-rest-re (majutsu-jjdescription--ignore-rest-line-re)))
     `((majutsu-jjdescription--summary-matcher
        (0 '(face git-commit-summary font-lock-face git-commit-summary) t))
+      ,@(when (integerp majutsu-jjdescription-summary-max-length)
+          `((,(majutsu-jjdescription--summary-regexp)
+             (2 '(face git-commit-overlong-summary
+                  font-lock-face git-commit-overlong-summary) t t))))
       (,comment-line-re
        (0 '(face font-lock-comment-face font-lock-face font-lock-comment-face) append))
       (,ignore-rest-re
@@ -573,8 +622,11 @@ available to `majutsu-jjdescription-setup' in `find-file-hook'."
           (with-editor-mode t))
       (normal-mode t)))
 
-  ;; Setup comments
+  ;; Setup comments and line length.
   (majutsu-jjdescription-setup-comments)
+  (when majutsu-jjdescription-fill-column
+    (setq-local fill-column majutsu-jjdescription-fill-column))
+  (majutsu-jjdescription-setup-auto-fill)
 
   ;; Ensure with-editor-mode is enabled
   (unless with-editor-mode
@@ -601,10 +653,13 @@ available to `majutsu-jjdescription-setup' in `find-file-hook'."
     (majutsu-jjdescription-setup)))
 
 (defun majutsu-jjdescription-setup-font-lock-in-buffer ()
-  "Refresh JJ description font-lock after major-mode changes."
+  "Refresh JJ description setup after major-mode changes."
   (when (and buffer-file-name
              (string-match-p majutsu-jjdescription-regexp buffer-file-name))
     (majutsu-jjdescription-setup-comments)
+    (when majutsu-jjdescription-fill-column
+      (setq-local fill-column majutsu-jjdescription-fill-column))
+    (majutsu-jjdescription-setup-auto-fill)
     (majutsu-jjdescription-setup-font-lock)))
 
 (defun majutsu-jjdescription--set-global-hooks (enable)

--- a/test/majutsu-jjdescription-test.el
+++ b/test/majutsu-jjdescription-test.el
@@ -91,6 +91,214 @@
     (forward-line 1)
     (should-not (memq 'git-commit-summary (majutsu-test--faces-at (point))))))
 
+(ert-deftest majutsu-jjdescription-overlong-summary-boundaries ()
+  "Highlight only summary characters strictly beyond the configured limit."
+  (dolist (case '((nil "1234567" nil)
+                  (0 "1234567" 0)
+                  (5 "12345" nil)
+                  (5 "1234567" 5)
+                  (-1 "1234567" nil)))
+    (pcase-let ((`(,limit ,summary ,overlong-offset) case))
+      (let ((majutsu-jjdescription-summary-max-length limit))
+        (with-temp-buffer
+          (text-mode)
+          (setq buffer-file-name "/tmp/editor-123.jjdescription")
+          (insert summary "\n\nJJ: note\n")
+          (majutsu-jjdescription-setup)
+          (font-lock-ensure)
+          (goto-char (point-min))
+          (when (and (integerp limit) (> limit 0))
+            (should-not (memq 'git-commit-overlong-summary
+                              (majutsu-test--faces-at (point)))))
+          (if overlong-offset
+              (progn
+                (forward-char overlong-offset)
+                (should (memq 'git-commit-overlong-summary
+                              (majutsu-test--faces-at (point)))))
+            (should-not
+             (cl-loop for pos from (line-beginning-position)
+                      below (line-end-position)
+                      thereis (memq 'git-commit-overlong-summary
+                                    (majutsu-test--faces-at pos))))))))))
+
+(ert-deftest majutsu-jjdescription-summary-limit-is-natnum ()
+  "The summary limit customization must reject negative values."
+  (should
+   (equal (get 'majutsu-jjdescription-summary-max-length 'custom-type)
+          '(choice (const :tag "Disable" nil)
+                   (natnum :tag "Column")))))
+
+(ert-deftest majutsu-jjdescription-overlong-summary-respects-ignore-rest ()
+  "Text after JJ's ignore-rest marker is never treated as a summary."
+  (let ((majutsu-jjdescription-summary-max-length 5))
+    (with-temp-buffer
+      (text-mode)
+      (setq buffer-file-name "/tmp/editor-123.jjdescription")
+      (insert "JJ: ignore-rest\n1234567\n")
+      (majutsu-jjdescription-setup)
+      (font-lock-ensure)
+      (goto-char (point-min))
+      (search-forward "1234567")
+      (let ((beg (- (point) 7))
+            (end (point)))
+        (should-not
+         (cl-loop for pos from beg below end
+                  thereis (memq 'git-commit-overlong-summary
+                                (majutsu-test--faces-at pos))))))))
+
+(ert-deftest majutsu-jjdescription-overlong-summary-shrink-clamps-old-range ()
+  "Shrinking a summary never extends font-lock past the new buffer end."
+  (let ((majutsu-jjdescription-summary-max-length 5))
+    (with-temp-buffer
+      (text-mode)
+      (setq buffer-file-name "/tmp/editor-123.jjdescription")
+      (insert "1234567\n")
+      (majutsu-jjdescription-setup)
+      (font-lock-ensure)
+      (goto-char (point-min))
+      (delete-region (+ (point-min) 5) (line-end-position))
+      (font-lock-ensure)
+      (goto-char (point-min))
+      (should (equal (buffer-substring-no-properties
+                      (line-beginning-position) (line-end-position))
+                     "12345"))
+      (should-not
+       (cl-loop for pos from (line-beginning-position)
+                below (line-end-position)
+                thereis (memq 'git-commit-overlong-summary
+                              (majutsu-test--faces-at pos)))))))
+
+(ert-deftest majutsu-jjdescription-fill-column-and-auto-fill ()
+  "Keep the summary intact and fill body text at the configured column."
+  (let ((majutsu-jjdescription-fill-column 12))
+    (with-temp-buffer
+      (text-mode)
+      (setq buffer-file-name "/tmp/editor-123.jjdescription")
+      (insert "summary line that must remain intact\n\none two three four five")
+      (majutsu-jjdescription-setup)
+      (should (= fill-column 12))
+      (should (eq auto-fill-function
+                  #'majutsu-jjdescription--auto-fill-except-summary))
+      (goto-char (point-min))
+      (end-of-line)
+      (funcall auto-fill-function)
+      (should (equal (buffer-substring-no-properties
+                      (line-beginning-position) (line-end-position))
+                     "summary line that must remain intact"))
+      (goto-char (point-max))
+      (funcall auto-fill-function)
+      (should (equal (buffer-substring-no-properties
+                      (save-excursion
+                        (goto-char (point-min))
+                        (search-forward "one")
+                        (match-beginning 0))
+                      (point-max))
+                     "one two\nthree four\nfive")))))
+
+(ert-deftest majutsu-jjdescription-fill-column-accepts-only-positive-integers ()
+  "The fill option accepts positive integers or nil as the disabled value."
+  (require 'wid-edit)
+  (let ((widget (widget-convert
+                 (get 'majutsu-jjdescription-fill-column 'custom-type))))
+    (should (widget-apply widget :match nil))
+    (should (widget-apply widget :match 1))
+    (should (widget-apply widget :match 72))
+    (should-not (widget-apply widget :match 0))
+    (should-not (widget-apply widget :match -1))))
+
+(ert-deftest majutsu-jjdescription-nil-fill-column-disables-auto-fill ()
+  "A nil option keeps the current fill column and disables Auto Fill."
+  (let ((majutsu-jjdescription-major-mode nil)
+        (majutsu-jjdescription-fill-column nil))
+    (with-temp-buffer
+      (text-mode)
+      (setq buffer-file-name "/tmp/editor-123.jjdescription")
+      (setq-local fill-column 37)
+      (majutsu-jjdescription-setup)
+      (should (= fill-column 37))
+      (should-not auto-fill-function))))
+
+(ert-deftest majutsu-jjdescription-auto-fill-delegates-to-major-mode ()
+  "Body filling delegates to the major mode's normal Auto Fill function."
+  (let ((majutsu-jjdescription-major-mode nil)
+        (majutsu-jjdescription-fill-column 20))
+    (with-temp-buffer
+      (text-mode)
+      (setq buffer-file-name "/tmp/editor-123.jjdescription")
+      (insert "summary\n\nbody text")
+      (majutsu-jjdescription-setup)
+      (let (called)
+        (setq-local normal-auto-fill-function
+                    (lambda () (setq called (point))))
+        (goto-char (point-max))
+        (funcall auto-fill-function)
+        (should (= called (point)))))))
+
+(ert-deftest majutsu-jjdescription-org-auto-fill-preserves-structures ()
+  "Org headings, tables, and blocks retain Org's Auto Fill behavior."
+  (let ((majutsu-jjdescription-major-mode nil)
+        (majutsu-jjdescription-fill-column 12))
+    (with-temp-buffer
+      (org-mode)
+      (setq buffer-file-name "/tmp/editor-123.jjdescription")
+      (insert (concat "summary\n\n"
+                      "* heading one two three four five\n\n"
+                      "| cell one two three four | cell two |\n\n"
+                      "#+begin_src emacs-lisp\n"
+                      "(message \"one two three four five\")\n"
+                      "#+end_src\n"))
+      (majutsu-jjdescription-setup)
+      (should (eq normal-auto-fill-function #'org-auto-fill-function))
+      (let ((before (buffer-string)))
+        (dolist (line '("* heading" "| cell" "(message"))
+          (goto-char (point-min))
+          (search-forward line)
+          (end-of-line)
+          (funcall auto-fill-function))
+        (should (equal (buffer-string) before))))))
+
+(ert-deftest majutsu-jjdescription-major-mode-refresh-reapplies-setup ()
+  "Changing major mode reapplies JJ description buffer configuration."
+  (let ((majutsu-jjdescription-fill-column 41))
+    (global-majutsu-jjdescription-mode 1)
+    (with-temp-buffer
+      (setq buffer-file-name "/tmp/editor-123.jjdescription")
+      (text-mode)
+      (setq-local fill-column 99)
+      (auto-fill-mode -1)
+      (fundamental-mode)
+      (should (= fill-column 41))
+      (should (equal comment-start majutsu-jjdescription-comment-prefix))
+      (should (eq auto-fill-function
+                  #'majutsu-jjdescription--auto-fill-except-summary))
+      (should majutsu-jjdescription-mode))))
+
+(ert-deftest majutsu-jjdescription-complete-setup-enables-auto-fill-once ()
+  "One complete description setup runs Auto Fill hooks exactly once."
+  (let ((majutsu-jjdescription-major-mode #'text-mode)
+        (majutsu-jjdescription-fill-column 41)
+        (count 0)
+        (auto-fill-mode-hook nil))
+    (add-hook 'auto-fill-mode-hook (lambda () (cl-incf count)))
+    (with-temp-buffer
+      (setq buffer-file-name "/tmp/editor-123.jjdescription")
+      (insert "summary\n\nbody\n")
+      (majutsu-jjdescription-setup)
+      (should (= count 1)))))
+
+(ert-deftest majutsu-jjdescription-major-mode-refresh-does-not-duplicate-hook ()
+  "Repeated mode refreshes do not duplicate the global refresh hook."
+  (global-majutsu-jjdescription-mode 1)
+  (global-majutsu-jjdescription-mode 1)
+  (with-temp-buffer
+    (setq buffer-file-name "/tmp/editor-123.jjdescription")
+    (text-mode)
+    (fundamental-mode)
+    (text-mode))
+  (should (= (cl-count #'majutsu-jjdescription-setup-font-lock-in-buffer
+                       after-change-major-mode-hook :test #'eq)
+             1)))
+
 (ert-deftest majutsu-jjdescription-font-lock-comments ()
   "JJ comment lines should be highlighted with comment faces."
   (with-temp-buffer

--- a/test/majutsu-jjdescription-test.el
+++ b/test/majutsu-jjdescription-test.el
@@ -91,6 +91,33 @@
     (forward-line 1)
     (should-not (memq 'git-commit-summary (majutsu-test--faces-at (point))))))
 
+(ert-deftest majutsu-jjdescription-overlong-summary ()
+  "Summary characters beyond configured length should be highlighted."
+  (let ((majutsu-jjdescription-summary-max-length 5))
+    (with-temp-buffer
+      (text-mode)
+      (setq buffer-file-name "/tmp/editor-123.jjdescription")
+      (insert "1234567\n\nJJ: note\n")
+      (majutsu-jjdescription-setup)
+      (font-lock-ensure)
+      (goto-char (point-min))
+      (should-not (memq 'git-commit-overlong-summary
+                        (majutsu-test--faces-at (point))))
+      (goto-char (point-min))
+      (forward-char 5)
+      (should (memq 'git-commit-overlong-summary
+                    (majutsu-test--faces-at (point)))))))
+
+(ert-deftest majutsu-jjdescription-fill-column ()
+  "JJ description buffers should use configured fill column."
+  (let ((majutsu-jjdescription-fill-column 77))
+    (with-temp-buffer
+      (text-mode)
+      (setq buffer-file-name "/tmp/editor-123.jjdescription")
+      (insert "summary\n")
+      (majutsu-jjdescription-setup)
+      (should (= fill-column 77)))))
+
 (ert-deftest majutsu-jjdescription-font-lock-comments ()
   "JJ comment lines should be highlighted with comment faces."
   (with-temp-buffer


### PR DESCRIPTION
Add configurable JJ description summary length highlighting using Magit's 68-column default, and configure fill-column for description buffers.

Enable auto-fill during JJ description setup while skipping the summary line, mirroring git-commit behavior. Document the new options and cover summary highlighting/fill-column setup with tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new options to control overlong summary highlighting (with a configurable max-length) in JJ description buffers
  * Added an optional fill column setting for consistent wrapping
  * Improved auto-fill behavior to maintain correct formatting of the summary line
* **Documentation**
  * Documented the new configuration options in the manual
* **Tests**
  * Added coverage for overlong summary highlighting behavior and fill-column setup
* **Bug Fixes**
  * Ensured these description behaviors are consistently refreshed on major mode changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->