### PR TITLE
Fix process waits under inhibited quit

### DIFF
--- a/majutsu-process.el
+++ b/majutsu-process.el
@@ -713,16 +713,24 @@ STDERR-PROCESS is non-nil, also drain it; per the Emacs manual, output from
 a separate standard error process is not delivered by waiting on the main
 process alone.
 
+Process sentinels run with quitting inhibited, but this helper can be
+re-entered from a sentinel-triggered refresh.  Locally re-enable quitting
+around the blocking wait so Emacs does not warn about an uninterruptible
+`accept-process-output' call.
+
 If the user interrupts the wait with `C-g', return 255 so callers can
 finalize the process section as a failed command.  In that case the
 surrounding `unwind-protect' is responsible for cleaning up PROCESS and
 STDERR-PROCESS; any partially captured stderr is discarded."
   (condition-case nil
-      (progn
-        (while (accept-process-output process))
-        (when stderr-process
-          (while (accept-process-output stderr-process)))
-        (process-exit-status process))
+      (if (with-local-quit
+            (while (accept-process-output process))
+            (when stderr-process
+              (while (accept-process-output stderr-process)))
+            t)
+          (process-exit-status process)
+        (setq quit-flag nil)
+        255)
     (quit 255)))
 
 (defun majutsu--call-process-responsive (program process-buf section root &rest args)

--- a/majutsu-restore.el
+++ b/majutsu-restore.el
@@ -78,10 +78,12 @@ In diff buffer on a file section, restore only that file."
                  args)))
     (if patch
         (progn
-          (majutsu-interactive-run-with-patch "restore" args patch)
+          (with-current-buffer selection-buf
+            (majutsu-interactive-run-with-patch "restore" args patch))
           (with-current-buffer selection-buf
             (majutsu-interactive-clear)))
-      (let ((exit (apply #'majutsu-run-jj "restore" args)))
+      (let ((exit (with-current-buffer selection-buf
+                    (apply #'majutsu-run-jj "restore" args))))
         (when (zerop exit)
           (message "Restored successfully"))))))
 

--- a/majutsu-split.el
+++ b/majutsu-split.el
@@ -50,10 +50,12 @@
         (progn
           ;; reverse=t means reset $right to $left, then apply patch forward
           ;; Result: $right = selected content = first commit
-          (majutsu-interactive-run-with-patch "split" args patch t)
+          (with-current-buffer selection-buf
+            (majutsu-interactive-run-with-patch "split" args patch t))
           (with-current-buffer selection-buf
             (majutsu-interactive-clear)))
-      (majutsu-run-jj-with-editor (cons "split" args)))))
+      (with-current-buffer selection-buf
+        (majutsu-run-jj-with-editor (cons "split" args))))))
 
 ;;;; Infix Commands
 

--- a/majutsu-squash.el
+++ b/majutsu-squash.el
@@ -64,10 +64,12 @@ a jj-commit section, add --revision from that section."
         (progn
           ;; reverse=t means reset $right to $left, then apply patch forward
           ;; Result: $right = selected content = what gets squashed
-          (majutsu-interactive-run-with-patch "squash" args patch t)
+          (with-current-buffer selection-buf
+            (majutsu-interactive-run-with-patch "squash" args patch t))
           (with-current-buffer selection-buf
             (majutsu-interactive-clear)))
-      (majutsu-run-jj-with-editor (cons "squash" args)))))
+      (with-current-buffer selection-buf
+        (majutsu-run-jj-with-editor (cons "squash" args))))))
 
 ;;;; Infix Commands
 

--- a/test/majutsu-interactive-test.el
+++ b/test/majutsu-interactive-test.el
@@ -11,7 +11,11 @@
 ;;; Code:
 
 (require 'ert)
+(require 'cl-lib)
 (require 'majutsu-interactive)
+(require 'majutsu-restore)
+(require 'majutsu-split)
+(require 'majutsu-squash)
 
 (ert-deftest majutsu-interactive--build-tool-config/strips-tramp-prefix ()
   "Tool config should pass local remote paths to jj merge-tool args."
@@ -72,6 +76,95 @@
         (let ((remote (majutsu-interactive--temp-dir)))
           (should (not (equal local remote)))
           (should (equal (length seen) 2)))))))
+
+(defun majutsu-interactive-test--with-selection-cwd (fn)
+  "Call FN with a selection buffer and another current buffer.
+FN is called as (FN SELECTION-DIR CALLER-DIR)."
+  (let* ((selection-dir (file-name-as-directory
+                         (make-temp-file "majutsu-selection-" t)))
+         (caller-dir (file-name-as-directory
+                      (make-temp-file "majutsu-caller-" t)))
+         (selection-buf (generate-new-buffer " *majutsu-selection-test*"))
+         (caller-buf (generate-new-buffer " *majutsu-caller-test*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer selection-buf
+            (setq default-directory selection-dir))
+          (with-current-buffer caller-buf
+            (setq default-directory caller-dir))
+          (cl-letf (((symbol-function 'majutsu-interactive--selection-buffer)
+                     (lambda () selection-buf)))
+            (with-current-buffer caller-buf
+              (funcall fn selection-dir caller-dir))))
+      (when (buffer-live-p selection-buf)
+        (kill-buffer selection-buf))
+      (when (buffer-live-p caller-buf)
+        (kill-buffer caller-buf))
+      (delete-directory selection-dir t)
+      (delete-directory caller-dir t))))
+
+(ert-deftest majutsu-restore-execute/patch-runs-in-selection-buffer-directory ()
+  "Partial restore should run jj where the selected patch was built."
+  (majutsu-interactive-test--with-selection-cwd
+   (lambda (selection-dir caller-dir)
+     (let (seen-run-dir seen-args seen-clear-dir)
+       (cl-letf (((symbol-function 'majutsu-interactive-build-patch-if-selected)
+                  (lambda (&rest _args) "patch"))
+                 ((symbol-function 'majutsu-interactive-run-with-patch)
+                  (lambda (&rest args)
+                    (setq seen-run-dir default-directory
+                          seen-args args)))
+                 ((symbol-function 'majutsu-interactive-clear)
+                  (lambda ()
+                    (setq seen-clear-dir default-directory))))
+         (majutsu-restore-execute '("--changes-in=@" "--interactive")))
+       (should (equal seen-run-dir selection-dir))
+       (should (not (equal seen-run-dir caller-dir)))
+       (should (equal seen-clear-dir selection-dir))
+       (should (equal seen-args
+                      '("restore" ("--changes-in=@") "patch")))))))
+
+(ert-deftest majutsu-split-execute/patch-runs-in-selection-buffer-directory ()
+  "Partial split should run jj where the selected patch was built."
+  (majutsu-interactive-test--with-selection-cwd
+   (lambda (selection-dir caller-dir)
+     (let (seen-run-dir seen-args seen-clear-dir)
+       (cl-letf (((symbol-function 'majutsu-interactive-build-patch-if-selected)
+                  (lambda (&rest _args) "patch"))
+                 ((symbol-function 'majutsu-interactive-run-with-patch)
+                  (lambda (&rest args)
+                    (setq seen-run-dir default-directory
+                          seen-args args)))
+                 ((symbol-function 'majutsu-interactive-clear)
+                  (lambda ()
+                    (setq seen-clear-dir default-directory))))
+         (majutsu-split-execute '("--revision=@" "--interactive")))
+       (should (equal seen-run-dir selection-dir))
+       (should (not (equal seen-run-dir caller-dir)))
+       (should (equal seen-clear-dir selection-dir))
+       (should (equal seen-args
+                      '("split" ("--revision=@") "patch" t)))))))
+
+(ert-deftest majutsu-squash-execute/patch-runs-in-selection-buffer-directory ()
+  "Partial squash should run jj where the selected patch was built."
+  (majutsu-interactive-test--with-selection-cwd
+   (lambda (selection-dir caller-dir)
+     (let (seen-run-dir seen-args seen-clear-dir)
+       (cl-letf (((symbol-function 'majutsu-interactive-build-patch-if-selected)
+                  (lambda (&rest _args) "patch"))
+                 ((symbol-function 'majutsu-interactive-run-with-patch)
+                  (lambda (&rest args)
+                    (setq seen-run-dir default-directory
+                          seen-args args)))
+                 ((symbol-function 'majutsu-interactive-clear)
+                  (lambda ()
+                    (setq seen-clear-dir default-directory))))
+         (majutsu-squash-execute '("--revision=@")))
+       (should (equal seen-run-dir selection-dir))
+       (should (not (equal seen-run-dir caller-dir)))
+       (should (equal seen-clear-dir selection-dir))
+       (should (equal seen-args
+                      '("squash" ("--revision=@") "patch" t)))))))
 
 (provide 'majutsu-interactive-test)
 ;;; majutsu-interactive-test.el ends here

--- a/test/majutsu-process-test.el
+++ b/test/majutsu-process-test.el
@@ -298,6 +298,19 @@ The process section should use root as command directory."
       (should (= 0 (majutsu--process-wait 'main 'stderr))))
     (should (equal (nreverse seen) '(main stderr)))))
 
+(ert-deftest majutsu-process-test-process-wait-enables-local-quit ()
+  "`majutsu--process-wait' should not block with quitting inhibited."
+  (let ((seen-inhibit-quit t))
+    (cl-letf (((symbol-function 'accept-process-output)
+               (lambda (&rest _args)
+                 (setq seen-inhibit-quit inhibit-quit)
+                 nil))
+              ((symbol-function 'process-exit-status)
+               (lambda (_process) 0)))
+      (let ((inhibit-quit t))
+        (should (= 0 (majutsu--process-wait 'fake-process)))))
+    (should-not seen-inhibit-quit)))
+
 (ert-deftest majutsu-process-test-process-wait-returns-255-on-quit ()
   "`majutsu--process-wait' should return 255 when interrupted."
   (cl-letf (((symbol-function 'accept-process-output)


### PR DESCRIPTION
Majutsu may refresh synchronously from process sentinels, and Emacs runs
sentinels with quitting inhibited.  Re-entering responsive jj calls from
that path made `majutsu--process-wait' call `accept-process-output' as an
uninterruptible blocking wait, triggering Emacs 30's warning.

Wrap the wait loop in `with-local-quit' so the blocking process wait remains
interruptible even when it is reached from a sentinel, and add regression
coverage for the local `inhibit-quit' binding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process waiting so quitting stays responsive during blocking output waits (including proper abort behavior).
  * Fixed restore, split, and squash to run and clean up patches consistently in the selection buffer context.
* **Tests**
  * Added coverage for local quit enablement during process waits.
  * Expanded interactive test coverage to ensure restore/split/squash execute `jj` from the selection directory and clear in the expected location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->