### PR TITLE
Fix jj large-file warnings leaking into UI output

### DIFF
--- a/majutsu-jj.el
+++ b/majutsu-jj.el
@@ -906,46 +906,61 @@ error text.  Output is optionally colorized based on
   (declare (indent 2))
   (setq args (majutsu-process-jj-arguments args))
   (let* ((beg (point))
-         (exit (apply #'majutsu-process-file (majutsu-jj--executable) nil t nil args)))
-    (when (and (bound-and-true-p majutsu-process-apply-ansi-colors)
-               (> (point) beg))
-      ;; Use text-properties instead of overlays so that subsequent
-      ;; washing/parsing that uses `buffer-substring' preserves faces.
-      (let ((ansi-color-apply-face-function #'ansi-color-apply-text-property-face))
-        (ansi-color-apply-on-region beg (point))))
-    (cond
-     ;; Command produced no output.
-     ((= (point) beg)
-      (if (= exit 0)
-          (magit-cancel-section)
-        (insert (propertize (format "jj %s failed (exit %s)\n"
-                                    (string-join args " ") exit)
-                            'font-lock-face 'error))
-        (unless (bolp)
-          (insert "\n"))))
-     ;; Failure path (unless we explicitly wash anyway).
-     ((and (not (eq keep-error 'wash-anyway))
-           (not (= exit 0)))
-      (goto-char beg)
-      (insert (propertize (format "jj %s failed (exit %s)\n"
-                                  (string-join args " ") exit)
-                          'font-lock-face 'error))
-      (unless (bolp)
-        (insert "\n")))
-     ;; Success (or wash anyway).
-     (t
-      (unless (bolp)
-        (insert "\n"))
-      (when (or (= exit 0)
-                (eq keep-error 'wash-anyway))
-        (save-restriction
-          (narrow-to-region beg (point))
-          (goto-char beg)
-          (funcall washer args))
-        (when (or (= (point) beg)
-                  (= (point) (1+ beg)))
-          (magit-cancel-section)))))
-    exit))
+         (err-file (make-nearby-temp-file "majutsu-jj-err")))
+    (unwind-protect
+        (let ((exit (apply #'majutsu-process-file (majutsu-jj--executable) nil
+                           (list t err-file) nil args)))
+          (when (and (bound-and-true-p majutsu-process-apply-ansi-colors)
+                     (> (point) beg))
+            ;; Use text-properties instead of overlays so that subsequent
+            ;; washing/parsing that uses `buffer-substring' preserves faces.
+            (let ((ansi-color-apply-face-function
+                   #'ansi-color-apply-text-property-face))
+              (ansi-color-apply-on-region beg (point))))
+          (cond
+           ;; Command produced no output.
+           ((= (point) beg)
+            (if (= exit 0)
+                (magit-cancel-section)
+              (insert (propertize (format "jj %s failed (exit %s)\n"
+                                          (string-join args " ") exit)
+                                  'font-lock-face 'error))
+              (when keep-error
+                (insert (ansi-color-filter-apply
+                         (with-temp-buffer
+                           (insert-file-contents err-file)
+                           (buffer-string)))))
+              (unless (bolp)
+                (insert "\n"))))
+           ;; Failure path (unless we explicitly wash anyway).
+           ((and (not (eq keep-error 'wash-anyway))
+                 (not (= exit 0)))
+            (goto-char beg)
+            (insert (propertize (format "jj %s failed (exit %s)\n"
+                                        (string-join args " ") exit)
+                                'font-lock-face 'error))
+            (when keep-error
+              (insert (ansi-color-filter-apply
+                       (with-temp-buffer
+                         (insert-file-contents err-file)
+                         (buffer-string)))))
+            (unless (bolp)
+              (insert "\n")))
+           ;; Success (or wash anyway).
+           (t
+            (unless (bolp)
+              (insert "\n"))
+            (when (or (= exit 0)
+                      (eq keep-error 'wash-anyway))
+              (save-restriction
+                (narrow-to-region beg (point))
+                (goto-char beg)
+                (funcall washer args))
+              (when (or (= (point) beg)
+                        (= (point) (1+ beg)))
+                (magit-cancel-section)))))
+          exit)
+      (ignore-errors (delete-file err-file)))))
 
 ;;; _
 (provide 'majutsu-jj)

--- a/majutsu-process.el
+++ b/majutsu-process.el
@@ -613,12 +613,13 @@ silenced so the captured stderr is verbatim, and is drained explicitly
 before the file is written so its output cannot lag behind."
   (let* ((stdout-dest (if (consp destination) (car destination) destination))
          (stderr-dest (and (consp destination) (cadr destination)))
+         (stderr-discard (and (consp destination) (null stderr-dest)))
          (stdout-buffer (majutsu--process-destination-buffer stdout-dest))
          (stdout-marker (and stdout-buffer
                              (copy-marker (with-current-buffer stdout-buffer
                                             (point))
                                           t)))
-         (stderr-buffer (and (stringp stderr-dest)
+         (stderr-buffer (and (or (stringp stderr-dest) stderr-discard)
                              (generate-new-buffer " *majutsu-stderr*")))
          (process (make-process
                    :name (file-name-nondirectory program)
@@ -649,7 +650,7 @@ before the file is written so its output cannot lag behind."
                 (process-send-eof process)
               (error nil)))
           (setq exit (majutsu--process-wait process stderr-process))
-          (when stderr-buffer
+          (when (and stderr-buffer (stringp stderr-dest))
             (with-current-buffer stderr-buffer
               (write-region (point-min) (point-max) stderr-dest nil 'silent)))
           exit)

--- a/test/majutsu-jj-test.el
+++ b/test/majutsu-jj-test.el
@@ -202,6 +202,65 @@
                          0))
           (should (equal seen-columns "80")))))))
 
+(ert-deftest majutsu-jj-wash/discards-stderr-on-success ()
+  "Successful wash output should exclude warning stderr."
+  (cl-letf (((symbol-function 'majutsu-process-file)
+             (lambda (_program _infile destination _display &rest _args)
+               (insert "diff output\n")
+               (write-region "Warning: refused to snapshot\n" nil
+                             (cadr destination) nil 'silent)
+               0)))
+    (with-temp-buffer
+      (should (= 0 (majutsu-jj-wash (lambda (&rest _) (goto-char (point-max)))
+                       nil
+                     "diff")))
+      (should (equal (buffer-string) "diff output\n")))))
+
+(ert-deftest majutsu-jj-wash/keeps-clean-stderr-on-failure ()
+  "Requested failure stderr should be preserved without ANSI escapes."
+  (cl-letf (((symbol-function 'majutsu-process-file)
+             (lambda (_program _infile destination _display &rest _args)
+               (write-region "\e[31mError: invalid revset\e[0m\n" nil
+                             (cadr destination) nil 'silent)
+               1)))
+    (with-temp-buffer
+      (should (= 1 (majutsu-jj-wash #'ignore t "log" "-r" "bad")))
+      (should (string-match-p "jj .* failed (exit 1)" (buffer-string)))
+      (should (string-match-p "Error: invalid revset" (buffer-string)))
+      (should-not (string-match-p (regexp-quote "\e[") (buffer-string))))))
+
+(ert-deftest majutsu-jj-wash/deletes-stderr-file-when-colorizer-signals ()
+  "The stderr temp file should be deleted if stdout colorization signals."
+  (let ((majutsu-process-apply-ansi-colors t)
+        err-file)
+    (cl-letf (((symbol-function 'majutsu-process-file)
+               (lambda (_program _infile destination _display &rest _args)
+                 (setq err-file (cadr destination))
+                 (insert "output\n")
+                 0))
+              ((symbol-function 'ansi-color-apply-on-region)
+               (lambda (&rest _) (error "colorizer failed"))))
+      (with-temp-buffer
+        (should-error (majutsu-jj-wash #'ignore nil "diff"))))
+    (should err-file)
+    (should-not (file-exists-p err-file))))
+
+(ert-deftest majutsu-jj-wash/deletes-stderr-file-when-washer-signals ()
+  "The stderr temp file should be deleted if the washer signals."
+  (let ((majutsu-process-apply-ansi-colors nil)
+        err-file)
+    (cl-letf (((symbol-function 'majutsu-process-file)
+               (lambda (_program _infile destination _display &rest _args)
+                 (setq err-file (cadr destination))
+                 (insert "output\n")
+                 0)))
+      (with-temp-buffer
+        (should-error
+         (majutsu-jj-wash (lambda (&rest _) (error "washer failed")) nil
+           "diff"))))
+    (should err-file)
+    (should-not (file-exists-p err-file))))
+
 (ert-deftest majutsu--jj-insert/returns-error-message-on-failure ()
   "majutsu--jj-insert should return error message when return-error is t and command fails."
   (let ((err-file (make-temp-file "majutsu-jj-err")))

--- a/test/majutsu-process-test.el
+++ b/test/majutsu-process-test.el
@@ -440,6 +440,16 @@ the separate standard error process."
         (should (string-match-p "O\n" (buffer-string)))
         (should (string-match-p "E\n" (buffer-string)))))))
 
+(ert-deftest majutsu-process-test-file-responsive-discards-explicit-nil-stderr ()
+  "An explicit nil stderr destination should discard, not mix, stderr."
+  (majutsu-process-test--with-sh
+    (with-temp-buffer
+      (let ((exit (majutsu--process-file-responsive
+                   "sh" nil (list t nil)
+                   "-c" "printf 'O\\n'; printf 'E\\n' 1>&2")))
+        (should (= 0 exit))
+        (should (equal (buffer-string) "O\n"))))))
+
 (ert-deftest majutsu-process-test-file-supported-p-narrow-contract ()
   "Only the call shapes Majutsu uses are routed through the runner."
   ;; Supported: no infile; stdout as t/buffer/string/nil; stderr nil/t/string.


### PR DESCRIPTION
## Summary

Fix jj stderr warnings leaking into Majutsu UI output when jj refuses to snapshot large untracked files, such as binary/reference files above `snapshot.max-new-file-size`.

The leak showed up in two places:

- rendered buffers such as diff/status, because `majutsu-jj-wash` inserted jj output with stderr mixed into stdout;
- machine-readable/completion paths, because the responsive `process-file` replacement did not honor explicit nil stderr destinations like `(list t nil)`, allowing warnings to be parsed as candidates.

## Changes

- Route explicit nil stderr destinations to a throwaway stderr process in the responsive process runner, matching `process-file` semantics.
- Capture stderr separately in `majutsu-jj-wash`.
  - Successful commands now render stdout only.
  - Failing commands still include stderr when the caller requests error output.
- Add regression tests for discarded stderr, successful warning stderr, and preserved failure stderr.

## Validation

- Ran the `majutsu-process-test.el` and `majutsu-jj-test.el` test files together: 66/66 passed.
- Manually verified against a jj worktree with large untracked pdf files: the snapshot warning no longer appears in washed status/diff output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of process stderr so it’s preserved in washed output only when requested, and properly excluded from normal output otherwise.
  * Ensured temporary stderr artifacts are reliably cleaned up on both success and error/interrupt paths.

* **Tests**
  * Added regression coverage for washed success vs failure stderr behavior (including ANSI-sanitization expectations).
  * Added coverage to confirm stderr is discarded when explicitly set to disabled, without mixing into stdout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->