### PR TITLE
Bind RET to the primary action in every command transient

### DIFF
--- a/majutsu-diff.el
+++ b/majutsu-diff.el
@@ -1432,6 +1432,7 @@ REVSET is passed to jj diff using `--revisions='."
     (majutsu-diff:-b)]
    ["Actions"
     ("d" "Execute" majutsu-diff-dwim)
+    ("RET" "Execute" majutsu-diff-dwim)
     ("s" "Save as default" majutsu-diff-save-arguments :transient t)
     ("g" "Refresh" majutsu-refresh :transient t)
     ("q" "Quit" transient-quit-one)]]

--- a/majutsu-ediff.el
+++ b/majutsu-ediff.el
@@ -740,6 +740,7 @@ Called by `jj resolve` merge editor command via emacsclient."
     ("c" "Clear selections" majutsu-selection-clear :transient t)]
    ["Actions"
     ("e" "Ediff (blob)" majutsu-ediff-dwim)
+    ("RET" "Ediff (blob)" majutsu-ediff-dwim)
     ("E" "Ediff (diffedit)" majutsu-ediff-edit)]
    ["Resolve"
     ("m" "Resolve (ediff)" majutsu-ediff-resolve)

--- a/majutsu-log.el
+++ b/majutsu-log.el
@@ -2067,6 +2067,7 @@ offer to create one using `jj git init`."
     (majutsu-log:--)]
    ["Actions"
     ("g" "buffer" majutsu-log-transient)
+    ("RET" "buffer" majutsu-log-transient)
     ("s" "buffer and set defaults" transient-set-and-exit)
     ("w" "buffer and save defaults" transient-save-and-exit)
     ("0" "Reset options" majutsu-log-transient-reset :transient t)

--- a/majutsu-rebase.el
+++ b/majutsu-rebase.el
@@ -183,6 +183,7 @@ ARGS are passed from the transient."
     ("-kd" "Keep divergent" "--keep-divergent")
     (majutsu-transient-arg-ignore-immutable)]
    ["Actions"
+    ("r" "Execute rebase" majutsu-rebase-execute)
     ("RET" "Execute rebase" majutsu-rebase-execute)
     ("q" "Quit" transient-quit-one)]]
   (interactive)

--- a/majutsu-restore.el
+++ b/majutsu-restore.el
@@ -173,6 +173,7 @@ In diff buffer on a file section, restore only that file."
     (majutsu-transient-arg-ignore-immutable)]
    ["Actions"
     ("r" "Restore" majutsu-restore-execute)
+    ("RET" "Restore" majutsu-restore-execute)
     ("q" "Quit" transient-quit-one)]]
   (interactive)
   (let* ((file (majutsu-file-at-point))


### PR DESCRIPTION
## Problem

The command transients are inconsistent about `RET`. Some bind it to their `execute`/`dwim` action, while others only bind a letter key — so `RET` finishes the command in some menus but silently does nothing in others, and you have to remember the per-transient letter to actually run it.

The `rebase` transient is bad in a different way: it binds `RET` but not the letter that would make sense to finish (`r`).

## Fix

Bind `RET` to the primary action everywhere it was missing, alongside the existing letter key (which keeps working):

- `diff`    → `majutsu-diff-dwim` (previously only `d`)
- `ediff`   → `majutsu-ediff-dwim` (previously only `e`, the blob/dwim default)
- `log`     → `majutsu-log-transient` (previously only `g`, regenerate buffer)
- `restore` → `majutsu-restore-execute` (previously only `r`)

And, in the case of rebase, I added `r`
- `rebase`  → `majutsu-rebase-execute` (previously only `RET`)

The other command transients (absorb, new, split, squash, revert, duplicate, simplify-parents, metaedit) already bound `RET` and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved keyboard accessibility by adding new shortcuts across multiple operations: pressing RET (Enter) now executes primary actions in diff, ediff, restore, and log menus; pressing "r" triggers rebase execution. These additions streamline common workflows and reduce reliance on mouse navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->