### PR TITLE
Fix GPG pinentry freezes in sync jj commands

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -77,6 +77,8 @@
 
 ** Fixed
 
+- Process: Synchronous jj commands now wait responsively so Emacs-based
+  GPG/pinentry prompts can be serviced instead of appearing to freeze Emacs.
 - Transients: Use a consistent ~RET~ execute binding in ~majutsu-squash~ and
   ~majutsu-split~ while keeping ~s~.
 - Ediff: Quitting ~majutsu-ediff-resolve~ without edits no longer writes a

--- a/majutsu-process.el
+++ b/majutsu-process.el
@@ -427,9 +427,7 @@ repository's log buffer (see `majutsu-refresh')."
     (oset section value process)
     (with-current-buffer process-buf
       (set-marker (process-mark process) (point)))
-    (if (fboundp 'with-editor-set-process-filter)
-        (with-editor-set-process-filter process #'majutsu--process-filter)
-      (set-process-filter process #'majutsu--process-filter))
+    (majutsu--process-install-filter process)
     (set-process-sentinel process #'majutsu--process-sentinel)
     (when input
       (with-current-buffer input
@@ -525,6 +523,12 @@ Return non-nil when LINE is consumed as a control packet."
                                           proc string))
       (set-marker (process-mark proc) (point)))))
 
+(defun majutsu--process-install-filter (process)
+  "Install Majutsu's process filter on PROCESS."
+  (if (fboundp 'with-editor-set-process-filter)
+      (with-editor-set-process-filter process #'majutsu--process-filter)
+    (set-process-filter process #'majutsu--process-filter)))
+
 (defun majutsu--process-sentinel (process _event)
   "Default sentinel used by `majutsu-start-process'."
   (when (memq (process-status process) '(exit signal))
@@ -589,6 +593,51 @@ process terminates."
       (process-put process 'finish-callback finish-callback))
     process))
 
+(defun majutsu--process-wait (process)
+  "Wait for PROCESS to finish while continuing to service Emacs subprocesses.
+
+This is used for commands that are synchronous from Majutsu's point of
+view, but may need another Emacs subprocess to run concurrently.  In
+particular, GnuPG setups using an Emacs-based pinentry need Emacs to keep
+servicing the server/pinentry process while jj is waiting for GPG."
+  (while (eq (process-status process) 'run)
+    ;; Wait for any process, not just PROCESS.  Pinentry-emacs talks to
+    ;; Emacs through another process; waiting only for jj would reproduce
+    ;; the same apparent freeze/deadlock as `process-file'.
+    (accept-process-output nil 0.1))
+  (process-exit-status process))
+
+(defun majutsu--call-process-responsive (program process-buf section root &rest args)
+  "Run PROGRAM with ARGS synchronously without blocking Emacs subprocesses.
+
+Output is appended to PROCESS-BUF at SECTION, using the same filter as
+`majutsu-start-process'.  Return the process exit status."
+  (let* ((process-environment (majutsu-process-environment args))
+         (default-process-coding-system '(utf-8-unix . utf-8-unix))
+         (process (apply #'start-file-process (file-name-nondirectory program)
+                         process-buf program args))
+         exit)
+    (set-process-query-on-exit-flag process nil)
+    (process-put process 'section section)
+    (process-put process 'command-buf (current-buffer))
+    (process-put process 'default-dir root)
+    (ignore-errors
+      (oset section process process)
+      (oset section value process))
+    (with-current-buffer process-buf
+      (set-marker (process-mark process) (point)))
+    ;; `majutsu-call-jj' handles finalization explicitly after this helper
+    ;; returns.  Suppress Emacs' default sentinel, which would otherwise append
+    ;; "Process ... finished" status text to the Majutsu process buffer.
+    (set-process-sentinel process #'ignore)
+    (majutsu--process-install-filter process)
+    (majutsu--process-display-buffer process)
+    (unwind-protect
+        (setq exit (majutsu--process-wait process))
+      (when (and (not exit) (process-live-p process))
+        (delete-process process)))
+    exit))
+
 (defun majutsu-call-jj (&rest args)
   "Call jj synchronously in a separate process, for side-effects.
 
@@ -596,7 +645,11 @@ Process output goes into a new section in the buffer returned by
 `majutsu-process-buffer'.  Return the exit code.
 
 Unlike `majutsu-start-jj', this does not implicitly refresh any Majutsu
-buffers.  Call `majutsu-refresh' explicitly when desired."
+buffers.  Call `majutsu-refresh' explicitly when desired.
+
+This function waits using `accept-process-output' rather than
+`process-file', so Emacs can continue to service subprocesses such as an
+Emacs-based GPG pinentry while jj is running."
   (let* ((default-directory (majutsu--toplevel-safe default-directory))
          (jj (majutsu-jj--executable))
          (args (majutsu-process-jj-arguments args))
@@ -609,7 +662,8 @@ buffers.  Call `majutsu-refresh' explicitly when desired."
                     (prog1 (majutsu--process-insert-section pwd jj args nil nil)
                       (backward-char 1))))
                  (inhibit-read-only t)
-                 (exit (apply #'majutsu-process-file jj nil process-buf nil args)))
+                 (exit (apply #'majutsu--call-process-responsive
+                              jj process-buf section process-root args)))
       (setq exit (majutsu-process-finish exit process-buf (current-buffer) process-root section))
       exit)))
 

--- a/test/majutsu-process-test.el
+++ b/test/majutsu-process-test.el
@@ -159,7 +159,8 @@ The process section should use root as command directory."
   (let ((default-directory "/repo/sub/")
         seen-process-cwd
         seen-finish-root
-        seen-prefix-pwd)
+        seen-prefix-pwd
+        seen-args)
     (with-temp-buffer
       (let ((process-buf (current-buffer)))
         (setq default-directory "/repo/")
@@ -175,9 +176,11 @@ The process section should use root as command directory."
                      (setq seen-prefix-pwd pwd)
                      (insert "\n")
                      'dummy-section))
-                  ((symbol-function 'process-file)
-                   (lambda (&rest _args)
+                  ((symbol-function 'majutsu--call-process-responsive)
+                   (lambda (_program _process-buf _section root &rest args)
                      (setq seen-process-cwd default-directory)
+                     (setq seen-finish-root root)
+                     (setq seen-args args)
                      0))
                   ((symbol-function 'majutsu-process-finish)
                    (lambda (exit _process-buf _command-buf default-dir _section)
@@ -186,7 +189,8 @@ The process section should use root as command directory."
           (should (= 0 (majutsu-call-jj "status"))))))
     (should (equal seen-prefix-pwd "/repo/"))
     (should (equal seen-process-cwd "/repo/"))
-    (should (equal seen-finish-root "/repo/"))))
+    (should (equal seen-finish-root "/repo/"))
+    (should (equal seen-args '("status")))))
 
 (ert-deftest majutsu-process-test-start-jj-uses-process-environment-helper ()
   "`majutsu-start-jj' should apply helper environment via start-process."
@@ -223,37 +227,65 @@ The process section should use root as command directory."
           (when (buffer-live-p buf)
             (kill-buffer buf)))))))
 
-(ert-deftest majutsu-process-test-call-jj-uses-process-environment-helper ()
-  "`majutsu-call-jj' should bind environment from helper output."
-  (let ((default-directory "/repo/sub/")
+(ert-deftest majutsu-process-test-responsive-call-uses-process-environment-helper ()
+  "`majutsu--call-process-responsive' should bind helper environment."
+  (let ((process-environment (cons "COLUMNS=80" process-environment))
         seen-env-args
-        seen-columns)
+        seen-columns
+        process)
     (with-temp-buffer
       (let ((process-buf (current-buffer)))
-        (cl-letf (((symbol-function 'majutsu--toplevel-safe)
-                   (lambda (&optional _directory) "/repo/"))
-                  ((symbol-function 'majutsu-process-jj-arguments)
-                   (lambda (args) args))
-                  ((symbol-function 'majutsu-process-environment)
+        (cl-letf (((symbol-function 'majutsu-process-environment)
                    (lambda (args)
                      (setq seen-env-args args)
                      (cons "COLUMNS=234" process-environment)))
-                  ((symbol-function 'majutsu-process-buffer)
-                   (lambda (&optional _nodisplay)
-                     process-buf))
-                  ((symbol-function 'majutsu--process-insert-section)
-                   (lambda (_pwd _program _args &optional _err _errlog _face)
-                     (insert "\n")
-                     'dummy-section))
-                  ((symbol-function 'process-file)
-                   (lambda (&rest _args)
+                  ((symbol-function 'start-file-process)
+                   (lambda (name buffer _program &rest _args)
                      (setq seen-columns (getenv "COLUMNS"))
-                     0))
-                  ((symbol-function 'majutsu-process-finish)
-                   (lambda (exit _process-buf _command-buf _default-dir _section)
-                     exit)))
-          (should (= 0 (majutsu-call-jj "diff" "--stat")))))
-      (should (equal seen-env-args '("diff" "--stat")))
-      (should (equal seen-columns "234")))))
+                     (setq process
+                           (make-process :name (format "%s-test" name)
+                                         :buffer buffer
+                                         :command (list "true")))))
+                  ((symbol-function 'majutsu--process-display-buffer)
+                   (lambda (_process) nil)))
+          (unwind-protect
+              (should (= 0 (majutsu--call-process-responsive
+                            "jj" process-buf 'dummy-section "/repo/"
+                            "diff" "--stat")))
+            (when (and process (process-live-p process))
+              (delete-process process))))))
+    (should (equal seen-env-args '("diff" "--stat")))
+    (should (equal seen-columns "234"))))
+
+(ert-deftest majutsu-process-test-responsive-call-suppresses-default-sentinel-output ()
+  "`majutsu--call-process-responsive' should not pollute its output buffer."
+  (with-temp-buffer
+    (let ((process-buf (current-buffer)))
+      (cl-letf (((symbol-function 'majutsu-process-environment)
+                 (lambda (_args) process-environment))
+                ((symbol-function 'majutsu--process-display-buffer)
+                 (lambda (_process) nil)))
+        (should (= 0 (majutsu--call-process-responsive
+                      "true" process-buf 'dummy-section "/repo/")))
+        ;; Give any pending sentinel notification one more chance to run.
+        (accept-process-output nil 0.05)
+        (should-not (string-match-p "Process .*\\(?:finished\\|exited\\)"
+                                    (buffer-string)))))))
+
+(ert-deftest majutsu-process-test-process-wait-accepts-output-for-any-process ()
+  "`majutsu--process-wait' should not wait only on the jj process."
+  (let ((statuses '(run run exit))
+        calls)
+    (cl-letf (((symbol-function 'process-status)
+               (lambda (_process) (pop statuses)))
+              ((symbol-function 'accept-process-output)
+               (lambda (&rest args)
+                 (push args calls)
+                 nil))
+              ((symbol-function 'process-exit-status)
+               (lambda (_process) 0)))
+      (should (= 0 (majutsu--process-wait 'fake-process))))
+    (should (equal (nreverse calls)
+                   '((nil 0.1) (nil 0.1))))))
 
 ;;; majutsu-process-test.el ends here


### PR DESCRIPTION
Replace the synchronous `process-file` path used by `majutsu-call-jj`
with a responsive `start-file-process` runner that waits via
`accept-process-output` for all Emacs subprocesses. This lets
Emacs-based GPG/pinentry prompts be serviced while jj is waiting,
avoiding an apparent Emacs freeze/deadlock.

Reuse the Majutsu process filter setup so process-buffer output,
with-editor control packets, and Magit prompt handling keep working
for the synchronous path. Suppress Emacs default process sentinel
output because Majutsu finalizes the process section explicitly.

Add regression coverage for root/argument forwarding, responsive
environment binding, default sentinel output suppression, and
waiting with `accept-process-output` on any process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Emacs no longer freezes when executing synchronous `jj` commands that require user interaction. The application now processes operations responsively, properly servicing authentication prompts (GPG, pinentry) instead of blocking. This ensures seamless workflow during credential entry and authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->