### PR TITLE
split: support binary whole-file selections

### DIFF
--- a/majutsu-interactive.el
+++ b/majutsu-interactive.el
@@ -42,6 +42,11 @@
   "Face for selected regions within hunks."
   :group 'majutsu-interactive)
 
+(defface majutsu-interactive-selected-file
+  '((t :background "#3a4f5f"))
+  "Face for selected whole-file changes."
+  :group 'majutsu-interactive)
+
 ;;; Selection Model
 
 (defun majutsu-interactive-selection-available-p ()
@@ -63,6 +68,18 @@ Selection spec is either `:all' for whole hunk, or (BEG . END) for region.")
   "Return the file name for hunk SECTION."
   (let ((val (oref section value)))
     (if (consp val) (car val) val)))
+
+(defun majutsu-interactive--file-id (file)
+  "Return the selection identifier for whole-file FILE."
+  (list :file file))
+
+(defun majutsu-interactive--file-id-p (id)
+  "Return non-nil when ID identifies a whole-file selection."
+  (and (consp id) (eq (car id) :file)))
+
+(defun majutsu-interactive--file-id-file (id)
+  "Return the path stored in whole-file selection ID."
+  (cadr id))
 
 (defun majutsu-interactive--ensure-selections ()
   "Ensure selections hash table exists."
@@ -129,8 +146,42 @@ When CONTEXT-ON-ADDED is non-nil, treat unselected added lines as context."
        magit-root-section))
     result))
 
+(defun majutsu-interactive--file-section-for-file (file)
+  "Find the real diff file section for FILE, ignoring diffstat if possible."
+  (let (fallback result)
+    (when (and file magit-root-section)
+      (magit-map-sections
+       (lambda (section)
+         (when (and (magit-section-match 'jj-file section)
+                    (equal (oref section value) file))
+           (unless fallback (setq fallback section))
+           (when (and (not result) (oref section header))
+             (setq result section))))
+       magit-root-section))
+    (or result fallback)))
+
+(defun majutsu-interactive--file-section-hunks (file-section)
+  "Return the hunk children of FILE-SECTION."
+  (seq-filter (lambda (child) (magit-section-match 'jj-hunk child))
+              (oref file-section children)))
+
+(defun majutsu-interactive--whole-file-selection-allowed-p ()
+  "Return non-nil when the active transient supports whole-file selections."
+  (and (boundp 'transient-current-command)
+       (eq transient-current-command 'majutsu-split)))
+
+(defun majutsu-interactive--toggle-whole-file (file-section)
+  "Toggle the whole-file selection represented by FILE-SECTION."
+  (unless (majutsu-interactive--whole-file-selection-allowed-p)
+    (user-error "Whole-file selections are only supported by jj split"))
+  (let* ((id (majutsu-interactive--file-id (oref file-section value)))
+         (current (majutsu-interactive--get-selection id)))
+    (majutsu-interactive--set-selection id (unless current :all))
+    (majutsu-interactive--render-overlays)
+    (message "%s whole-file change" (if current "Deselected" "Selected"))))
+
 (defun majutsu-interactive-toggle-file ()
-  "Toggle selection of all hunks in the file at point."
+  "Toggle all hunks, or a hunkless whole-file change, at point."
   (interactive)
   (let (file-section)
     (magit-section-case
@@ -138,25 +189,28 @@ When CONTEXT-ON-ADDED is non-nil, treat unselected added lines as context."
       (jj-file (setq file-section it)))
     (let ((file (and file-section (oref file-section value))))
       (when (and file-section (magit-section-match 'jj-file file-section))
-        (unless (seq-some (lambda (child) (magit-section-match 'jj-hunk child))
-                          (oref file-section children))
-          (setq file-section (majutsu-interactive--file-section-with-hunks file)))
+        (unless (majutsu-interactive--file-section-hunks file-section)
+          (setq file-section
+                (or (majutsu-interactive--file-section-with-hunks file)
+                    (majutsu-interactive--file-section-for-file file))))
         (unless file-section
-          (user-error "No hunks for file at point"))
-        (let* ((hunks (oref file-section children))
-               (all-selected (cl-every
-                              (lambda (h)
-                                (majutsu-interactive--get-selection
-                                 (majutsu-interactive--hunk-id h)))
-                              hunks)))
-          (dolist (hunk hunks)
-            (when (magit-section-match 'jj-hunk hunk)
-              (majutsu-interactive--set-selection
-               (majutsu-interactive--hunk-id hunk)
-               (unless all-selected :all))))
-          (majutsu-interactive--render-overlays)
-          (message "%s all hunks in file"
-                   (if all-selected "Deselected" "Selected")))))))
+          (user-error "No file change at point"))
+        (let ((hunks (majutsu-interactive--file-section-hunks file-section)))
+          (if (null hunks)
+              (majutsu-interactive--toggle-whole-file file-section)
+            (let ((all-selected
+                   (cl-every
+                    (lambda (h)
+                      (majutsu-interactive--get-selection
+                       (majutsu-interactive--hunk-id h)))
+                    hunks)))
+              (dolist (hunk hunks)
+                (majutsu-interactive--set-selection
+                 (majutsu-interactive--hunk-id hunk)
+                 (unless all-selected :all)))
+              (majutsu-interactive--render-overlays)
+              (message "%s all hunks in file"
+                       (if all-selected "Deselected" "Selected")))))))))
 
 (defun majutsu-interactive--normalize-line-range (start end limit-start limit-end)
   "Return a line-aligned range between START and END.
@@ -261,21 +315,27 @@ The range is clamped to LIMIT-START and LIMIT-END."
   (let ((selections majutsu-interactive--selections))
     (when selections
       (maphash
-       (lambda (hunk-id spec)
-         (when-let* ((section (majutsu-interactive--find-hunk-section hunk-id)))
-           (cond
-            ((eq spec :all)
-             (let ((ov (make-overlay (oref section start) (oref section end))))
-               (overlay-put ov 'face 'majutsu-interactive-selected-hunk)
-               (overlay-put ov 'evaporate t)
-               (push ov majutsu-interactive--overlays)))
-            ((consp spec)
-             (let ((ranges (if (and spec (consp (car spec))) spec (list spec))))
-               (dolist (range ranges)
-                 (let ((ov (make-overlay (car range) (cdr range))))
-                   (overlay-put ov 'face 'majutsu-interactive-selected-region)
-                   (overlay-put ov 'evaporate t)
-                   (push ov majutsu-interactive--overlays))))))))
+       (lambda (id spec)
+         (if (majutsu-interactive--file-id-p id)
+             (when-let* ((section (majutsu-interactive--find-file-section id)))
+               (let ((ov (make-overlay (oref section start) (oref section end))))
+                 (overlay-put ov 'face 'majutsu-interactive-selected-file)
+                 (overlay-put ov 'evaporate t)
+                 (push ov majutsu-interactive--overlays)))
+           (when-let* ((section (majutsu-interactive--find-hunk-section id)))
+             (cond
+              ((eq spec :all)
+               (let ((ov (make-overlay (oref section start) (oref section end))))
+                 (overlay-put ov 'face 'majutsu-interactive-selected-hunk)
+                 (overlay-put ov 'evaporate t)
+                 (push ov majutsu-interactive--overlays)))
+              ((consp spec)
+               (let ((ranges (if (and spec (consp (car spec))) spec (list spec))))
+                 (dolist (range ranges)
+                   (let ((ov (make-overlay (car range) (cdr range))))
+                     (overlay-put ov 'face 'majutsu-interactive-selected-region)
+                     (overlay-put ov 'evaporate t)
+                     (push ov majutsu-interactive--overlays)))))))))
        selections))))
 
 (defun majutsu-interactive--find-hunk-section (hunk-id)
@@ -291,6 +351,11 @@ The range is clamped to LIMIT-START and LIMIT-END."
         (walk magit-root-section)))
     result))
 
+(defun majutsu-interactive--find-file-section (file-id)
+  "Find the real diff section identified by whole-file FILE-ID."
+  (majutsu-interactive--file-section-for-file
+   (majutsu-interactive--file-id-file file-id)))
+
 ;;; Patch Generation
 
 (defun majutsu-interactive--collect-selected-hunks ()
@@ -304,6 +369,79 @@ Returns list of (FILE-SECTION HUNK-SECTION SPEC)."
            (push (list (oref hunk parent) hunk spec) result)))
        majutsu-interactive--selections))
     (nreverse result)))
+
+(defun majutsu-interactive--collect-selected-files ()
+  "Return the real diff sections for selected whole-file changes."
+  (let (result)
+    (when majutsu-interactive--selections
+      (maphash
+       (lambda (id _spec)
+         (when (majutsu-interactive--file-id-p id)
+           (when-let* ((section (majutsu-interactive--find-file-section id)))
+             (push section result))))
+       majutsu-interactive--selections))
+    (nreverse result)))
+
+(defun majutsu-interactive--header-path (header prefix)
+  "Return the path following PREFIX on a line in HEADER."
+  (when (string-match (concat "^" (regexp-quote prefix) "\\(.+\\)$")
+                      (or header ""))
+    (let ((path (match-string 1 header)))
+      (if (not (string-prefix-p "\"" path))
+          path
+        (condition-case nil
+            (pcase-let ((`(,decoded . ,end) (read-from-string path)))
+              (unless (and (stringp decoded) (= end (length path)))
+                (user-error "Invalid quoted Git path: %s" path))
+              decoded)
+          (error (user-error "Invalid quoted Git path: %s" path)))))))
+
+(defun majutsu-interactive--safe-relative-path (path)
+  "Return PATH, or signal a user error if it is unsafe for the helper tool."
+  (unless (and (stringp path)
+               (not (string-empty-p path))
+               (not (file-name-absolute-p path))
+               (not (string-match-p "[\n\r\0]" path))
+               (not (member ".." (split-string path "/" t))))
+    (user-error "Unsafe whole-file selection path: %S" path))
+  path)
+
+(defun majutsu-interactive--file-operation (file-section)
+  "Parse an explicit whole-file operation from FILE-SECTION metadata."
+  (let* ((header (or (oref file-section header) ""))
+         (value (oref file-section value))
+         (rename-from (majutsu-interactive--header-path header "rename from "))
+         (rename-to (majutsu-interactive--header-path header "rename to "))
+         (copy-from (majutsu-interactive--header-path header "copy from "))
+         (copy-to (majutsu-interactive--header-path header "copy to "))
+         (path (majutsu-interactive--safe-relative-path
+                (or rename-to copy-to value))))
+    (cond
+     ((or rename-from rename-to)
+      (unless (and rename-from rename-to)
+        (user-error "Incomplete rename metadata for %s" value))
+      (list :action 'rename
+            :source (majutsu-interactive--safe-relative-path rename-from)
+            :path path))
+     ((or copy-from copy-to)
+      (unless (and copy-from copy-to)
+        (user-error "Incomplete copy metadata for %s" value))
+      (list :action 'copy
+            :source (majutsu-interactive--safe-relative-path copy-from)
+            :path path))
+     ((or (string-match-p "^deleted file mode " header)
+          (string-match-p "^+++ /dev/null$" header))
+      (list :action 'delete :path path))
+     ((or (string-match-p "^new file mode " header)
+          (string-match-p "^--- /dev/null$" header))
+      (list :action 'add :path path))
+     (t
+      (list :action 'modify :path path)))))
+
+(defun majutsu-interactive--build-file-operations ()
+  "Return explicit operations for all selected whole-file changes."
+  (mapcar #'majutsu-interactive--file-operation
+          (majutsu-interactive--collect-selected-files)))
 
 (defun majutsu-interactive--collect-hunks-by-file ()
   "Return hash table of FILE-SECTION to list of HUNK-SECTIONS."
@@ -500,8 +638,6 @@ When CONTEXT-ON-ADDED is non-nil, treat unselected added lines as context.
 Returns patch string or nil if no selections."
   (let* ((selected (majutsu-interactive--collect-selected-hunks))
          (by-file (make-hash-table :test 'eq)))
-    (unless selected
-      (user-error "No hunks selected"))
     ;; Group by file section
     (dolist (item selected)
       (let ((file (car item))
@@ -564,6 +700,23 @@ Returns patch string or nil if no selections."
         (majutsu-interactive--fixup-patch
          (mapconcat #'identity (nreverse patches) ""))))))
 
+(defun majutsu-interactive-build-operation-if-selected
+    (&optional buffer invert include-all-files context-on-added)
+  "Return BUFFER's selected text patch and explicit whole-file operations.
+The result is a plist containing :patch and :file-ops, or nil when nothing
+usable is selected.  Whole-file selections never cause unselected text hunks
+to be included, regardless of INVERT or INCLUDE-ALL-FILES.
+CONTEXT-ON-ADDED has the same meaning as in
+`majutsu-interactive-build-patch-if-selected'."
+  (with-current-buffer (or buffer (current-buffer))
+    (when (majutsu-interactive--has-selections-p)
+      (let ((patch (and (majutsu-interactive--collect-selected-hunks)
+                        (majutsu-interactive--build-patch
+                         invert include-all-files context-on-added)))
+            (file-ops (majutsu-interactive--build-file-operations)))
+        (when (or patch file-ops)
+          (list :patch patch :file-ops file-ops))))))
+
 
 (defun majutsu-interactive--fixup-patch (patch)
   "Fix hunk header line counts in PATCH using diff-mode."
@@ -599,9 +752,15 @@ Returns patch string or nil if no selections."
       (insert patch))
     file))
 
-(defun majutsu-interactive--write-applypatch-script (reverse)
+(defun majutsu-interactive--script-path (root path)
+  "Return a safely shell-quoted PATH beneath shell variable ROOT."
+  (format "\"$%s\"/%s" root (shell-quote-argument path)))
+
+(defun majutsu-interactive--write-applypatch-script (reverse &optional file-ops)
   "Write the applypatch helper script and return its path.
-When REVERSE is non-nil, reset $right to $left state first, then apply patch."
+When REVERSE is non-nil, reset $right to $left state first, then apply patch.
+FILE-OPS contains explicit `add', `modify', `delete', `rename', or `copy'
+actions.  Only right-tree paths needed by those operations are preserved."
   (let ((script (expand-file-name "applypatch.sh" (majutsu-interactive--temp-dir))))
     (with-temp-file script
       (insert "#!/bin/sh\n")
@@ -610,31 +769,74 @@ When REVERSE is non-nil, reset $right to $left state first, then apply patch."
       (insert "LEFT=\"$1\"\n")
       (insert "RIGHT=\"$2\"\n")
       (insert "PATCH=\"$3\"\n")
+      (insert "majutsu_apply_patch() {\n")
+      (insert "  [ -s \"$PATCH\" ] || return 0\n")
+      (insert "  git apply --recount --unidiff-zero -v \"$PATCH\" 2>&1 && return 0\n")
+      (insert "  git init -q || return $?\n")
+      (insert "  git add -A || return $?\n")
+      (insert "  git -c user.name=Majutsu -c user.email=majutsu.invalid commit -q -m base --allow-empty || return $?\n")
+      (insert "  git apply --3way --recount -v \"$PATCH\" 2>&1\n")
+      (insert "  STATUS=$?\n")
+      (insert "  rm -rf -- .git || return $?\n")
+      (insert "  return $STATUS\n")
+      (insert "}\n")
+      (when file-ops
+        (unless reverse
+          (error "Whole-file operations require a reset-style merge tool"))
+        (insert "majutsu_remove() { rm -rf -- \"$1\"; }\n")
+        (insert "majutsu_copy() {\n")
+        (insert "  mkdir -p -- \"$(dirname -- \"$2\")\" || return $?\n")
+        (insert "  cp -a -- \"$1\" \"$2\"\n")
+        (insert "}\n")
+        (insert "PRESERVED=$(mktemp -d \"${TMPDIR:-/tmp}/majutsu-interactive-right.XXXXXX\") || exit $?\n")
+        (insert "majutsu_cleanup() { rm -rf -- \"$PRESERVED\"; }\n")
+        (insert "trap majutsu_cleanup 0 1 2 3 15\n")
+        (dolist (op file-ops)
+          (when (memq (plist-get op :action) '(add modify rename copy))
+            (let ((path (plist-get op :path)))
+              (insert
+               (format "majutsu_copy %s %s || exit $?\n"
+                       (majutsu-interactive--script-path "RIGHT" path)
+                       (majutsu-interactive--script-path "PRESERVED" path)))))))
       (when reverse
-        ;; For split/squash: reset $right to $left (parent) state first
-        ;; Then apply the patch containing remaining content
         (insert "# Reset right to left state\n")
-        (insert "rm -rf \"$RIGHT\"/* 2>/dev/null\n")
-        (insert "rm -rf \"$RIGHT\"/.[!.]* 2>/dev/null\n")
-        (insert "cp -a \"$LEFT\"/. \"$RIGHT\"/ 2>/dev/null || true\n"))
-      (insert "cd \"$RIGHT\"\n")
-      ;; Try git apply with --recount which recalculates line numbers
-      (insert "git apply --recount --unidiff-zero -v \"$PATCH\" 2>&1 && exit 0\n")
-      ;; Fallback: init git repo for 3way merge
-      (insert "git init -q 2>/dev/null\n")
-      (insert "git add -A 2>/dev/null\n")
-      (insert "git commit -q -m 'base' --allow-empty 2>/dev/null\n")
-      (insert "git apply --3way --recount -v \"$PATCH\" 2>&1\n")
-      (insert "EXIT=$?\n")
-      (insert "rm -rf .git 2>/dev/null\n")
-      (insert "exit $EXIT\n"))
+        (insert "find \"$RIGHT\" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} + || exit $?\n")
+        (insert "cp -a -- \"$LEFT\"/. \"$RIGHT\"/ || exit $?\n"))
+      (insert "cd \"$RIGHT\" || exit $?\n")
+      (insert "majutsu_apply_patch || exit $?\n")
+      (dolist (op file-ops)
+        (let* ((action (plist-get op :action))
+               (path (plist-get op :path))
+               (destination (majutsu-interactive--script-path "RIGHT" path))
+               (preserved (majutsu-interactive--script-path "PRESERVED" path)))
+          (pcase action
+            ((or 'add 'modify)
+             (insert (format "majutsu_remove %s || exit $?\n" destination))
+             (insert (format "majutsu_copy %s %s || exit $?\n"
+                             preserved destination)))
+            ('delete
+             (insert (format "majutsu_remove %s || exit $?\n" destination)))
+            ('rename
+             (insert
+              (format "majutsu_remove %s || exit $?\n"
+                      (majutsu-interactive--script-path
+                       "RIGHT" (plist-get op :source))))
+             (insert (format "majutsu_remove %s || exit $?\n" destination))
+             (insert (format "majutsu_copy %s %s || exit $?\n"
+                             preserved destination)))
+            ('copy
+             (insert (format "majutsu_remove %s || exit $?\n" destination))
+             (insert (format "majutsu_copy %s %s || exit $?\n"
+                             preserved destination)))
+            (_ (error "Unknown whole-file operation: %S" action)))))
+      (insert "exit 0\n"))
     (set-file-modes script #o755)
     script))
 
-(defun majutsu-interactive--build-tool-config (patch-file reverse)
+(defun majutsu-interactive--build-tool-config (patch-file reverse &optional file-ops)
   "Build jj --config arguments for applypatch tool with PATCH-FILE.
-When REVERSE is non-nil, the script will apply the patch in reverse."
-  (let* ((script (majutsu-interactive--write-applypatch-script reverse))
+When REVERSE is non-nil, reset before applying.  FILE-OPS are replayed after."
+  (let* ((script (majutsu-interactive--write-applypatch-script reverse file-ops))
          (script-path (majutsu-convert-filename-for-jj script))
          (patch-path (majutsu-convert-filename-for-jj patch-file)))
     (list
@@ -645,11 +847,14 @@ When REVERSE is non-nil, the script will apply the patch in reverse."
 
 ;;; Pending Operation Flow
 
-(defun majutsu-interactive-run-with-patch (command args filesets patch &optional reverse)
-  "Run jj COMMAND with ARGS and FILESETS, applying PATCH via custom tool.
-If REVERSE is non-nil, apply the patch in reverse using git apply -R."
-  (let* ((patch-file (majutsu-interactive--write-patch patch))
-         (tool-config (majutsu-interactive--build-tool-config patch-file reverse))
+(defun majutsu-interactive-run-with-patch
+    (command args filesets patch &optional reverse file-ops)
+  "Run jj COMMAND with ARGS and FILESETS, applying PATCH and FILE-OPS.
+If REVERSE is non-nil, reset the right tree to the left tree before applying
+the selected text patch and explicit whole-file operations."
+  (let* ((patch-file (majutsu-interactive--write-patch (or patch "")))
+         (tool-config (majutsu-interactive--build-tool-config
+                       patch-file reverse file-ops))
          (args (append args
                        (list "-i" "--tool" "majutsu-applypatch")
                        tool-config))

--- a/majutsu-split.el
+++ b/majutsu-split.el
@@ -30,26 +30,38 @@
                 arg))
             majutsu-buffer-diff-range)))
 
+(defun majutsu-split--remove-interactive-tool-args (args)
+  "Return ARGS without native interactive-editor or tool arguments."
+  (let (result)
+    (while args
+      (let ((arg (pop args)))
+        (cond
+         ((member arg '("-i" "--interactive")) nil)
+         ((member arg '("-t" "--tool")) (pop args))
+         ((or (string-prefix-p "--tool=" arg)
+              (string-prefix-p "-t=" arg)) nil)
+         (t (push arg result)))))
+    (nreverse result)))
+
 (transient-define-suffix majutsu-split-execute (args)
   "Execute split with selections recorded in the transient."
   :description "Execute split"
   :class 'majutsu-transient-default-action-suffix
   (interactive (list (transient-args 'majutsu-split)))
   (pcase-let* ((`(,args ,filesets) (majutsu-filesets-split-transient-value args))
-               ;; Generate patch for SELECTED content (invert=nil)
-               ;; This is what goes into the first commit
-               (patch (majutsu-interactive-build-patch-if-selected nil nil nil))
-               (args (if patch
-                         (seq-remove (lambda (arg)
-                                       (or (string= arg "--interactive")
-                                           (transient-arg-value "--tool=" (list arg))))
-                                     args)
+               ;; Text hunks and hunkless files coexist in one operation.
+               (operation (majutsu-interactive-build-operation-if-selected
+                           nil nil nil nil))
+               (patch (plist-get operation :patch))
+               (file-ops (plist-get operation :file-ops))
+               (args (if operation
+                         (majutsu-split--remove-interactive-tool-args args)
                        args)))
-    (if patch
+    (if operation
         (progn
-          ;; reverse=t means reset $right to $left, then apply patch forward
-          ;; Result: $right = selected content = first commit
-          (majutsu-interactive-run-with-patch "split" args filesets patch t)
+          ;; Reset to the left tree, then replay precisely the selections.
+          (majutsu-interactive-run-with-patch
+           "split" args filesets patch t file-ops)
           (majutsu-interactive-clear))
       (majutsu-run-jj-with-editor
        (cons "split" (majutsu-jj-append-filesets args filesets))))))

--- a/test/majutsu-interactive-test.el
+++ b/test/majutsu-interactive-test.el
@@ -13,13 +13,42 @@
 (require 'ert)
 (require 'majutsu-interactive)
 
+(defun majutsu-interactive-test--insert-diff (diff &optional file)
+  "Wash DIFF and return its real jj-file section, optionally matching FILE."
+  (majutsu-diff-mode)
+  (let ((inhibit-read-only t)
+        (magit-section-inhibit-markers t))
+    (magit-insert-section (root)
+      (insert diff)
+      (save-restriction
+        (narrow-to-region (point-min) (point-max))
+        (majutsu-diff-wash-diffs '("--git")))))
+  (let (result)
+    (magit-map-sections
+     (lambda (section)
+       (when (and (not result)
+                  (magit-section-match 'jj-file section)
+                  (oref section header)
+                  (or (null file) (equal (oref section value) file)))
+         (setq result section)))
+     magit-root-section)
+    result))
+
+(defun majutsu-interactive-test--file-contents (path &optional literal)
+  "Return PATH contents, reading literally when LITERAL is non-nil."
+  (with-temp-buffer
+    (if literal
+        (insert-file-contents-literally path)
+      (insert-file-contents path))
+    (buffer-string)))
+
 (ert-deftest majutsu-interactive-run-with-patch/inserts-tool-before-filesets ()
   "Patch runner should keep jj options before filesets."
   (let (called)
     (cl-letf (((symbol-function 'majutsu-interactive--write-patch)
                (lambda (_patch) "/tmp/patch.diff"))
               ((symbol-function 'majutsu-interactive--build-tool-config)
-               (lambda (_patch-file _reverse)
+               (lambda (_patch-file _reverse &optional _file-ops)
                  '("--config" "merge-tools.majutsu-applypatch.program=/tmp/applypatch")))
               ((symbol-function 'majutsu-run-jj-with-editor)
                (lambda (&rest args)
@@ -38,7 +67,7 @@
     (cl-letf (((symbol-function 'majutsu-interactive--write-patch)
                (lambda (_patch) "/tmp/patch.diff"))
               ((symbol-function 'majutsu-interactive--build-tool-config)
-               (lambda (_patch-file _reverse)
+               (lambda (_patch-file _reverse &optional _file-ops)
                  '("--config" "tool=config")))
               ((symbol-function 'majutsu-run-jj-with-editor)
                (lambda (&rest args)
@@ -55,7 +84,8 @@
   "Tool config should pass local remote paths to jj merge-tool args."
   (let ((config
          (cl-letf (((symbol-function 'majutsu-interactive--write-applypatch-script)
-                    (lambda (_reverse) "/ssh:demo:/tmp/applypatch.sh"))
+                    (lambda (_reverse &optional _file-ops)
+                      "/ssh:demo:/tmp/applypatch.sh"))
                    ((symbol-function 'majutsu-convert-filename-for-jj)
                     (lambda (path)
                       (pcase path
@@ -110,6 +140,155 @@
         (let ((remote (majutsu-interactive--temp-dir)))
           (should (not (equal local remote)))
           (should (equal (length seen) 2)))))))
+
+(ert-deftest majutsu-interactive-file-operation/parses-explicit-actions ()
+  "Whole-file actions must come from diff metadata, including rename/copy."
+  (dolist
+      (case
+       '(("diff --git a/add.bin b/add.bin\nnew file mode 100644\nBinary files /dev/null and b/add.bin differ\n"
+          "add.bin" (:action add :path "add.bin"))
+         ("diff --git a/mod.bin b/mod.bin\nindex 123..456 100644\nBinary files a/mod.bin and b/mod.bin differ\n"
+          "mod.bin" (:action modify :path "mod.bin"))
+         ("diff --git a/del.bin b/del.bin\ndeleted file mode 100644\nBinary files a/del.bin and /dev/null differ\n"
+          "del.bin" (:action delete :path "del.bin"))
+         ("diff --git a/old.bin b/new.bin\nsimilarity index 100%\nrename from old.bin\nrename to new.bin\n"
+          "new.bin" (:action rename :source "old.bin" :path "new.bin"))
+         ("diff --git a/src.bin b/copy.bin\nsimilarity index 100%\ncopy from src.bin\ncopy to copy.bin\n"
+          "copy.bin" (:action copy :source "src.bin" :path "copy.bin"))
+         ("diff --git a/x b/x\nsimilarity index 100%\nrename from \"old\\040name.bin\"\nrename to \"new\\040name.bin\"\n"
+          "x" (:action rename :source "old name.bin" :path "new name.bin"))
+         ("diff --git a/x b/x\nsimilarity index 100%\ncopy from \"src\\042quote\\134path.bin\"\ncopy to \"dst\\040name.bin\"\n"
+          "x" (:action copy :source "src\"quote\\path.bin"
+               :path "dst name.bin"))))
+    (with-temp-buffer
+      (pcase-let ((`(,diff ,file ,expected) case))
+        (let ((section (majutsu-interactive-test--insert-diff diff file)))
+          (should section)
+          (should (equal (majutsu-interactive--file-operation section)
+                         expected)))))))
+
+(ert-deftest majutsu-interactive-header-path/rejects-malformed-git-quoting ()
+  "Malformed Git C-style paths must not silently become filesystem paths."
+  (should-error
+   (majutsu-interactive--header-path
+    "rename from \"unterminated\\040path\n" "rename from ")
+   :type 'user-error)
+  (should-error
+   (majutsu-interactive--header-path
+    "copy from \"valid\"trailing\n" "copy from ")
+   :type 'user-error))
+
+(ert-deftest majutsu-interactive-toggle-file/selects-hunkless-file-for-split ()
+  "A binary file section is selectable as a whole-file split operation."
+  (with-temp-buffer
+    (let* ((diff "diff --git a/bin.dat b/bin.dat\nnew file mode 100644\nBinary files /dev/null and b/bin.dat differ\n")
+           (section (majutsu-interactive-test--insert-diff diff "bin.dat"))
+           (transient-current-command 'majutsu-split))
+      (goto-char (oref section start))
+      (majutsu-interactive-toggle-file)
+      (should
+       (equal (majutsu-interactive-build-operation-if-selected nil t t nil)
+              '(:patch nil :file-ops ((:action add :path "bin.dat"))))))))
+
+(ert-deftest majutsu-interactive-toggle-file/rejects-hunkless-non-split ()
+  "Restore/squash must reject and not record a whole-file selection."
+  (dolist (command '(majutsu-restore majutsu-squash nil))
+    (with-temp-buffer
+      (let* ((diff "diff --git a/bin.dat b/bin.dat\nindex 1..2 100644\nBinary files a/bin.dat and b/bin.dat differ\n")
+             (section (majutsu-interactive-test--insert-diff diff "bin.dat"))
+             (transient-current-command command))
+        (goto-char (oref section start))
+        (should-error (majutsu-interactive-toggle-file) :type 'user-error)
+        (should-not (majutsu-interactive-has-selections-p))))))
+
+(ert-deftest majutsu-interactive-operation/mixed-does-not-include-unselected-hunks ()
+  "A mixed text/binary operation must not carry an unselected text hunk."
+  (with-temp-buffer
+    (let* ((diff (concat
+                  "diff --git a/text.txt b/text.txt\n--- a/text.txt\n+++ b/text.txt\n"
+                  "@@ -1 +1 @@\n-old one\n+selected one\n"
+                  "@@ -10 +10 @@\n-old two\n+unselected two\n"
+                  "diff --git a/bin.dat b/bin.dat\nnew file mode 100644\n"
+                  "Binary files /dev/null and b/bin.dat differ\n"))
+           (text (majutsu-interactive-test--insert-diff diff "text.txt"))
+           (binary (majutsu-interactive--file-section-for-file "bin.dat"))
+           (hunk (car (majutsu-interactive--file-section-hunks text))))
+      (majutsu-interactive--set-selection
+       (majutsu-interactive--hunk-id hunk) :all)
+      (majutsu-interactive--set-selection
+       (majutsu-interactive--file-id (oref binary value)) :all)
+      (let* ((operation (majutsu-interactive-build-operation-if-selected))
+             (patch (plist-get operation :patch)))
+        (should (string-match-p "selected one" patch))
+        (should-not (string-match-p "unselected two" patch))
+        (should (equal (plist-get operation :file-ops)
+                       '((:action add :path "bin.dat"))))))))
+
+(ert-deftest majutsu-interactive--write-applypatch-script/replays-explicit-ops ()
+  "The real helper replays add/modify/delete/rename/copy after text patch."
+  (let* ((dir (make-temp-file "majutsu-interactive-script-" t))
+         (left (expand-file-name "left" dir))
+         (right (expand-file-name "right" dir))
+         (patch-file (expand-file-name "patch.diff" dir))
+         (ops '((:action add :path "added.bin")
+                (:action modify :path "modified.bin")
+                (:action delete :path "deleted.bin")
+                (:action delete :path "collision")
+                (:action rename :source "old.bin" :path "renamed.bin")
+                (:action copy :source "source.bin" :path "copied.bin"))))
+    (unwind-protect
+        (progn
+          (make-directory left)
+          (make-directory right)
+          (dolist (entry '(("text.txt" . "old\n")
+                           ("modified.bin" . "old-mod")
+                           ("deleted.bin" . "delete-me")
+                           ("collision" . "left-file")
+                           ("old.bin" . "rename-me")
+                           ("source.bin" . "copy-me")))
+            (with-temp-file (expand-file-name (car entry) left)
+              (insert (cdr entry))))
+          (dolist (entry '(("text.txt" . "unselected-right\n")
+                           ("added.bin" . "added")
+                           ("modified.bin" . "new-mod")
+                           ("renamed.bin" . "rename-me")
+                           ("source.bin" . "copy-me")
+                           ("copied.bin" . "copy-me")
+                           ("unselected.bin" . "must-disappear")))
+            (with-temp-file (expand-file-name (car entry) right)
+              (insert (cdr entry))))
+          ;; Exercise the Major regression: the original right path is an
+          ;; unrelated directory, but explicit delete must still delete it.
+          (make-directory (expand-file-name "collision" right))
+          (with-temp-file (expand-file-name "collision/child" right)
+            (insert "unrelated"))
+          (with-temp-file patch-file
+            (insert "diff --git a/text.txt b/text.txt\n--- a/text.txt\n+++ b/text.txt\n@@ -1 +1 @@\n-old\n+selected\n"))
+          (let (script)
+            (cl-letf (((symbol-function 'majutsu-interactive--temp-dir)
+                       (lambda () dir)))
+              (setq script
+                    (majutsu-interactive--write-applypatch-script t ops)))
+            (should (zerop (call-process script nil nil nil
+                                         left right patch-file))))
+          (should (equal (majutsu-interactive-test--file-contents
+                          (expand-file-name "text.txt" right))
+                         "selected\n"))
+          (should (equal (majutsu-interactive-test--file-contents
+                          (expand-file-name "added.bin" right)) "added"))
+          (should (equal (majutsu-interactive-test--file-contents
+                          (expand-file-name "modified.bin" right)) "new-mod"))
+          (should-not (file-exists-p (expand-file-name "deleted.bin" right)))
+          (should-not (file-exists-p (expand-file-name "collision" right)))
+          (should-not (file-exists-p (expand-file-name "old.bin" right)))
+          (should (equal (majutsu-interactive-test--file-contents
+                          (expand-file-name "renamed.bin" right)) "rename-me"))
+          (should (equal (majutsu-interactive-test--file-contents
+                          (expand-file-name "source.bin" right)) "copy-me"))
+          (should (equal (majutsu-interactive-test--file-contents
+                          (expand-file-name "copied.bin" right)) "copy-me"))
+          (should-not (file-exists-p (expand-file-name "unselected.bin" right))))
+      (delete-directory dir t))))
 
 (provide 'majutsu-interactive-test)
 ;;; majutsu-interactive-test.el ends here

--- a/test/majutsu-split-test.el
+++ b/test/majutsu-split-test.el
@@ -15,7 +15,7 @@
 (ert-deftest majutsu-split-execute/places-structured-filesets-after-options ()
   "Execute split with transient filesets after option arguments."
   (let (called)
-    (cl-letf (((symbol-function 'majutsu-interactive-build-patch-if-selected)
+    (cl-letf (((symbol-function 'majutsu-interactive-build-operation-if-selected)
                (lambda (&rest _) nil))
               ((symbol-function 'majutsu-run-jj-with-editor)
                (lambda (&rest args)
@@ -28,8 +28,8 @@
 (ert-deftest majutsu-split-execute/patch-keeps-filesets-after-options ()
   "Patch split should still pass transient filesets after option arguments."
   (let (called cleared)
-    (cl-letf (((symbol-function 'majutsu-interactive-build-patch-if-selected)
-               (lambda (&rest _) "PATCH"))
+    (cl-letf (((symbol-function 'majutsu-interactive-build-operation-if-selected)
+               (lambda (&rest _) '(:patch "PATCH" :file-ops nil)))
               ((symbol-function 'majutsu-interactive-run-with-patch)
                (lambda (&rest args)
                  (setq called args)))
@@ -37,7 +37,24 @@
                (lambda () (setq cleared t))))
       (majutsu-split-execute '(("--" "src/a.el") "--revision=@" "--interactive"))
       (should (equal called
-                     '("split" ("--revision=@") ("src/a.el") "PATCH" t)))
+                     '("split" ("--revision=@") ("src/a.el") "PATCH" t nil)))
+      (should cleared))))
+
+(ert-deftest majutsu-split-execute/file-op-only-forwards-filesets-and-strips-tool ()
+  "File-op-only splits use the custom tool and preserve current filesets."
+  (let ((ops '((:action delete :path "gone.bin"))) called cleared)
+    (cl-letf (((symbol-function 'majutsu-interactive-build-operation-if-selected)
+               (lambda (&rest _) (list :patch nil :file-ops ops)))
+              ((symbol-function 'majutsu-interactive-run-with-patch)
+               (lambda (&rest args) (setq called args)))
+              ((symbol-function 'majutsu-interactive-clear)
+               (lambda () (setq cleared t))))
+      (majutsu-split-execute
+       '(("--" "bin/gone.bin") "--revision=@" "-i"
+         "--tool" "meld" "--tool=vimdiff"))
+      (should (equal called
+                     (list "split" '("--revision=@") '("bin/gone.bin")
+                           nil t ops)))
       (should cleared))))
 
 (provide 'majutsu-split-test)


### PR DESCRIPTION
The split transient could only turn selected text hunks into a patch.  Binary file changes do not have hunk sections in the diff buffer, so selecting a binary file did not produce a patch and `jj split` fell back to its normal interactive editor flow instead of splitting the selected binary change.

Fix this by adding a separate whole-file selection path for hunkless diff file sections:

  - represent whole-file selections separately from hunk selections;
  - allow hunkless file selection while the split transient is active;
  - keep text-file selection behavior unchanged by continuing to select hunks when a file has hunk children;
  - build split operations that may contain both a text patch and whole-file file operations; and
  - have `majutsu-split-execute` forward those file operations to the custom applypatch tool even when there is no text patch.

The applypatch helper now handles whole-file operations by preserving only the selected paths from the original right-hand tree before resetting `$right` to `$left`.  After applying any selected text patch, it replays the selected file operations into `$right`.  This supports binary add/modify/delete style changes without generating Git binary patches, avoids snapshotting the entire right-hand tree, and fails the tool if preservation or replay encounters a real filesystem error.

Because the selection command is shared with restore and squash, guard the new hunkless whole-file selection path so non-split transients reject it with a user-visible error instead of recording a selection their executors would ignore. Restore and squash remain on their existing patch-only behavior.

Add focused tests for:

  - selecting a hunkless binary diff file and producing a file-op-only operation;
  - rejecting hunkless whole-file selection from a non-split transient;
  - executing the generated helper script and verifying only selected file operations are replayed after reset; and
  - forwarding file-op-only operations through `majutsu-split-execute` while stripping `--interactive`/`--tool` arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting and applying whole-file changes, including binary file updates and file-level actions.
  * Improved selection handling so file changes can be toggled alongside existing hunk/region selections.

* **Bug Fixes**
  * Better handling of rename, copy, delete, and reverse-apply cases when generating patch operations.
  * Fixed execution flow so file-level selections are preserved correctly during patch application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->