### PR TITLE
diff: preserve ANSI escapes for split

### DIFF
--- a/majutsu-diff.el
+++ b/majutsu-diff.el
@@ -1341,8 +1341,12 @@ With prefix STYLE, cycle between `all' and `t'."
             (cons (if (eq backend 'color-words) "--color=debug" "--color=never")
                   (seq-remove (lambda (arg) (string-prefix-p "--color" arg))
                               majutsu-jj-global-arguments)))
-           (majutsu-process-apply-ansi-colors
-            (majutsu-diff--backend-uses-ansi-p backend)))
+           ;; Diff buffers are used as patch source by interactive commands.
+           ;; For the regular git backend we force `--color=never', so applying
+           ;; `ansi-color' here is unnecessary and corrupts file contents that
+           ;; contain literal ANSI escape sequences.  Color-words handles its
+           ;; own ANSI/debug output in its washer.
+           (majutsu-process-apply-ansi-colors nil))
       (if (eq backend 'color-words)
           (progn
             ;; No diff-mode keywords — ANSI faces via `font-lock-face'

--- a/test/majutsu-diff-test.el
+++ b/test/majutsu-diff-test.el
@@ -111,6 +111,21 @@
                     "--ignore-all-space"))
                  '("--stat" "--context=5" "--ignore-all-space"))))
 
+(ert-deftest majutsu-diff-refresh-buffer-does-not-ansi-wash-git-diff ()
+  "Git diff buffers must preserve literal ANSI escapes in file content."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-args '("--git"))
+    (setq-local majutsu-buffer-diff-range '("--revisions=@"))
+    (let (seen-ansi seen-global-args)
+      (cl-letf (((symbol-function 'magit-run-section-hook)
+                 (lambda (&rest _)
+                   (setq seen-ansi majutsu-process-apply-ansi-colors
+                         seen-global-args majutsu-jj-global-arguments))))
+        (majutsu-diff-refresh-buffer))
+      (should-not seen-ansi)
+      (should (member "--color=never" seen-global-args)))))
+
 (ert-deftest majutsu-diff-set-buffer-args-does-not-clear-filesets ()
   "Updating diff args must not clear existing filesets unless requested."
   (with-temp-buffer


### PR DESCRIPTION
Interactive split builds its patch from the rendered diff buffer. Git diff
buffers already force jj to use --color=never, but Majutsu still ran the
process output through ansi-color. That stripped literal ANSI escape bytes
that were part of the file contents, so the generated patch no longer
matched the base file and git apply failed.

Disable ANSI washing for diff refreshes. Color-words continues to handle its
own debug/ANSI output in its washer, while regular git diffs now keep file
content byte-for-byte so split patches apply correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented diff buffer corruption when diff output contains literal ANSI escape sequences, ensuring the full diff contents render correctly during refresh.

* **Tests**
  * Added an ERT coverage case confirming that ANSI “washing” is not applied to git-style diffs containing ANSI escape sequences, and that color handling is kept consistent during buffer refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->