### PR TITLE
fix: harden Forge refresh and process failure handling

### DIFF
--- a/majutsu-forge.el
+++ b/majutsu-forge.el
@@ -55,7 +55,29 @@
 (defvar magit-status-margin)
 
 (defvar majutsu-forge--sections-installed nil
-  "Non-nil when `majutsu-forge-mode' installed section hooks.")
+  "Non-nil when `majutsu-forge-mode' completed section hook setup.")
+
+(defvar majutsu-forge--installed-section-hooks nil
+  "Section hook functions installed by `majutsu-forge-mode'.
+
+This only records entries that were absent before the mode was enabled, so
+cleanup does not remove an identical hook function installed by the user.")
+
+(defvar majutsu-forge--installed-hooks nil
+  "Ordinary hook entries installed by `majutsu-forge-mode'.
+
+Each entry is a cons cell of the form (HOOK . FUNCTION).")
+
+(defvar majutsu-forge--installed-advices nil
+  "Advice entries installed by `majutsu-forge-mode'.
+
+Each entry is a cons cell of the form (SYMBOL . FUNCTION).")
+
+(defvar majutsu-forge--refreshing nil
+  "Non-nil while Forge advice is refreshing Majutsu buffers.")
+
+(defvar majutsu-forge--pending-refresh-roots nil
+  "Repository roots queued by reentrant Forge refreshes.")
 
 (defvar majutsu-forge--bindings-installed nil
   "Non-nil when `majutsu-forge-mode' installed key bindings.")
@@ -241,25 +263,56 @@ default.  The pull-request section itself remains visitable."
   (majutsu-forge--with-section-errors "discussions"
     (forge-insert-discussions)))
 
+(defun majutsu-forge--default-hook-member-p (hook function)
+  "Return non-nil when FUNCTION is in HOOK's default value."
+  (let ((value (default-value hook)))
+    (or (eq value function)
+        (and (listp value) (memq function value)))))
+
+(defun majutsu-forge--add-owned-hook (hook function)
+  "Add FUNCTION to HOOK and remember when Majutsu owns the entry."
+  (unless (majutsu-forge--default-hook-member-p hook function)
+    (unwind-protect
+        (add-hook hook function)
+      ;; Record an entry even if a wrapper around `add-hook' signals after
+      ;; modifying the hook.  The mode's error path can then roll it back.
+      (when (majutsu-forge--default-hook-member-p hook function)
+        (cl-pushnew (cons hook function)
+                    majutsu-forge--installed-hooks
+                    :test #'equal)))))
+
+(defun majutsu-forge--remove-owned-hooks ()
+  "Remove ordinary hook entries installed by `majutsu-forge-mode'."
+  (dolist (entry majutsu-forge--installed-hooks)
+    (remove-hook (car entry) (cdr entry)))
+  (setq majutsu-forge--installed-hooks nil))
+
+(defun majutsu-forge--add-owned-section-hook (function)
+  "Add section hook FUNCTION and remember when Majutsu owns the entry."
+  (unless (majutsu-forge--default-hook-member-p
+           'majutsu-log-sections-hook function)
+    (unwind-protect
+        (magit-add-section-hook 'majutsu-log-sections-hook function nil t)
+      ;; As above, make a partially successful installation reversible.
+      (when (majutsu-forge--default-hook-member-p
+             'majutsu-log-sections-hook function)
+        (cl-pushnew function majutsu-forge--installed-section-hooks)))))
+
 (defun majutsu-forge--add-section-hooks ()
   "Add Forge section hooks to `majutsu-log-sections-hook'."
-  (magit-add-section-hook 'majutsu-log-sections-hook
-                          #'majutsu-forge--clear-section-errors nil t)
-  (magit-add-section-hook 'majutsu-log-sections-hook
-                          #'majutsu-forge-insert-pullreqs nil t)
-  (magit-add-section-hook 'majutsu-log-sections-hook
-                          #'majutsu-forge-insert-issues nil t)
-  (magit-add-section-hook 'majutsu-log-sections-hook
-                          #'majutsu-forge-insert-discussions nil t)
+  (dolist (function '(majutsu-forge--clear-section-errors
+                      majutsu-forge-insert-pullreqs
+                      majutsu-forge-insert-issues
+                      majutsu-forge-insert-discussions))
+    (majutsu-forge--add-owned-section-hook function))
   (setq majutsu-forge--sections-installed t))
 
 (defun majutsu-forge--remove-section-hooks ()
-  "Remove Forge section hooks from `majutsu-log-sections-hook'."
-  (remove-hook 'majutsu-log-sections-hook #'majutsu-forge--clear-section-errors)
-  (remove-hook 'majutsu-log-sections-hook #'majutsu-forge-insert-pullreqs)
-  (remove-hook 'majutsu-log-sections-hook #'majutsu-forge-insert-issues)
-  (remove-hook 'majutsu-log-sections-hook #'majutsu-forge-insert-discussions)
-  (setq majutsu-forge--sections-installed nil))
+  "Remove section hooks installed by `majutsu-forge-mode'."
+  (dolist (function majutsu-forge--installed-section-hooks)
+    (remove-hook 'majutsu-log-sections-hook function))
+  (setq majutsu-forge--installed-section-hooks nil
+        majutsu-forge--sections-installed nil))
 
 ;;; Bindings
 
@@ -365,53 +418,93 @@ default.  The pull-request section itself remains visitable."
          (file-equal-p (file-truename root) (file-truename other)))))
 
 (defun majutsu-forge--refresh-majutsu-buffers (&optional root)
-  "Refresh live Majutsu buffers under ROOT.
+  "Refresh live Majutsu buffers under ROOT or any root in a list.
 
-If ROOT is nil, refresh all live Majutsu buffers."
-  (dolist (buffer (buffer-list))
-    (when (buffer-live-p buffer)
-      (with-current-buffer buffer
-        (when (and (derived-mode-p 'majutsu-mode)
-                   (or (not root)
-                       (majutsu-forge--same-root-p
-                        root majutsu--default-directory)))
-          (ignore-errors (majutsu-refresh-buffer)))))))
+If ROOT is nil or a list containing nil, refresh all live Majutsu buffers."
+  (let ((roots (cond ((null root) nil)
+                     ((listp root) root)
+                     (t (list root)))))
+    (dolist (buffer (buffer-list))
+      (when (buffer-live-p buffer)
+        (with-current-buffer buffer
+          (when (and (derived-mode-p 'majutsu-mode)
+                     (or (not roots)
+                         (memq nil roots)
+                         (cl-some (lambda (candidate)
+                                    (majutsu-forge--same-root-p
+                                     candidate majutsu--default-directory))
+                                  roots)))
+            (ignore-errors (majutsu-refresh-buffer))))))))
+
+(defun majutsu-forge--request-majutsu-refresh (root)
+  "Refresh Majutsu buffers for ROOT without recursive refresh fanout.
+
+Requests made while a refresh is running are coalesced by repository root.
+After the initial pass, all pending roots share one supplemental pass; requests
+made during that supplemental pass are deliberately dropped."
+  (if majutsu-forge--refreshing
+      (cl-pushnew root majutsu-forge--pending-refresh-roots :test #'equal)
+    (let ((majutsu-forge--refreshing t)
+          (majutsu-forge--pending-refresh-roots nil))
+      (unwind-protect
+          (progn
+            (majutsu-forge--refresh-majutsu-buffers root)
+            (let ((pending (nreverse majutsu-forge--pending-refresh-roots)))
+              ;; Clear the queue before the supplemental pass.  Nested
+              ;; requests can set it again, but the unwind cleanup below
+              ;; drops them instead of allowing an unbounded retry loop.
+              (setq majutsu-forge--pending-refresh-roots nil)
+              (when pending
+                (majutsu-forge--refresh-majutsu-buffers pending))))
+        (setq majutsu-forge--pending-refresh-roots nil)))))
 
 (defun majutsu-forge--after-forge-refresh (&optional buffer)
   "Refresh Majutsu buffers after `forge-refresh-buffer' refreshes BUFFER."
-  (when-let* ((root (majutsu-forge--buffer-root buffer)))
-    (majutsu-forge--refresh-majutsu-buffers root)))
+  ;; Forge handles a non-nil BUFFER by recursively calling itself without an
+  ;; argument inside that buffer.  The inner call performs the refresh and
+  ;; invokes this advice, so handling the outer call too would refresh every
+  ;; matching Majutsu buffer twice.
+  (unless buffer
+    (when-let* ((root (majutsu-forge--buffer-root)))
+      (majutsu-forge--request-majutsu-refresh root))))
 
 ;;; Advice
 
+(defun majutsu-forge--add-owned-advice (symbol where function)
+  "Advise SYMBOL at WHERE with FUNCTION and record Majutsu ownership."
+  (unless (advice-member-p function symbol)
+    (unwind-protect
+        (advice-add symbol where function)
+      ;; Preserve enough state to undo an advice installer that signals after
+      ;; changing the function definition.
+      (when (advice-member-p function symbol)
+        (cl-pushnew (cons symbol function)
+                    majutsu-forge--installed-advices
+                    :test #'equal)))))
+
 (defun majutsu-forge--add-advices ()
   "Install Forge advice used by `majutsu-forge-mode'."
-  (when (and (fboundp 'forge-refresh-buffer)
-             (not (advice-member-p #'majutsu-forge--after-forge-refresh
-                                   'forge-refresh-buffer)))
-    (advice-add 'forge-refresh-buffer :after
-                #'majutsu-forge--after-forge-refresh))
-  (when (and (fboundp 'forge--insert-pullreq-commits)
-             (not (advice-member-p #'majutsu-forge--insert-pullreq-commits-around
-                                   'forge--insert-pullreq-commits)))
-    (advice-add 'forge--insert-pullreq-commits :around
-                #'majutsu-forge--insert-pullreq-commits-around)))
+  (when (fboundp 'forge-refresh-buffer)
+    (majutsu-forge--add-owned-advice
+     'forge-refresh-buffer :after #'majutsu-forge--after-forge-refresh))
+  (when (fboundp 'forge--insert-pullreq-commits)
+    (majutsu-forge--add-owned-advice
+     'forge--insert-pullreq-commits :around
+     #'majutsu-forge--insert-pullreq-commits-around)))
 
 (defun majutsu-forge--remove-advices ()
   "Remove Forge advice installed by `majutsu-forge-mode'."
-  (when (fboundp 'forge-refresh-buffer)
-    (advice-remove 'forge-refresh-buffer #'majutsu-forge--after-forge-refresh))
-  (when (fboundp 'forge--insert-pullreq-commits)
-    (advice-remove 'forge--insert-pullreq-commits
-                   #'majutsu-forge--insert-pullreq-commits-around)))
+  (dolist (entry majutsu-forge--installed-advices)
+    (when (fboundp (car entry))
+      (advice-remove (car entry) (cdr entry))))
+  (setq majutsu-forge--installed-advices nil))
 
 (defun majutsu-forge--cleanup-installation ()
   "Remove global state installed by `majutsu-forge-mode'."
-  (when majutsu-forge--sections-installed
+  (when (or majutsu-forge--sections-installed
+            majutsu-forge--installed-section-hooks)
     (majutsu-forge--remove-section-hooks))
-  (remove-hook 'majutsu-log-mode-hook #'majutsu-forge--connect-database-once)
-  (remove-hook 'majutsu-log-mode-hook #'majutsu-forge--init-buffer)
-  (remove-hook 'majutsu-refresh-buffer-hook #'majutsu-forge--expand-sections)
+  (majutsu-forge--remove-owned-hooks)
   (when majutsu-forge--bindings-installed
     (majutsu-forge--remove-mode-bindings))
   (majutsu-forge--restore-bindings)
@@ -434,19 +527,22 @@ log buffers.  It is intended to work best in colocated jj/Git repositories."
             (majutsu-forge--require)
             (when majutsu-forge-add-default-sections
               (majutsu-forge--add-section-hooks)
-              (add-hook 'majutsu-log-mode-hook #'majutsu-forge--connect-database-once)
-              (add-hook 'majutsu-log-mode-hook #'majutsu-forge--init-buffer)
-              (add-hook 'majutsu-refresh-buffer-hook #'majutsu-forge--expand-sections))
+              (majutsu-forge--add-owned-hook
+               'majutsu-log-mode-hook #'majutsu-forge--connect-database-once)
+              (majutsu-forge--add-owned-hook
+               'majutsu-log-mode-hook #'majutsu-forge--init-buffer)
+              (majutsu-forge--add-owned-hook
+               'majutsu-refresh-buffer-hook #'majutsu-forge--expand-sections))
             (when majutsu-forge-add-default-bindings
               (majutsu-forge--add-mode-bindings))
             (majutsu-forge--add-advices)
-            (majutsu-forge--refresh-majutsu-buffers))
+            (majutsu-forge--request-majutsu-refresh nil))
         (error
          (majutsu-forge--cleanup-installation)
          (setq majutsu-forge-mode nil)
          (signal (car err) (cdr err))))
     (majutsu-forge--cleanup-installation)
-    (majutsu-forge--refresh-majutsu-buffers)))
+    (majutsu-forge--request-majutsu-refresh nil)))
 
 (provide 'majutsu-forge)
 ;;; majutsu-forge.el ends here

--- a/majutsu-jj.el
+++ b/majutsu-jj.el
@@ -897,19 +897,38 @@ newline, return an empty string.  This function aligns with
   "Return S as a jj fileset string literal."
   (format "file:\"%s\"" (majutsu-jj--escape-fileset-string s)))
 
+(defun majutsu-jj--insert-failure-output (args exit error-text)
+  "Insert a failure summary for ARGS, EXIT, and cleaned ERROR-TEXT."
+  (insert (propertize (format "jj %s failed (exit %s)\n"
+                              (string-join args " ") exit)
+                      'font-lock-face 'error))
+  (when error-text
+    (insert error-text))
+  (unless (bolp)
+    (insert "\n")))
+
 (defun majutsu-jj-wash (washer keep-error &rest args)
   "Run jj with ARGS, insert output at point, then call WASHER.
 KEEP-ERROR matches `magit--git-wash': nil drops stderr on error,
-`wash-anyway' keeps output even on non-zero exit, anything else keeps the
-error text.  Output is optionally colorized based on
-`majutsu-process-apply-ansi-colors'."
+`wash-anyway' washes stdout even on non-zero exit and then appends stderr,
+and anything else keeps the error text without washing stdout.  Output is
+optionally colorized based on `majutsu-process-apply-ansi-colors'."
   (declare (indent 2))
   (setq args (majutsu-process-jj-arguments args))
   (let* ((beg (point))
          (err-file (make-nearby-temp-file "majutsu-jj-err")))
     (unwind-protect
-        (let ((exit (apply #'majutsu-process-file (majutsu-jj--executable) nil
-                           (list t err-file) nil args)))
+        (let* ((exit (apply #'majutsu-process-file (majutsu-jj--executable) nil
+                            (list t err-file) nil args))
+               (error-text
+                (when (and keep-error (not (= exit 0)))
+                  (let ((text
+                         (ansi-color-filter-apply
+                          (with-temp-buffer
+                            (insert-file-contents err-file)
+                            (buffer-string)))))
+                    (unless (string-empty-p text)
+                      text)))))
           (when (and (bound-and-true-p majutsu-process-apply-ansi-colors)
                      (> (point) beg))
             ;; Use text-properties instead of overlays so that subsequent
@@ -922,43 +941,41 @@ error text.  Output is optionally colorized based on
            ((= (point) beg)
             (if (= exit 0)
                 (magit-cancel-section)
-              (insert (propertize (format "jj %s failed (exit %s)\n"
-                                          (string-join args " ") exit)
-                                  'font-lock-face 'error))
-              (when keep-error
-                (insert (ansi-color-filter-apply
-                         (with-temp-buffer
-                           (insert-file-contents err-file)
-                           (buffer-string)))))
-              (unless (bolp)
-                (insert "\n"))))
+              (majutsu-jj--insert-failure-output args exit error-text)))
            ;; Failure path (unless we explicitly wash anyway).
            ((and (not (eq keep-error 'wash-anyway))
                  (not (= exit 0)))
             (goto-char beg)
-            (insert (propertize (format "jj %s failed (exit %s)\n"
-                                        (string-join args " ") exit)
-                                'font-lock-face 'error))
-            (when keep-error
-              (insert (ansi-color-filter-apply
-                       (with-temp-buffer
-                         (insert-file-contents err-file)
-                         (buffer-string)))))
-            (unless (bolp)
-              (insert "\n")))
+            (majutsu-jj--insert-failure-output args exit error-text))
            ;; Success (or wash anyway).
            (t
             (unless (bolp)
               (insert "\n"))
             (when (or (= exit 0)
                       (eq keep-error 'wash-anyway))
-              (save-restriction
-                (narrow-to-region beg (point))
-                (goto-char beg)
-                (funcall washer args))
-              (when (or (= (point) beg)
-                        (= (point) (1+ beg)))
-                (magit-cancel-section)))))
+              (let ((stdout-end (copy-marker (point) t)))
+                (unwind-protect
+                    (progn
+                      ;; Structured washers such as
+                      ;; `majutsu-diff-wash-diffs' must only ever see stdout.
+                      (save-restriction
+                        (narrow-to-region beg stdout-end)
+                        (goto-char beg)
+                        (funcall washer args))
+                      (let ((washer-point (point)))
+                        (goto-char stdout-end)
+                        (if (and (not (= exit 0))
+                                 (eq keep-error 'wash-anyway))
+                            ;; Diagnostics are deliberately outside the
+                            ;; washer's narrowed region.  A stderr line that
+                            ;; resembles structured output cannot confuse the
+                            ;; parser or prevent it from advancing.
+                            (majutsu-jj--insert-failure-output
+                             args exit error-text)
+                          (when (or (= washer-point beg)
+                                    (= washer-point (1+ beg)))
+                            (magit-cancel-section)))))
+                  (set-marker stdout-end nil))))))
           exit)
       (ignore-errors (delete-file err-file)))))
 

--- a/majutsu-process.el
+++ b/majutsu-process.el
@@ -603,6 +603,38 @@ is discarded (nil), mixed with stdout (t), or written to a file (string)."
           (insert string)
           (set-marker marker (point)))))))
 
+(defun majutsu--process-file-created-main-process
+    (before stderr-buffer stderr-process stdout-buffer stdout-filter command name)
+  "Return a reliably identified main process created after BEFORE.
+
+STDERR-PROCESS must be the new process attached to Majutsu's private
+STDERR-BUFFER.  The returned process must also be new, have the corresponding
+Emacs-generated NAME, and retain the exact STDOUT-BUFFER, STDOUT-FILTER, and
+COMMAND passed to `make-process'.  Main and stderr process suffixes are checked
+independently because Emacs uniquifies those names independently.  Return nil
+instead of guessing when these constraints do not identify exactly one process."
+  (let ((main-name-re (format "\\`%s\\(?:<[0-9]+>\\)?\\'"
+                              (regexp-quote name)))
+        (stderr-name-re (format "\\`%s stderr\\(?:<[0-9]+>\\)?\\'"
+                                (regexp-quote name))))
+    (when (and (processp stderr-process)
+               (not (memq stderr-process before))
+               (eq (process-buffer stderr-process) stderr-buffer)
+               (string-match-p stderr-name-re (process-name stderr-process)))
+      (let ((candidates
+             (seq-filter
+              (lambda (candidate)
+                (and (not (memq candidate before))
+                     (not (eq candidate stderr-process))
+                     (string-match-p main-name-re (process-name candidate))
+                     (eq (process-buffer candidate) stdout-buffer)
+                     (equal (process-command candidate) command)
+                     (or (null stdout-filter)
+                         (eq (process-filter candidate) stdout-filter))))
+              (process-list))))
+        (and (null (cdr candidates))
+             (car candidates))))))
+
 (defun majutsu--process-file-responsive (program _infile destination &rest args)
   "Run PROGRAM with ARGS synchronously while servicing Emacs subprocesses.
 
@@ -610,7 +642,9 @@ DESTINATION follows the `process-file' stdout/stderr contract supported by
 `majutsu--process-file-supported-p'.  When stderr is requested as a file,
 the standard error process spawned by `make-process' has its sentinel
 silenced so the captured stderr is verbatim, and is drained explicitly
-before the file is written so its output cannot lag behind."
+before the file is written so its output cannot lag behind.  If a non-atomic
+wrapper signals after creating a process, reclaim that process only when its
+private stderr process and requested attributes identify it uniquely."
   (let* ((stdout-dest (if (consp destination) (car destination) destination))
          (stderr-dest (and (consp destination) (cadr destination)))
          (stderr-discard (and (consp destination) (null stderr-dest)))
@@ -619,29 +653,54 @@ before the file is written so its output cannot lag behind."
                              (copy-marker (with-current-buffer stdout-buffer
                                             (point))
                                           t)))
+         (stdout-filter (and stdout-marker
+                             (majutsu--process-file-insert-filter stdout-marker)))
          (stderr-buffer (and (or (stringp stderr-dest) stderr-discard)
                              (generate-new-buffer " *majutsu-stderr*")))
-         (process (make-process
-                   :name (file-name-nondirectory program)
-                   :buffer stdout-buffer
-                   :command (cons program args)
-                   :connection-type 'pipe
-                   :coding default-process-coding-system
-                   :noquery t
-                   :filter (and stdout-marker
-                                (majutsu--process-file-insert-filter stdout-marker))
-                   :sentinel #'ignore
-                   :stderr stderr-buffer
-                   :file-handler t))
-         (stderr-process (and stderr-buffer (get-buffer-process stderr-buffer)))
+         (process-name (file-name-nondirectory program))
+         (command (cons program args))
+         (processes-before (process-list))
+         process
+         stderr-process
          exit)
-    ;; Emacs' default sentinel on the standard error process appends a
-    ;; "Process ... finished" line to the stderr buffer; silence it so the
-    ;; captured stderr is verbatim.
-    (when stderr-process
-      (set-process-sentinel stderr-process #'ignore))
     (unwind-protect
         (progn
+          ;; Create the process inside the protected region.  In particular,
+          ;; a file-handler or invalid executable can make `make-process'
+          ;; signal after the temporary stderr buffer has been allocated.
+          (condition-case err
+              (setq process
+                    (make-process
+                     :name process-name
+                     :buffer stdout-buffer
+                     :command command
+                     :connection-type 'pipe
+                     :coding default-process-coding-system
+                     :noquery t
+                     :filter stdout-filter
+                     :sentinel #'ignore
+                     :stderr stderr-buffer
+                     :file-handler t))
+            (error
+             ;; A file handler or wrapper can create the real process and
+             ;; signal before returning it.  Recover that process only when
+             ;; its private stderr process and all requested attributes make
+             ;; the association unambiguous; otherwise leave PROCESS nil so
+             ;; cleanup cannot kill an unrelated process.
+             (setq stderr-process
+                   (and stderr-buffer (get-buffer-process stderr-buffer)))
+             (setq process
+                   (majutsu--process-file-created-main-process
+                    processes-before stderr-buffer stderr-process
+                    stdout-buffer stdout-filter command process-name))
+             (signal (car err) (cdr err))))
+          (setq stderr-process
+                (and stderr-buffer (get-buffer-process stderr-buffer)))
+          ;; Emacs' default sentinel on the standard error process appends a
+          ;; "Process ... finished" line to the stderr buffer; silence it so
+          ;; captured stderr is verbatim.
+          (when stderr-process
+            (set-process-sentinel stderr-process #'ignore))
           ;; The main process may have already exited (e.g. it does not
           ;; read stdin); guard `process-send-eof' so we never signal
           ;; "Process ... not running" from the dispatch path.
@@ -654,9 +713,9 @@ before the file is written so its output cannot lag behind."
             (with-current-buffer stderr-buffer
               (write-region (point-min) (point-max) stderr-dest nil 'silent)))
           exit)
-      (when (process-live-p process)
+      (when (and process (process-live-p process))
         (delete-process process))
-      (when (process-live-p stderr-process)
+      (when (and stderr-process (process-live-p stderr-process))
         (delete-process stderr-process))
       (when stdout-marker
         (set-marker stdout-marker nil))

--- a/test/majutsu-diff-test.el
+++ b/test/majutsu-diff-test.el
@@ -101,6 +101,70 @@
         (should-not (text-properties-at 0 (oref diffstat-file value)))
         (should-not (text-properties-at 0 (oref diff-file value)))))))
 
+(ert-deftest majutsu-jj-wash/failed-diff-keeps-stderr-outside-parser ()
+  "Failed `--git --stat' output should keep its tree and append stderr safely."
+  (with-temp-buffer
+    (magit-section-mode)
+    (let* ((inhibit-read-only t)
+           (magit-section-inhibit-markers t)
+           (real-wash-file (symbol-function 'majutsu-diff-wash-file))
+           (wash-file-calls 0)
+           (stdout
+            (concat
+             (string-join
+              '("foo | 1 +"
+                "1 file changed, 1 insertion(+), 0 deletions(-)"
+                "diff --git a/foo b/foo"
+                "index 1234567..89abcde 100644"
+                "--- a/foo"
+                "+++ b/foo"
+                "@@ -1 +1 @@"
+                "-foo"
+                "+bar")
+              "\n")
+             "\n")))
+      (cl-letf (((symbol-function 'majutsu-process-file)
+                 (lambda (_program _infile destination _display &rest _args)
+                   (insert stdout)
+                   (write-region "\e[31mdiff --git malformed diagnostic\e[0m\n"
+                                 nil (cadr destination) nil 'silent)
+                   1))
+                ((symbol-function 'majutsu-diff-wash-file)
+                 (lambda ()
+                   ;; Fail instead of hanging if a malformed pseudo-header is
+                   ;; ever allowed into the real washer's progress loop.
+                   (when (> (cl-incf wash-file-calls) 2)
+                     (ert-fail "Diff washer stopped advancing"))
+                   (funcall real-wash-file))))
+        (magit-insert-section (diffbuf)
+          (magit-insert-section (diff-root)
+            (should (= 1 (majutsu-jj-wash
+                           #'majutsu-diff-wash-diffs 'wash-anyway
+                           "diff" "--git" "--stat"))))))
+      (let* ((diff-root (car (oref magit-root-section children)))
+             (children (oref diff-root children))
+             (diffstat (seq-find (lambda (section)
+                                   (eq (oref section type) 'diffstat))
+                                 children))
+             (stat-file (and diffstat
+                             (seq-find (lambda (section)
+                                         (eq (oref section type) 'jj-file))
+                                       (oref diffstat children))))
+             (diff-file (seq-find (lambda (section)
+                                    (and (eq (oref section type) 'jj-file)
+                                         (equal (oref section value) "foo")))
+                                  children)))
+        (should (= wash-file-calls 1))
+        (should (eieio-object-p diffstat))
+        (should (eieio-object-p stat-file))
+        (should (eieio-object-p diff-file))
+        (should (string-match-p "jj .*diff .*failed (exit 1)"
+                                (buffer-string)))
+        (should (string-match-p "diff --git malformed diagnostic"
+                                (buffer-string)))
+        (should-not (string-match-p (regexp-quote "\e[")
+                                    (buffer-string)))))))
+
 (ert-deftest majutsu-insert-diff/puts-filesets-after-separator ()
   "Diff command construction should pass filesets after --."
   (let (called heading)

--- a/test/majutsu-forge-test.el
+++ b/test/majutsu-forge-test.el
@@ -13,7 +13,9 @@
 (require 'majutsu-forge)
 
 (ert-deftest majutsu-forge-section-hooks/adds-and-removes-default-hooks ()
-  (let ((original (default-value 'majutsu-log-sections-hook)))
+  (let ((original (default-value 'majutsu-log-sections-hook))
+        (majutsu-forge--sections-installed nil)
+        (majutsu-forge--installed-section-hooks nil))
     (unwind-protect
         (progn
           (set-default 'majutsu-log-sections-hook '(majutsu-log-insert-logs))
@@ -34,6 +36,33 @@
           (majutsu-forge--remove-section-hooks)
           (should (equal (default-value 'majutsu-log-sections-hook)
                          '(majutsu-log-insert-logs))))
+      (set-default 'majutsu-log-sections-hook original))))
+
+(ert-deftest majutsu-forge-section-hooks/rolls-back-partial-installation ()
+  "An error midway through section setup should leave no installed prefix."
+  (let ((original (default-value 'majutsu-log-sections-hook))
+        (real-add (symbol-function 'magit-add-section-hook))
+        (majutsu-forge--sections-installed nil)
+        (majutsu-forge--installed-section-hooks nil))
+    (unwind-protect
+        (progn
+          (set-default 'majutsu-log-sections-hook '(majutsu-log-insert-logs))
+          (cl-letf (((symbol-function 'magit-add-section-hook)
+                     (lambda (hook function &rest args)
+                       (if (eq function 'majutsu-forge-insert-issues)
+                           (error "section setup failed")
+                         (apply real-add hook function args)))))
+            (should-error (majutsu-forge--add-section-hooks)))
+          (should-not majutsu-forge--sections-installed)
+          (should (equal (default-value 'majutsu-log-sections-hook)
+                         '(majutsu-log-insert-logs
+                           majutsu-forge--clear-section-errors
+                           majutsu-forge-insert-pullreqs)))
+          (majutsu-forge--cleanup-installation)
+          (should (equal (default-value 'majutsu-log-sections-hook)
+                         '(majutsu-log-insert-logs)))
+          (should-not majutsu-forge--installed-section-hooks))
+      (majutsu-forge--cleanup-installation)
       (set-default 'majutsu-log-sections-hook original))))
 
 (ert-deftest majutsu-forge-insert-pullreq-commits/uses-placeholder ()
@@ -71,6 +100,141 @@
               (forge--insert-pullreq-commits nil))
             (should (equal (buffer-string) "git log body\n"))))
       (majutsu-forge--remove-advices))))
+
+(ert-deftest majutsu-forge-refresh-advice/explicit-buffer-refreshes-once ()
+  "Forge's recursive explicit-BUFFER dispatch should trigger one refresh."
+  (let ((majutsu-forge--installed-advices nil)
+        (majutsu-forge--refreshing nil)
+        (majutsu-forge--pending-refresh-roots nil)
+        (refreshes 0)
+        roots
+        (target (generate-new-buffer " *majutsu-forge-target*")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'forge-refresh-buffer)
+                   (lambda (&optional buffer)
+                     (when (buffer-live-p buffer)
+                       (with-current-buffer buffer
+                         (forge-refresh-buffer))))))
+          (unwind-protect
+              (progn
+                (majutsu-forge--add-advices)
+                (with-temp-buffer
+                  (cl-letf (((symbol-function 'majutsu-forge--buffer-root)
+                             (lambda (&optional buffer)
+                               (should-not buffer)
+                               (should (eq (current-buffer) target))
+                               "/repo/"))
+                            ((symbol-function
+                              'majutsu-forge--refresh-majutsu-buffers)
+                             (lambda (&optional root)
+                               (push root roots)
+                               (cl-incf refreshes))))
+                    (forge-refresh-buffer target)))
+                (should (= refreshes 1))
+                (should (equal roots '("/repo/"))))
+            (majutsu-forge--remove-advices)))
+      (when (buffer-live-p target)
+        (kill-buffer target)))))
+
+(ert-deftest majutsu-forge-refresh-advice/coalesces-reentrant-refreshes ()
+  "Nested Forge refreshes should cause at most one supplemental pass."
+  (let ((majutsu-forge--installed-advices nil)
+        (majutsu-forge--refreshing nil)
+        (majutsu-forge--pending-refresh-roots nil)
+        (refreshes 0))
+    (cl-letf (((symbol-function 'forge-refresh-buffer) #'ignore)
+              ((symbol-function 'majutsu-forge--buffer-root)
+               (lambda (&optional _buffer) "/repo/"))
+              ((symbol-function 'majutsu-forge--refresh-majutsu-buffers)
+               (lambda (&optional _root)
+                 (cl-incf refreshes)
+                 ;; Queue multiple requests in both the initial and
+                 ;; supplemental passes.  Only the initial queue is drained.
+                 (forge-refresh-buffer)
+                 (forge-refresh-buffer))))
+      (unwind-protect
+          (progn
+            (majutsu-forge--add-advices)
+            (forge-refresh-buffer)
+            (should (= refreshes 2))
+            (should-not majutsu-forge--refreshing)
+            (should-not majutsu-forge--pending-refresh-roots))
+        (majutsu-forge--remove-advices)))))
+
+(ert-deftest majutsu-forge-refresh/pending-nil-means-refresh-all ()
+  "A queued all-buffer request should get one complete supplemental pass."
+  (let ((majutsu-forge--refreshing nil)
+        (majutsu-forge--pending-refresh-roots nil)
+        (refreshes 0))
+    (with-temp-buffer
+      (let ((target (current-buffer)))
+        (cl-letf (((symbol-function 'buffer-list) (lambda () (list target)))
+                  ((symbol-function 'derived-mode-p) (lambda (&rest _) t))
+                  ((symbol-function 'majutsu-refresh-buffer)
+                   (lambda ()
+                     (cl-incf refreshes)
+                     (majutsu-forge--request-majutsu-refresh nil))))
+          (majutsu-forge--request-majutsu-refresh nil))))
+    (should (= refreshes 2))
+    (should-not majutsu-forge--refreshing)
+    (should-not majutsu-forge--pending-refresh-roots)))
+
+(ert-deftest majutsu-forge-cleanup/preserves-preexisting-hooks-and-advices ()
+  "Cleanup should only remove entries installed by the current mode run."
+  (let ((original-sections (default-value 'majutsu-log-sections-hook))
+        (original-log-mode (default-value 'majutsu-log-mode-hook))
+        (original-refresh (default-value 'majutsu-refresh-buffer-hook))
+        (majutsu-forge--sections-installed nil)
+        (majutsu-forge--installed-section-hooks nil)
+        (majutsu-forge--installed-hooks nil)
+        (majutsu-forge--installed-advices nil)
+        (majutsu-forge--bindings-installed nil)
+        (majutsu-forge--saved-bindings nil))
+    (cl-letf (((symbol-function 'forge-refresh-buffer) #'ignore)
+              ((symbol-function 'forge--insert-pullreq-commits) #'ignore))
+      (unwind-protect
+          (progn
+            (set-default 'majutsu-log-sections-hook
+                         '(majutsu-log-insert-logs
+                           majutsu-forge-insert-pullreqs))
+            (set-default 'majutsu-log-mode-hook
+                         '(majutsu-forge--init-buffer))
+            (set-default 'majutsu-refresh-buffer-hook
+                         '(majutsu-forge--expand-sections))
+            ;; Model identical advice installed independently before the mode.
+            (advice-add 'forge-refresh-buffer :after
+                        #'majutsu-forge--after-forge-refresh)
+            (advice-add 'forge--insert-pullreq-commits :around
+                        #'majutsu-forge--insert-pullreq-commits-around)
+            (majutsu-forge--add-section-hooks)
+            (majutsu-forge--add-owned-hook
+             'majutsu-log-mode-hook #'majutsu-forge--connect-database-once)
+            (majutsu-forge--add-owned-hook
+             'majutsu-log-mode-hook #'majutsu-forge--init-buffer)
+            (majutsu-forge--add-owned-hook
+             'majutsu-refresh-buffer-hook #'majutsu-forge--expand-sections)
+            (majutsu-forge--add-advices)
+            (majutsu-forge--cleanup-installation)
+            (should (equal (default-value 'majutsu-log-sections-hook)
+                           '(majutsu-log-insert-logs
+                             majutsu-forge-insert-pullreqs)))
+            (should (equal (default-value 'majutsu-log-mode-hook)
+                           '(majutsu-forge--init-buffer)))
+            (should (equal (default-value 'majutsu-refresh-buffer-hook)
+                           '(majutsu-forge--expand-sections)))
+            (should (advice-member-p #'majutsu-forge--after-forge-refresh
+                                     'forge-refresh-buffer))
+            (should (advice-member-p
+                     #'majutsu-forge--insert-pullreq-commits-around
+                     'forge--insert-pullreq-commits)))
+        (advice-remove 'forge-refresh-buffer
+                       #'majutsu-forge--after-forge-refresh)
+        (advice-remove 'forge--insert-pullreq-commits
+                       #'majutsu-forge--insert-pullreq-commits-around)
+        (majutsu-forge--cleanup-installation)
+        (set-default 'majutsu-log-sections-hook original-sections)
+        (set-default 'majutsu-log-mode-hook original-log-mode)
+        (set-default 'majutsu-refresh-buffer-hook original-refresh)))))
 
 (ert-deftest majutsu-forge-mode-bindings/restore-previous-bindings ()
   (let ((original-n (keymap-lookup majutsu-mode-map "N"))

--- a/test/majutsu-jj-test.el
+++ b/test/majutsu-jj-test.el
@@ -216,6 +216,30 @@
                      "diff")))
       (should (equal (buffer-string) "diff output\n")))))
 
+(ert-deftest majutsu-jj-wash/wash-anyway-appends-stderr-after-stdout-wash ()
+  "A failed wash should parse only stdout, then append cleaned diagnostics."
+  (let (washed)
+    (cl-letf (((symbol-function 'majutsu-process-file)
+               (lambda (_program _infile destination _display &rest _args)
+                 (insert "diff output\n")
+                 (write-region "\e[31mError: partial diff\e[0m\n" nil
+                               (cadr destination) nil 'silent)
+                 1)))
+      (with-temp-buffer
+        (should (= 1 (majutsu-jj-wash
+                       (lambda (&rest _)
+                         (setq washed (buffer-string))
+                         (goto-char (point-max)))
+                       'wash-anyway
+                       "diff")))
+        (should (equal washed "diff output\n"))
+        (should (string-prefix-p washed (buffer-string)))
+        (should (string-match-p "jj .*diff failed (exit 1)"
+                                (buffer-string)))
+        (should (string-match-p "Error: partial diff" (buffer-string)))
+        (should-not (string-match-p (regexp-quote "\e[")
+                                    (buffer-string)))))))
+
 (ert-deftest majutsu-jj-wash/keeps-clean-stderr-on-failure ()
   "Requested failure stderr should be preserved without ANSI escapes."
   (cl-letf (((symbol-function 'majutsu-process-file)

--- a/test/majutsu-process-test.el
+++ b/test/majutsu-process-test.el
@@ -398,6 +398,93 @@ is not silently reported as passed."
       (should (= 3 (majutsu--process-file-responsive
                     "sh" nil t "-c" "exit 3"))))))
 
+(ert-deftest majutsu-process-test-file-responsive-cleans-stderr-on-create-error ()
+  "A `make-process' error should not leak the temporary stderr buffer."
+  (let (stderr-buffer)
+    (cl-letf (((symbol-function 'make-process)
+               (lambda (&rest plist)
+                 (setq stderr-buffer (plist-get plist :stderr))
+                 (error "process creation failed"))))
+      (with-temp-buffer
+        (should-error
+         (majutsu--process-file-responsive
+          "missing-jj" nil (list t "/tmp/majutsu-unused-stderr")))))
+    (should (bufferp stderr-buffer))
+    (should-not (buffer-live-p stderr-buffer))))
+
+(ert-deftest majutsu-process-test-file-responsive-cleans-identifiable-created-process ()
+  "Clean a real process when a non-atomic wrapper creates it then signals."
+  (majutsu-process-test--with-sh
+    (let ((real-make-process (symbol-function 'make-process))
+          blocker
+          created
+          stderr-process
+          stderr-buffer)
+      (unwind-protect
+          (progn
+            ;; Force Emacs to uniquify the main process name independently
+            ;; from the stderr process name.
+            (setq blocker
+                  (funcall real-make-process
+                           :name "sh"
+                           :command '("sh" "-c" "sleep 20")
+                           :noquery t))
+            (cl-letf (((symbol-function 'make-process)
+                       (lambda (&rest plist)
+                         (setq stderr-buffer (plist-get plist :stderr))
+                         (setq created (apply real-make-process plist))
+                         (setq stderr-process
+                               (get-buffer-process stderr-buffer))
+                         (error "wrapper failed after process creation"))))
+              (with-temp-buffer
+                (should-error
+                 (majutsu--process-file-responsive
+                  "sh" nil (list t "/tmp/majutsu-unused-stderr")
+                  "-c" "sleep 20"))))
+            (should (processp created))
+            (should-not (process-live-p created))
+            (should-not (memq created (process-list)))
+            (should (process-live-p blocker))
+            (should (processp stderr-process))
+            (should-not (process-live-p stderr-process))
+            (should-not (memq stderr-process (process-list)))
+            (should-not (buffer-live-p stderr-buffer)))
+        (when (and created (process-live-p created))
+          (delete-process created))
+        (when (and blocker (process-live-p blocker))
+          (delete-process blocker))
+        (when (and stderr-process (process-live-p stderr-process))
+          (delete-process stderr-process))
+        (when (buffer-live-p stderr-buffer)
+          (kill-buffer stderr-buffer))))))
+
+(ert-deftest majutsu-process-test-file-responsive-does-not-guess-created-process ()
+  "Do not kill an unidentifiable process created by a failing wrapper."
+  (majutsu-process-test--with-sh
+    (let ((real-make-process (symbol-function 'make-process))
+          unrelated)
+      (unwind-protect
+          (progn
+            (cl-letf (((symbol-function 'make-process)
+                       (lambda (&rest _plist)
+                         ;; This process is created during the wrapper call,
+                         ;; but is not linked to Majutsu's private stderr
+                         ;; buffer and therefore cannot be identified safely.
+                         (setq unrelated
+                               (funcall real-make-process
+                                        :name "majutsu-unrelated"
+                                        :command '("sh" "-c" "sleep 20")
+                                        :noquery t))
+                         (error "unrelated wrapper failure"))))
+              (with-temp-buffer
+                (should-error
+                 (majutsu--process-file-responsive
+                  "sh" nil (list t "/tmp/majutsu-unused-stderr")
+                  "-c" "sleep 20"))))
+            (should (process-live-p unrelated)))
+        (when (and unrelated (process-live-p unrelated))
+          (delete-process unrelated))))))
+
 (ert-deftest majutsu-process-test-file-responsive-stderr-file-has-no-sentinel-noise ()
   "Responsive runner must not write Emacs sentinel status lines to a stderr file.
 


### PR DESCRIPTION
Follow-up hardening for the recently merged Forge integration.

- coalesces reentrant Forge refreshes without dropping a final refresh
- refreshes an explicit Majutsu buffer exactly once
- rolls back partially installed hooks/advice
- keeps stderr outside diff parsing while preserving failure diagnostics
- cleans only uniquely identified wrapper-created processes on creation failure

Validation:
- 785/785 ERT tests
- 50 source files byte-compiled
- combined four-change integration stack: 828/828 on jj 0.40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Forge and Majutsu refresh behavior to prevent redundant or recursive refreshes.
  - Forge integration cleanup now preserves existing hooks and advice while safely rolling back incomplete setup.
  - Improved handling of command failures, including clearer error summaries and cleaned diagnostic output.
  - Fixed edge cases in process execution and cleanup to prevent leaked or incorrectly terminated processes.
  - Ensured washed command output remains correctly separated from failure diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->