### PR TITLE
fix: harden workspace trash and whole-file splits

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -5,6 +5,10 @@
 
 ** Breaking changes
 
+- The minimum supported Jujutsu version is now 0.40.0 ::
+  Workspace root discovery uses =WorkspaceRef.root()=, which was added in jj
+  0.40.0.  Earlier jj releases are no longer supported.
+
 - The Squash transient now uses =--from= for source revisions ::
   The =-r/--revision= shortcut was removed.  Use =-f/--from= instead.
   Diff =--revisions= selections are carried into squash as =--from= sources.
@@ -61,6 +65,14 @@
   Reviewer, CC, and topic prompts use Majutsu's native Gerrit REST client.
 
 ** Changed
+
+- Workspace trash and whole-file Split paths are fail-closed ::
+  Workspace list fields use JSON transport, trash targets are bound to their
+  device/inode identity across confirmation and forget, and multi-root trash
+  failures are reported together after every target is attempted.  Hunkless
+  whole-file Split operations now use structured =jj diff -T= metadata instead
+  of parsing Git display headers.  Each asynchronous patch operation also gets
+  a private temporary directory.
 
 - Evil dispatcher entries show Evil-facing keys ::
   The top-level dispatcher now mirrors buffer bindings such as ~x~, ~L~, ~_~,

--- a/README.org
+++ b/README.org
@@ -80,7 +80,7 @@ by Forge's Git-oriented renderer are replaced by a placeholder in Majutsu buffer
 * Requirements
 
 - Emacs 29.1+
-- [[https://github.com/jj-vcs/jj][Jujutsu (jj)]] v0.39.0+
+- [[https://github.com/jj-vcs/jj][Jujutsu (jj)]] v0.40.0+
 - [[https://magit.vc/][magit]], [[https://github.com/magit/transient][transient]], [[https://github.com/magit/with-editor][with-editor]]
 
 * Documentation

--- a/docs/majutsu.org
+++ b/docs/majutsu.org
@@ -27,7 +27,7 @@ Majutsu stands on the shoulders of giants. We are grateful to:
 * Installation
 ** Requirements
 - Emacs 29.1 or later.
-- Jujutsu (jj) v0.39.0 or later installed and in your =PATH=.
+- Jujutsu (jj) v0.40.0 or later installed and in your =PATH=.
 - =magit= 3.3.0 or later (for section management).
 - =consult= 1.0 or later and =plz= 0.9.1 or later (for native Gerrit completion).
 - =transient= 0.5.0 or later (popup menus).
@@ -595,7 +595,7 @@ Interactive selection is integrated into the Split (~S~), Squash (~s~), and Rest
 | Key | Command                           | Description                           |
 |-----+-----------------------------------+---------------------------------------|
 | ~H~ | majutsu-interactive-toggle-hunk   | Toggle selection of hunk at point     |
-| ~F~ | majutsu-interactive-toggle-file   | Toggle selection of all hunks in file |
+| ~F~ | majutsu-interactive-toggle-file   | Toggle all hunks; hunkless file in Split |
 | ~R~ | majutsu-interactive-toggle-region | Toggle selection of active region     |
 | ~C~ | majutsu-interactive-clear         | Clear all patch selections            |
 
@@ -611,7 +611,7 @@ This means you can:
 4. The restore will apply only to those hunks, using the diff's revision context
 
 *** Visual Feedback
-Selected hunks are highlighted with =majutsu-interactive-selected-hunk= face (green background by default). Selected regions within hunks use =majutsu-interactive-selected-region= face (purple background).
+Selected hunks are highlighted with =majutsu-interactive-selected-hunk= face (green background by default). Selected regions within hunks use =majutsu-interactive-selected-region= face (purple background). A selected hunkless whole-file Split change uses =majutsu-interactive-selected-file=.
 
 *** Selection Semantics
 The meaning of "selected" differs by operation:
@@ -639,6 +639,10 @@ Majutsu uses a custom merge tool to apply partial patches. When you execute an o
 
 2. *Tool Invocation*: Jujutsu's =-i --tool= mechanism is used with a custom =majutsu-applypatch= tool.
 
+   Each invocation receives its own temporary patch and helper directory. An
+   overlapping asynchronous operation therefore cannot overwrite another
+   operation's inputs.
+
 3. *Patch Application*:
    - For *Split/Squash*: The tool resets =$right= (current state) to =$left= (parent state), then applies the patch forward. This results in =$right= containing only the selected changes.
    - For *Restore*: The tool applies the patch directly to =$right=.
@@ -646,7 +650,8 @@ Majutsu uses a custom merge tool to apply partial patches. When you execute an o
 This approach avoids the complexity of reverse patch application (=git apply -R=), which has edge cases with new files, deleted files, and content starting with =+= or =-=.
 
 *** Edge Cases
-Interactive patching supports all file operation types:
+Text-hunk selection supports the file operations below. Split additionally
+supports hunkless whole-file changes as described at the end of this section.
 
 **** New Files
 When splitting or squashing a new file:
@@ -668,8 +673,16 @@ matching.
 
 **** Renamed/Copied Files
 Renamed and copied files are handled correctly:
-- The rename/copy metadata is preserved in the patch
+- Text-hunk patches preserve the rendered rename/copy headers
 - You can select specific hunks within renamed files just like regular modifications
+
+In a Git-format diff buffer, hunkless whole-file changes (for example binary
+or mode-only changes) can be selected as a unit by Split. Their status and
+source/target paths come from a separate JSON =jj diff -T= query for the same
+range and filesets, never from the rendered =diff --git= header. If that
+metadata is unavailable, reordered, or inconsistent with the displayed patch,
+Majutsu refuses the whole-file selection. Squash and Restore do not support
+hunkless whole-file selection.
 
 *** Workflow Example
 1. Open a diff with ~D~ or ~d~
@@ -682,6 +695,7 @@ Renamed and copied files are handled correctly:
 *** Customization
 - Face: majutsu-interactive-selected-hunk :: Face for selected hunks.
 - Face: majutsu-interactive-selected-region :: Face for selected regions.
+- Face: majutsu-interactive-selected-file :: Face for selected hunkless whole-file Split changes.
 
 ** Metaediting
 - Key: ? m (majutsu-metaedit) :: Open the Metaedit transient. Defaults to one revision from point (fallback =@=). If multiple revisions are selected, Majutsu asks you to narrow it down.
@@ -831,7 +845,7 @@ Jujutsu supports multiple workspaces sharing the same repository storage. This i
 - Key: v (majutsu-workspace-visit) :: Visit a workspace by changing =default-directory= and refreshing Majutsu buffers.
 - Key: a (majutsu-workspace-add) :: Add a new workspace.
 - Key: -t :: Toggle trashing workspace directories after forgetting them.
-- Key: f (majutsu-workspace-forget) :: Forget a workspace. With =-t= enabled from the workspace transient, also move its local directory to the system trash after =jj workspace forget= succeeds. Majutsu refuses remote roots and any root that owns the shared =.jj/repo= store. If moving to trash fails after the workspace was forgotten, Majutsu reports the directory that must be moved manually.
+- Key: f (majutsu-workspace-forget) :: Forget a workspace. With =-t= enabled from the workspace transient, also move its local directory to the system trash after =jj workspace forget= succeeds. Majutsu refuses remote roots and any root that owns the shared =.jj/repo= store. Before confirmation it records each existing directory's device/inode identity; after forget it will not trash a path that appeared, disappeared, changed identity, or became a repo-store owner. After a successful forget, every target is checked/attempted and any failures are reported together for manual cleanup.
 - Key: u (majutsu-workspace-update-stale) :: Update a stale workspace.
 - Key: n (majutsu-workspace-rename) :: Rename a workspace.
 - Key: r (majutsu-workspace-root) :: Show and copy the current workspace root.
@@ -840,7 +854,9 @@ Workspace sections are rendered from a structured =jj workspace list -T=
 template. By default they show each workspace name, working-copy ids,
 description, and resolved root path when available. If jj cannot resolve a
 workspace root, Majutsu treats it as unavailable instead of showing the raw
-=<Error: ...>= text in the section body.
+=<Error: ...>= text in the section body. Every machine field is JSON-encoded,
+so newlines and other control characters in legal workspace paths cannot split
+or truncate a record.
 
 * Conflict Resolution
 ** Detecting Conflicts

--- a/docs/majutsu.texi
+++ b/docs/majutsu.texi
@@ -265,7 +265,7 @@ Brandon Olivier for the initial codebase of @samp{jj-mode.el}.
 @item
 Emacs 29.1 or later.
 @item
-Jujutsu (jj) v0.39.0 or later installed and in your @samp{PATH}.
+Jujutsu (jj) v0.40.0 or later installed and in your @samp{PATH}.
 @item
 @samp{magit} 3.3.0 or later (for section management).
 @item
@@ -1508,7 +1508,7 @@ Majutsu provides Magit-style partial hunk selection for Jujutsu operations. This
 
 Interactive selection is integrated into the Split (@code{S})@comma{} Squash (@code{s})@comma{} and Restore (@code{R}) transients. When you open one of these transients from a Diff buffer@comma{} a "Patch Selection" group appears with the following commands:
 
-@multitable {aaa} {aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa} {aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}
+@multitable {aaa} {aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa} {aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}
 @headitem Key
 @tab Command
 @tab Description
@@ -1517,7 +1517,7 @@ Interactive selection is integrated into the Split (@code{S})@comma{} Squash (@c
 @tab Toggle selection of hunk at point
 @item @code{F}
 @tab majutsu-interactive-toggle-file
-@tab Toggle selection of all hunks in file
+@tab Toggle all hunks; hunkless file in Split
 @item @code{R}
 @tab majutsu-interactive-toggle-region
 @tab Toggle selection of active region
@@ -1552,7 +1552,7 @@ The restore will apply only to those hunks@comma{} using the diff's revision con
 @node Visual Feedback
 @subsection Visual Feedback
 
-Selected hunks are highlighted with @samp{majutsu-interactive-selected-hunk} face (green background by default). Selected regions within hunks use @samp{majutsu-interactive-selected-region} face (purple background).
+Selected hunks are highlighted with @samp{majutsu-interactive-selected-hunk} face (green background by default). Selected regions within hunks use @samp{majutsu-interactive-selected-region} face (purple background). A selected hunkless whole-file Split change uses @samp{majutsu-interactive-selected-file}.
 
 @node Selection Semantics
 @subsection Selection Semantics
@@ -1609,6 +1609,10 @@ Majutsu uses a custom merge tool to apply partial patches. When you execute an o
 @item
 @strong{Tool Invocation}: Jujutsu's @samp{-i --tool} mechanism is used with a custom @samp{majutsu-applypatch} tool.
 
+Each invocation receives its own temporary patch and helper directory. An
+overlapping asynchronous operation therefore cannot overwrite another
+operation's inputs.
+
 @item
 @strong{Patch Application}:
 @itemize
@@ -1624,7 +1628,8 @@ This approach avoids the complexity of reverse patch application (@samp{git appl
 @node Edge Cases
 @subsection Edge Cases
 
-Interactive patching supports all file operation types:
+Text-hunk selection supports the file operations below. Split additionally
+supports hunkless whole-file changes as described at the end of this section.
 
 @enumerate
 @item
@@ -1667,10 +1672,18 @@ matching.
 Renamed and copied files are handled correctly:
 @itemize
 @item
-The rename/copy metadata is preserved in the patch
+Text-hunk patches preserve the rendered rename/copy headers
 @item
 You can select specific hunks within renamed files just like regular modifications
 @end itemize
+
+In a Git-format diff buffer@comma{} hunkless whole-file changes (for example binary
+or mode-only changes) can be selected as a unit by Split. Their status and
+source/target paths come from a separate JSON @samp{jj diff -T} query for the same
+range and filesets@comma{} never from the rendered @samp{diff --git} header. If that
+metadata is unavailable@comma{} reordered@comma{} or inconsistent with the displayed patch@comma{}
+Majutsu refuses the whole-file selection. Squash and Restore do not support
+hunkless whole-file selection.
 @end enumerate
 
 @node Workflow Example
@@ -1699,6 +1712,8 @@ Execute the operation - only selected changes will be affected
 Face for selected hunks.
 @item Face: majutsu-interactive-selected-region
 Face for selected regions.
+@item Face: majutsu-interactive-selected-file
+Face for selected hunkless whole-file Split changes.
 @end table
 
 @node Metaediting
@@ -2110,7 +2125,7 @@ Toggle trashing workspace directories after forgetting them.
 @item @kbd{f} (@code{majutsu-workspace-forget})
 @kindex f
 @findex majutsu-workspace-forget
-Forget a workspace. With @samp{-t} enabled from the workspace transient@comma{} also move its local directory to the system trash after @samp{jj workspace forget} succeeds. Majutsu refuses remote roots and any root that owns the shared @samp{.jj/repo} store. If moving to trash fails after the workspace was forgotten@comma{} Majutsu reports the directory that must be moved manually.
+Forget a workspace. With @samp{-t} enabled from the workspace transient@comma{} also move its local directory to the system trash after @samp{jj workspace forget} succeeds. Majutsu refuses remote roots and any root that owns the shared @samp{.jj/repo} store. Before confirmation it records each existing directory's device/inode identity; after forget it will not trash a path that appeared@comma{} disappeared@comma{} changed identity@comma{} or became a repo-store owner. After a successful forget@comma{} every target is checked/attempted and any failures are reported together for manual cleanup.
 @item @kbd{u} (@code{majutsu-workspace-update-stale})
 @kindex u
 @findex majutsu-workspace-update-stale
@@ -2129,7 +2144,9 @@ Workspace sections are rendered from a structured @samp{jj workspace list -T}
 template. By default they show each workspace name@comma{} working-copy ids@comma{}
 description@comma{} and resolved root path when available. If jj cannot resolve a
 workspace root@comma{} Majutsu treats it as unavailable instead of showing the raw
-@samp{<Error: ...>} text in the section body.
+@samp{<Error: ...>} text in the section body. Every machine field is JSON-encoded@comma{}
+so newlines and other control characters in legal workspace paths cannot split
+or truncate a record.
 
 @node Conflict Resolution
 @chapter Conflict Resolution

--- a/majutsu-diff.el
+++ b/majutsu-diff.el
@@ -29,6 +29,8 @@
 (require 'majutsu-process)
 (require 'majutsu-config)
 (require 'majutsu-selection)
+(require 'majutsu-template)
+(require 'json)
 (require 'magit-diff)      ; for faces/font-lock keywords
 (require 'diff-mode)
 (require 'smerge-mode)
@@ -432,15 +434,270 @@ The returned value is a (ARGS RANGE FILESETS) triple."
           "\\(?: +\\(\\+*\\)\\(-*\\)\\)?$") ; add/del graph (optional)
   "Regexp matching `jj diff --stat` entries, modeled after Magit's statline.")
 
+(defconst majutsu-diff--file-metadata-template
+  (majutsu-template-compile
+   ["[" [:json [:status]]
+    "," [:json [:path]]
+    "," [:json [:source :path]]
+    "," [:json [:target :path]] "]\n"]
+   'TreeDiffEntry)
+  "Template for unambiguous machine-readable diff entry metadata.")
+
+(defvar majutsu-diff--active-file-metadata nil
+  "Structured file metadata matching the Git diff currently being washed.")
+
+(defvar majutsu-diff--file-metadata-queue nil
+  "Remaining structured entries while Git file sections are being washed.")
+
+(defvar-local majutsu-diff--file-metadata-by-section nil
+  "Hash table mapping real diff file sections to structured metadata.")
+
+(defun majutsu-diff--parse-file-metadata-line (line)
+  "Parse one JSON diff metadata LINE into a plist, or return nil."
+  (condition-case nil
+      (pcase (json-parse-string line
+                                :array-type 'list
+                                :null-object nil
+                                :false-object nil)
+        (`(,status ,path ,source ,target)
+         (when (and (stringp status)
+                    (stringp path)
+                    (stringp source)
+                    (stringp target))
+           (list :status status
+                 :path path
+                 :source source
+                 :target target))))
+    (error nil)))
+
+(defun majutsu-diff--parse-file-metadata-output (output)
+  "Parse newline-delimited JSON diff metadata OUTPUT."
+  (delq nil
+        (mapcar #'majutsu-diff--parse-file-metadata-line
+                (split-string (or output "") "\n" t))))
+
+(defun majutsu-diff--query-file-metadata (range filesets)
+  "Return structured metadata for diff RANGE and FILESETS.
+The main diff command has already snapshotted the working copy, so this
+sidecar query uses `--ignore-working-copy'."
+  (let ((args (majutsu-jj-append-filesets
+               (append (list "--ignore-working-copy"
+                             "diff" "-T" majutsu-diff--file-metadata-template)
+                       range)
+               filesets)))
+    (condition-case nil
+        (majutsu--with-no-color
+          (with-temp-buffer
+            (when (zerop (apply #'majutsu-jj-insert args))
+              (majutsu-diff--parse-file-metadata-output (buffer-string)))))
+      (error nil))))
+
+(defun majutsu-diff--raw-git-file-headers ()
+  "Return raw Git file header blocks in the current narrowed buffer."
+  (save-excursion
+    (goto-char (point-min))
+    (let (headers)
+      (while (re-search-forward "^diff --git " nil t)
+        (let ((beg (match-beginning 0)))
+          (forward-line 1)
+          (let ((end (or (save-excursion
+                           (when (re-search-forward
+                                  "^\\(?:diff --git \\|@@ \\)" nil t)
+                             (match-beginning 0)))
+                         (point-max))))
+            (push (buffer-substring-no-properties beg end) headers)
+            (goto-char end))))
+      (nreverse headers))))
+
+(defun majutsu-diff--set-section-path (section path)
+  "Set real file SECTION and its hunk identities to exact PATH."
+  (oset section value path)
+  (dolist (child (oref section children))
+    (when (magit-section-match 'jj-hunk child)
+      (let ((value (oref child value)))
+        (when (consp value)
+          (oset child value (cons path (cdr value))))))))
+
+(defun majutsu-diff--read-git-quoted-token (token)
+  "Decode one C-quoted Git path at the start of TOKEN.
+Return (VALUE . END), where END is the first position after the closing quote,
+or nil for malformed input."
+  (when (string-prefix-p "\"" token)
+    (catch 'done
+      (let ((index 1)
+            bytes)
+        (cl-labels
+            ((push-char
+              (char)
+              (dolist (byte (string-to-list
+                             (encode-coding-string (string char) 'utf-8 t)))
+                (push byte bytes))))
+          (while (< index (length token))
+            (let ((char (aref token index)))
+              (setq index (1+ index))
+              (cond
+               ((= char ?\")
+                (let ((raw (apply #'unibyte-string (nreverse bytes))))
+                  (throw 'done
+                         (cons (decode-coding-string raw 'utf-8 t) index))))
+               ((/= char ?\\)
+                (push-char char))
+               ((>= index (length token))
+                (throw 'done nil))
+               (t
+                (let ((escaped (aref token index)))
+                  (cond
+                   ((and (>= escaped ?0) (<= escaped ?7))
+                    (let ((start index)
+                          (count 0))
+                      (while (and (< index (length token))
+                                  (< count 3)
+                                  (>= (aref token index) ?0)
+                                  (<= (aref token index) ?7))
+                        (setq index (1+ index)
+                              count (1+ count)))
+                      (let ((byte (string-to-number
+                                   (substring token start index) 8)))
+                        (when (> byte 255)
+                          (throw 'done nil))
+                        (push byte bytes))))
+                   (t
+                    (setq index (1+ index))
+                    (let ((byte (cdr (assq escaped
+                                           '((?a . 7) (?b . 8) (?t . 9)
+                                             (?n . 10) (?v . 11) (?f . 12)
+                                             (?r . 13) (?\" . 34) (?\\ . 92))))))
+                      (unless byte
+                        (throw 'done nil))
+                      (push byte bytes))))))))))
+        nil))))
+
+(defun majutsu-diff--git-quoted-token-value (token)
+  "Decode a complete quoted Git path TOKEN, or return nil."
+  (pcase (majutsu-diff--read-git-quoted-token token)
+    (`(,value . ,end)
+     (and (= end (length token)) value))))
+
+(defun majutsu-diff--git-token-matches-p (token expected)
+  "Return non-nil when Git path TOKEN represents EXPECTED."
+  (or (equal token expected)
+      (equal (majutsu-diff--git-quoted-token-value token) expected)))
+
+(defun majutsu-diff--git-header-paths-match-p (header entry)
+  "Return non-nil when Git diff HEADER paths match structured ENTRY.
+ENTRY remains the source of truth; this only rejects a stale or reordered
+sidecar result."
+  (when-let* ((line (car (split-string (or header "") "\n")))
+              ((string-prefix-p "diff --git " line)))
+    (let* ((payload (string-remove-prefix "diff --git " line))
+           (left (concat "a/" (plist-get entry :source)))
+           (right (concat "b/" (plist-get entry :target)))
+           (raw (concat left " " right)))
+      (or (equal payload raw)
+          ;; If the left token is raw, its exact structured value tells us
+          ;; where the otherwise ambiguous separator must be.
+          (and (string-prefix-p (concat left " ") payload)
+               (majutsu-diff--git-token-matches-p
+                (substring payload (1+ (length left))) right))
+          ;; A quoted left token is self-delimiting; decode it and validate the
+          ;; complete remaining token independently.
+          (and (string-prefix-p "\"" payload)
+               (pcase (majutsu-diff--read-git-quoted-token payload)
+                 (`(,value . ,end)
+                  (and (equal value left)
+                       (< end (length payload))
+                       (= (aref payload end) ?\s)
+                       (majutsu-diff--git-token-matches-p
+                        (substring payload (1+ end)) right)))))))))
+
+(defun majutsu-diff--git-header-status-match-p (header status)
+  "Return non-nil when extended Git HEADER agrees with structured STATUS."
+  (let ((added (or (string-match-p "^new file mode " header)
+                   (string-match-p "^--- /dev/null$" header)))
+        (removed (or (string-match-p "^deleted file mode " header)
+                     (string-match-p "^+++ /dev/null$" header)))
+        (renamed (and (string-match-p "^rename from " header)
+                      (string-match-p "^rename to " header)))
+        (copied (and (string-match-p "^copy from " header)
+                     (string-match-p "^copy to " header))))
+    (pcase status
+      ("added" added)
+      ("removed" removed)
+      ("renamed" renamed)
+      ("copied" copied)
+      ("modified" (not (or added removed renamed copied)))
+      (_ nil))))
+
+(defun majutsu-diff--file-metadata-matches-section-p (entry section)
+  "Return non-nil when structured ENTRY is consistent with file SECTION."
+  (let ((header (oref section header)))
+    (and (majutsu-diff--git-header-paths-match-p header entry)
+         (majutsu-diff--git-header-status-match-p
+         header (plist-get entry :status)))))
+
+(defun majutsu-diff--raw-file-metadata-consistent-p (metadata)
+  "Return non-nil when ordered METADATA matches the raw Git patch exactly."
+  (let ((headers (majutsu-diff--raw-git-file-headers)))
+    (and metadata
+         (= (length headers) (length metadata))
+         (cl-every
+          #'identity
+          (cl-mapcar
+           (lambda (entry header)
+             (and (majutsu-diff--git-header-paths-match-p header entry)
+                  (majutsu-diff--git-header-status-match-p
+                   header (plist-get entry :status))))
+           metadata headers)))))
+
+(defun majutsu-diff--attach-file-metadata (metadata)
+  "Attach ordered structured METADATA to washed file sections.
+Fail closed unless section count, order, paths, and operation statuses all
+agree with the sidecar metadata."
+  (setq majutsu-diff--file-metadata-by-section (make-hash-table :test #'eq))
+  (let ((root (or (bound-and-true-p magit-insert-section--current)
+                  magit-root-section))
+        real-files stat-files)
+    (when root
+      (magit-map-sections
+       (lambda (section)
+         (when (magit-section-match 'jj-file section)
+           (if (oref section header)
+               (push section real-files)
+             (push section stat-files))))
+       root))
+    (setq real-files (nreverse real-files)
+          stat-files (nreverse stat-files))
+    (when (and metadata
+               (= (length real-files) (length metadata))
+               (cl-every #'identity
+                         (cl-mapcar #'majutsu-diff--file-metadata-matches-section-p
+                                    metadata real-files)))
+      (cl-mapc
+       (lambda (section entry)
+         (majutsu-diff--set-section-path section (plist-get entry :path))
+         (puthash section entry majutsu-diff--file-metadata-by-section))
+       real-files metadata)
+      (when (= (length stat-files) (length metadata))
+        (cl-mapc (lambda (section entry)
+                   (oset section value (plist-get entry :path)))
+                 stat-files metadata)))))
+
+(defun majutsu-diff-file-metadata (section)
+  "Return exact structured metadata attached to file SECTION, or nil."
+  (and majutsu-diff--file-metadata-by-section
+       (gethash section majutsu-diff--file-metadata-by-section)))
+
 (defun majutsu-diff--collect-diff-files ()
   "Return a list of file paths from \"diff --git\" headers in the buffer.
 The list is in the same order as the diff headers appear."
-  (save-excursion
-    (goto-char (point-min))
-    (let (files)
-      (while (re-search-forward "^diff --git a/\\(.*\\) b/\\(.*\\)$" nil t)
-        (push (match-string-no-properties 2) files))
-      (nreverse files))))
+  (or (mapcar (lambda (entry) (plist-get entry :path))
+              majutsu-diff--active-file-metadata)
+      (save-excursion
+        (goto-char (point-min))
+        (let (files)
+          (while (re-search-forward "^diff --git a/\\(.*\\) b/\\(.*\\)$" nil t)
+            (push (match-string-no-properties 2) files))
+          (nreverse files)))))
 
 (defun majutsu-jump-to-diffstat-or-diff (&optional expand)
   "Jump to the diffstat or diff.
@@ -533,7 +790,25 @@ ARGS are the diff arguments used to produce DIFF-OUTPUT."
          (washer (majutsu-diff--backend-washer backend)))
     (magit-insert-section (diff-root)
       (magit-insert-heading (format "jj %s" (string-join args " ")))
-      (majutsu-jj-wash washer 'wash-anyway args))))
+      (majutsu-jj-wash
+          (lambda (wash-args)
+            ;; The Git command has already snapshotted the working copy.
+            ;; Query the same range without snapshotting again, then
+            ;; attach exact paths/statuses only if the ordered raw headers and
+            ;; operation kinds agree.
+            (let* ((metadata (and (eq backend 'git)
+                                  (majutsu-diff--query-file-metadata
+                                   majutsu-buffer-diff-range
+                                   majutsu-buffer-diff-filesets)))
+                   (matching-git-metadata
+                    (and (majutsu-diff--raw-file-metadata-consistent-p metadata)
+                         metadata))
+                   (majutsu-diff--active-file-metadata matching-git-metadata)
+                   (majutsu-diff--file-metadata-queue
+                    (copy-sequence matching-git-metadata)))
+              (funcall washer wash-args)
+              (majutsu-diff--attach-file-metadata metadata)))
+        'wash-anyway args))))
 
 ;;; Diff wash
 
@@ -604,15 +879,25 @@ Assumes point is at the start of the diff output."
   (when (looking-at "^diff --git ")
     (while (and (not (eobp))
                 (looking-at "^diff --git "))
-      (majutsu-diff-wash-file))
+      (let ((before (point)))
+        (majutsu-diff-wash-file)
+        ;; A malformed or future Git header must never trap refresh in a
+        ;; non-advancing parser loop.
+        (when (= before (point))
+          (forward-line 1))))
     (unless (bolp) (insert "\n"))))
 
 (defun majutsu-diff-wash-file ()
   "Parse a single file section at point and wrap it in Magit sections."
-  (when (looking-at "^diff --git a/\\(.*\\) b/\\(.*\\)$")
-    (let* ((file-a (match-string-no-properties 1))
-           (file-b (match-string-no-properties 2))
-           (file (or file-b file-a))
+  (when (looking-at "^diff --git ")
+    (let* ((diff-line (buffer-substring-no-properties
+                       (line-beginning-position) (line-end-position)))
+           (metadata (pop majutsu-diff--file-metadata-queue))
+           (fallback
+            (if (string-match "^diff --git a/\\(.*\\) b/\\(.*\\)$" diff-line)
+                (or (match-string 2 diff-line) (match-string 1 diff-line))
+              (string-remove-prefix "diff --git " diff-line)))
+           (file (or (plist-get metadata :path) fallback))
            (headers nil)
            (diff-header (buffer-substring-no-properties
                          (line-beginning-position)
@@ -628,11 +913,12 @@ Assumes point is at the start of the diff output."
                                                    (1+ (line-end-position))))
               headers)
         (majutsu-diff--delete-line))
+      (setq headers (nreverse headers))
       (magit-insert-section
           (jj-file file nil
-                   :header (concat diff-header (string-join (nreverse headers) "")))
+                   :header (concat diff-header (string-join headers "")))
         (magit-insert-heading
-          (propertize (majutsu-diff--file-heading file (nreverse headers))
+          (propertize (majutsu-diff--file-heading file headers)
                       'font-lock-face 'magit-diff-file-heading))
         ;; Hunk bodies remain in the buffer; just wrap them.
         (while (and (not (eobp)) (looking-at "^@@ "))

--- a/majutsu-interactive.el
+++ b/majutsu-interactive.el
@@ -174,6 +174,9 @@ When CONTEXT-ON-ADDED is non-nil, treat unselected added lines as context."
   "Toggle the whole-file selection represented by FILE-SECTION."
   (unless (majutsu-interactive--whole-file-selection-allowed-p)
     (user-error "Whole-file selections are only supported by jj split"))
+  (unless (majutsu-diff-file-metadata file-section)
+    (user-error
+     "Whole-file selection requires exact jj diff metadata; refresh the diff and try again"))
   (let* ((id (majutsu-interactive--file-id (oref file-section value)))
          (current (majutsu-interactive--get-selection id)))
     (majutsu-interactive--set-selection id (unless current :all))
@@ -382,61 +385,42 @@ Returns list of (FILE-SECTION HUNK-SECTION SPEC)."
        majutsu-interactive--selections))
     (nreverse result)))
 
-(defun majutsu-interactive--header-path (header prefix)
-  "Return the path following PREFIX on a line in HEADER."
-  (when (string-match (concat "^" (regexp-quote prefix) "\\(.+\\)$")
-                      (or header ""))
-    (let ((path (match-string 1 header)))
-      (if (not (string-prefix-p "\"" path))
-          path
-        (condition-case nil
-            (pcase-let ((`(,decoded . ,end) (read-from-string path)))
-              (unless (and (stringp decoded) (= end (length path)))
-                (user-error "Invalid quoted Git path: %s" path))
-              decoded)
-          (error (user-error "Invalid quoted Git path: %s" path)))))))
-
 (defun majutsu-interactive--safe-relative-path (path)
   "Return PATH, or signal a user error if it is unsafe for the helper tool."
   (unless (and (stringp path)
                (not (string-empty-p path))
                (not (file-name-absolute-p path))
-               (not (string-match-p "[\n\r\0]" path))
+               (not (string= path "."))
+               (not (string-match-p "\0" path))
                (not (member ".." (split-string path "/" t))))
     (user-error "Unsafe whole-file selection path: %S" path))
   path)
 
 (defun majutsu-interactive--file-operation (file-section)
-  "Parse an explicit whole-file operation from FILE-SECTION metadata."
-  (let* ((header (or (oref file-section header) ""))
-         (value (oref file-section value))
-         (rename-from (majutsu-interactive--header-path header "rename from "))
-         (rename-to (majutsu-interactive--header-path header "rename to "))
-         (copy-from (majutsu-interactive--header-path header "copy from "))
-         (copy-to (majutsu-interactive--header-path header "copy to "))
-         (path (majutsu-interactive--safe-relative-path
-                (or rename-to copy-to value))))
-    (cond
-     ((or rename-from rename-to)
-      (unless (and rename-from rename-to)
-        (user-error "Incomplete rename metadata for %s" value))
-      (list :action 'rename
-            :source (majutsu-interactive--safe-relative-path rename-from)
-            :path path))
-     ((or copy-from copy-to)
-      (unless (and copy-from copy-to)
-        (user-error "Incomplete copy metadata for %s" value))
-      (list :action 'copy
-            :source (majutsu-interactive--safe-relative-path copy-from)
-            :path path))
-     ((or (string-match-p "^deleted file mode " header)
-          (string-match-p "^+++ /dev/null$" header))
-      (list :action 'delete :path path))
-     ((or (string-match-p "^new file mode " header)
-          (string-match-p "^--- /dev/null$" header))
-      (list :action 'add :path path))
-     (t
-      (list :action 'modify :path path)))))
+  "Return an explicit whole-file operation from FILE-SECTION metadata.
+Never infer filesystem paths from rendered Git patch headers."
+  (let ((metadata (majutsu-diff-file-metadata file-section)))
+    (unless metadata
+      (user-error
+       "Whole-file selection requires exact jj diff metadata; refresh the diff and try again"))
+    (let ((status (plist-get metadata :status))
+          (path (majutsu-interactive--safe-relative-path
+                 (plist-get metadata :target))))
+      (pcase status
+        ("added" (list :action 'add :path path))
+        ("modified" (list :action 'modify :path path))
+        ("removed" (list :action 'delete :path path))
+        ("renamed"
+         (list :action 'rename
+               :source (majutsu-interactive--safe-relative-path
+                        (plist-get metadata :source))
+               :path path))
+        ("copied"
+         (list :action 'copy
+               :source (majutsu-interactive--safe-relative-path
+                        (plist-get metadata :source))
+               :path path))
+        (_ (user-error "Unsupported whole-file jj diff status: %S" status))))))
 
 (defun majutsu-interactive--build-file-operations ()
   "Return explicit operations for all selected whole-file changes."
@@ -728,26 +712,15 @@ CONTEXT-ON-ADDED has the same meaning as in
 
 ;;; Tool Invocation
 
-(defvar majutsu-interactive--temp-dir nil
-  "Temporary directory for patch files.")
+(defun majutsu-interactive--make-operation-temp-dir ()
+  "Create and return a private nearby directory for one jj operation."
+  (make-nearby-temp-file "majutsu-interactive-" t))
 
-(defvar majutsu-interactive--temp-dir-remote nil
-  "Remote prefix associated with `majutsu-interactive--temp-dir'.")
-
-(defun majutsu-interactive--temp-dir ()
-  "Return or create temporary directory."
-  (let ((remote (file-remote-p default-directory)))
-    (unless (and majutsu-interactive--temp-dir
-                 (equal remote majutsu-interactive--temp-dir-remote)
-                 (file-directory-p majutsu-interactive--temp-dir))
-      (setq majutsu-interactive--temp-dir
-            (make-nearby-temp-file "majutsu-interactive-" t)
-            majutsu-interactive--temp-dir-remote remote)))
-  majutsu-interactive--temp-dir)
-
-(defun majutsu-interactive--write-patch (patch)
-  "Write PATCH to a temporary file and return its path."
-  (let ((file (expand-file-name "patch.diff" (majutsu-interactive--temp-dir))))
+(defun majutsu-interactive--write-patch (patch &optional directory)
+  "Write PATCH to a temporary file in DIRECTORY and return its path."
+  (let ((file (expand-file-name
+               "patch.diff"
+               (or directory (majutsu-interactive--make-operation-temp-dir)))))
     (with-temp-file file
       (insert patch))
     file))
@@ -756,12 +729,16 @@ CONTEXT-ON-ADDED has the same meaning as in
   "Return a safely shell-quoted PATH beneath shell variable ROOT."
   (format "\"$%s\"/%s" root (shell-quote-argument path)))
 
-(defun majutsu-interactive--write-applypatch-script (reverse &optional file-ops)
+(defun majutsu-interactive--write-applypatch-script
+    (reverse &optional file-ops directory)
   "Write the applypatch helper script and return its path.
 When REVERSE is non-nil, reset $right to $left state first, then apply patch.
 FILE-OPS contains explicit `add', `modify', `delete', `rename', or `copy'
-actions.  Only right-tree paths needed by those operations are preserved."
-  (let ((script (expand-file-name "applypatch.sh" (majutsu-interactive--temp-dir))))
+actions.  Only right-tree paths needed by those operations are preserved.
+Write the script in DIRECTORY when non-nil."
+  (let ((script (expand-file-name
+                 "applypatch.sh"
+                 (or directory (majutsu-interactive--make-operation-temp-dir)))))
     (with-temp-file script
       (insert "#!/bin/sh\n")
       (insert "# Majutsu applypatch helper\n")
@@ -833,10 +810,13 @@ actions.  Only right-tree paths needed by those operations are preserved."
     (set-file-modes script #o755)
     script))
 
-(defun majutsu-interactive--build-tool-config (patch-file reverse &optional file-ops)
+(defun majutsu-interactive--build-tool-config
+    (patch-file reverse &optional file-ops directory)
   "Build jj --config arguments for applypatch tool with PATCH-FILE.
-When REVERSE is non-nil, reset before applying.  FILE-OPS are replayed after."
-  (let* ((script (majutsu-interactive--write-applypatch-script reverse file-ops))
+When REVERSE is non-nil, reset before applying.  FILE-OPS are replayed after.
+Write the helper script in DIRECTORY when non-nil."
+  (let* ((script (majutsu-interactive--write-applypatch-script
+                  reverse file-ops directory))
          (script-path (majutsu-convert-filename-for-jj script))
          (patch-path (majutsu-convert-filename-for-jj patch-file)))
     (list
@@ -847,19 +827,65 @@ When REVERSE is non-nil, reset before applying.  FILE-OPS are replayed after."
 
 ;;; Pending Operation Flow
 
+(defun majutsu-interactive--delete-operation-temp-dir (directory)
+  "Best-effort removal of operation DIRECTORY."
+  (when (and directory (file-exists-p directory))
+    (ignore-errors (delete-directory directory t))))
+
+(defun majutsu-interactive--temp-dir-process-sentinel (process event)
+  "Run PROCESS's original sentinel for EVENT, then remove its temp directory."
+  (let ((original (process-get process 'majutsu-interactive-original-sentinel)))
+    (unwind-protect
+        (when original
+          (funcall original process event))
+      (when (memq (process-status process) '(exit signal))
+        (majutsu-interactive--delete-operation-temp-dir
+         (process-get process 'majutsu-interactive-temp-dir))))))
+
+(defun majutsu-interactive--retain-temp-dir-for-process (process directory)
+  "Keep DIRECTORY until asynchronous PROCESS exits."
+  (if (and (processp process) (process-live-p process))
+      (let ((original (process-sentinel process)))
+        (process-put process 'majutsu-interactive-temp-dir directory)
+        (process-put process 'majutsu-interactive-original-sentinel
+                     original)
+        (set-process-sentinel process
+                              #'majutsu-interactive--temp-dir-process-sentinel)
+        ;; The process can exit after the first liveness check but before the
+        ;; replacement sentinel is installed.  In that case the old sentinel
+        ;; may already have consumed the only exit event, so clean up here.
+        (unless (process-live-p process)
+          (ignore-errors (set-process-sentinel process original))
+          (process-put process 'majutsu-interactive-temp-dir nil)
+          (process-put process 'majutsu-interactive-original-sentinel nil)
+          (majutsu-interactive--delete-operation-temp-dir directory))
+        t)
+    nil))
+
 (defun majutsu-interactive-run-with-patch
     (command args filesets patch &optional reverse file-ops)
   "Run jj COMMAND with ARGS and FILESETS, applying PATCH and FILE-OPS.
 If REVERSE is non-nil, reset the right tree to the left tree before applying
 the selected text patch and explicit whole-file operations."
-  (let* ((patch-file (majutsu-interactive--write-patch (or patch "")))
-         (tool-config (majutsu-interactive--build-tool-config
-                       patch-file reverse file-ops))
-         (args (append args
-                       (list "-i" "--tool" "majutsu-applypatch")
-                       tool-config))
-         (full-args (cons command (majutsu-jj-append-filesets args filesets))))
-    (majutsu-run-jj-with-editor full-args)))
+  (let ((directory (majutsu-interactive--make-operation-temp-dir))
+        retained)
+    (unwind-protect
+        (let* ((patch-file (majutsu-interactive--write-patch
+                            (or patch "") directory))
+               (tool-config (majutsu-interactive--build-tool-config
+                             patch-file reverse file-ops directory))
+               (args (append args
+                             (list "-i" "--tool" "majutsu-applypatch")
+                             tool-config))
+               (full-args
+                (cons command (majutsu-jj-append-filesets args filesets)))
+               (process (majutsu-run-jj-with-editor full-args)))
+          (setq retained
+                (majutsu-interactive--retain-temp-dir-for-process
+                 process directory))
+          process)
+      (unless retained
+        (majutsu-interactive--delete-operation-temp-dir directory)))))
 
 ;;; _
 (provide 'majutsu-interactive)

--- a/majutsu-workspace.el
+++ b/majutsu-workspace.el
@@ -18,17 +18,18 @@
 ;; This library provides helpers and UI for `jj workspace` commands, inspired
 ;; by Magit's worktree support.
 ;;
-;; Majutsu queries workspace data using a structured
+;; Majutsu queries workspace data using a JSON-field
 ;; `jj workspace list -T ...' template and prefers the parsed workspace root
-;; from that output when available. It falls back to `jj workspace root --name'
+;; from that output when available.  It falls back to `jj workspace root --name'
 ;; (available since jj v0.38.0) when a root still needs to be resolved.
-;; The trash flow checks for `.jj/repo' to avoid trashing the root that owns
-;; the shared repository store.
+;; The trash flow rejects `.jj/repo' owners and binds local directory identity
+;; across confirmation and `jj workspace forget'.
 
 ;;; Code:
 
 (require 'ansi-color)
 (require 'cl-lib)
+(require 'json)
 (require 'subr-x)
 
 (require 'majutsu-completion)
@@ -40,7 +41,9 @@
 
 (defconst majutsu-workspace--field-separator (string 30)
   "Separator inserted between template fields for parsing.
-We use an ASCII record separator so parsing stays robust.")
+Each field is JSON-encoded first, so the separator can never occur in a
+field even when a workspace name, description, or root contains control
+characters.")
 
 (defconst majutsu-workspace--default-fields
   '(current name change-id commit-id desc root)
@@ -64,20 +67,21 @@ Return a normalized directory path, or nil if jj rendered an error string."
 
 (defconst majutsu-workspace--field-specs
   '((current
-     :template [:if [:target :current_working_copy] "@"]
+     :template [:if [:target :current_working_copy] "@" ""]
      :parse majutsu-workspace--parse-current)
     (name
      :template [:name]
      :parse identity)
     (change-id
-     :template [:target :change_id :shortest 8]
+     :template [:stringify [:target :change_id :shortest 8]]
      :parse identity)
     (commit-id
-     :template [:target :commit_id :shortest 8]
+     :template [:stringify [:target :commit_id :shortest 8]]
      :parse identity)
     (desc
      :template [:if [:target :description]
-                   [:method [:target :description] :first_line]]
+                   [:method [:target :description] :first_line]
+                   ""]
      :parse majutsu-workspace--parse-desc)
     (root
      :template [:root]
@@ -103,7 +107,9 @@ When FIELDS is nil, use `majutsu-workspace--default-fields'."
   (cons :join
         (cons majutsu-workspace--field-separator
               (mapcar (lambda (field)
-                        (plist-get (majutsu-workspace--field-spec field) :template))
+                        (list :json
+                              (plist-get (majutsu-workspace--field-spec field)
+                                         :template)))
                       fields))))
 
 (defun majutsu-workspace--compile-fields (&optional fields)
@@ -130,6 +136,15 @@ When FIELDS is nil, use `majutsu-workspace--default-fields'."
   "Split VALUE by `majutsu-workspace--field-separator', preserving empties."
   (majutsu--split-fields value majutsu-workspace--field-separator))
 
+(defun majutsu-workspace--decode-field (value)
+  "Decode JSON string field VALUE, returning nil for invalid data."
+  (condition-case nil
+      (let ((decoded (json-parse-string (or value "")
+                                        :null-object nil
+                                        :false-object nil)))
+        (and (stringp decoded) decoded))
+    (error nil)))
+
 (defun majutsu-workspace--parse-line (line &optional plan)
   "Parse a single workspace LINE using PLAN.
 Return an entry plist, or nil if the line does not contain a workspace name."
@@ -144,7 +159,8 @@ Return an entry plist, or nil if the line does not contain a workspace name."
                       (plist-put entry
                                  (majutsu-workspace--field-key field)
                                  (funcall (plist-get spec :parse)
-                                          (nth idx fields)))))
+                                          (majutsu-workspace--decode-field
+                                           (nth idx fields))))))
     (when-let* ((name (plist-get entry :name)))
       (unless (string-empty-p name)
         entry))))
@@ -342,47 +358,128 @@ root remains unavailable, the matching alist value is nil."
   (and root
        (file-directory-p (expand-file-name ".jj/repo" root))))
 
-(defun majutsu-workspace--validate-trash-roots (root-alist)
-  "Signal if any workspace root in ROOT-ALIST must not be trashed.
-ROOT-ALIST maps workspace names to directory paths.  Nil roots and
-already-deleted paths are allowed because `jj workspace forget' can also
-be used after deleting a workspace directory manually.  Remote roots are
-always rejected: Emacs cannot guarantee that deleting one moves it to a
-local or remote system trash instead of permanently removing it."
-  (dolist (entry root-alist)
-    (pcase-let ((`(,name . ,root) entry))
-      (when (and root (not (string-empty-p root)))
-        ;; Check the path syntax before any file operation can contact a
-        ;; remote host.
-        (when (file-remote-p root)
-          (user-error "Refusing to trash remote workspace %s at %s"
-                      name root))
-        (when (and (file-exists-p root)
-                   (majutsu-workspace--repo-store-p root))
-          (user-error "Refusing to trash workspace %s; %s owns the shared .jj/repo store"
-                      name root))))))
+(defun majutsu-workspace--directory-identity (attributes)
+  "Return the stable local file identity from ATTRIBUTES."
+  (and attributes (file-attribute-file-identifier attributes)))
 
-(defun majutsu-workspace--trash-roots (root-alist)
-  "Move known workspace roots in ROOT-ALIST to the system trash.
-ROOT-ALIST maps workspace names to directory paths.  Nil roots and
-already-deleted paths are ignored.  Call
-`majutsu-workspace--validate-trash-roots' before forgetting workspaces to
-reject roots that own shared repo storage without mutating repository
-state."
-  ;; Keep this guard here as defense in depth for non-interactive callers.
-  (majutsu-workspace--validate-trash-roots root-alist)
-  (dolist (entry root-alist)
-    (pcase-let ((`(,name . ,root) entry))
-      (when (and root
-                 (not (string-empty-p root))
-                 (file-exists-p root))
-        (condition-case err
-            (let ((delete-by-moving-to-trash t))
-              (delete-directory root t t))
-          (error
-           (user-error
-            "Workspace %s was forgotten, but %s was not moved to trash: %s; move it manually"
-            name root (error-message-string err))))))))
+(defun majutsu-workspace--prepare-trash-targets (root-alist)
+  "Validate ROOT-ALIST and bind each existing root to its file identity.
+
+ROOT-ALIST maps workspace names to directory paths.  The returned target
+plists contain `:name', `:root', `:existed', and `:identity'.  Nil roots and
+already-missing paths are allowed because `jj workspace forget' is also useful
+after a directory was removed manually.
+
+Remote roots are rejected before any file operation.  Existing targets must
+be real directories, must not own the shared `.jj/repo' store, and must retain
+the same device/inode identity throughout validation."
+  (mapcar
+   (lambda (entry)
+     (pcase-let ((`(,name . ,root) entry))
+       (cond
+        ((or (null root) (string-empty-p root))
+         (list :name name :root root :existed nil :identity nil))
+        ((file-remote-p root)
+         (user-error "Refusing to trash remote workspace %s at %s" name root))
+        (t
+         (let ((before (file-attributes root 'integer)))
+           (if (null before)
+               (list :name name :root root :existed nil :identity nil)
+             (unless (eq (file-attribute-type before) t)
+               (user-error "Refusing to trash workspace %s; %s is not a real directory"
+                           name root))
+             (when (majutsu-workspace--repo-store-p root)
+               (user-error "Refusing to trash workspace %s; %s owns the shared .jj/repo store"
+                           name root))
+             (let* ((after (file-attributes root 'integer))
+                    (before-id (majutsu-workspace--directory-identity before))
+                    (after-id (majutsu-workspace--directory-identity after)))
+               (unless (and before-id
+                            (eq (file-attribute-type after) t)
+                            (equal before-id after-id))
+                 (user-error "Refusing to trash workspace %s; %s changed while it was validated"
+                             name root))
+               (list :name name :root root :existed t :identity before-id))))))))
+   root-alist))
+
+(defun majutsu-workspace--trash-target-failure (target reason)
+  "Return a failure plist for TARGET with REASON."
+  (list :name (plist-get target :name)
+        :root (plist-get target :root)
+        :reason reason))
+
+(defun majutsu-workspace--quoted-root (root)
+  "Return ROOT quoted with control characters escaped for messages."
+  (let ((print-escape-control-characters t)
+        (print-escape-newlines t))
+    (prin1-to-string root)))
+
+(defun majutsu-workspace--trash-roots (targets)
+  "Move identity-bound TARGETS to the system trash.
+
+TARGETS must come from `majutsu-workspace--prepare-trash-targets'.  Every
+target is checked again after `jj workspace forget'.  A path that appeared,
+disappeared, changed device/inode, or became a shared repo-store owner is not
+deleted.  Continue after individual failures and return all failure plists."
+  (let (failures)
+    (dolist (target targets)
+      (condition-case err
+          (let* ((root (plist-get target :root))
+                 (existed (plist-get target :existed))
+                 (identity (plist-get target :identity))
+                 (attributes (and root
+                                  (not (string-empty-p root))
+                                  (file-attributes root 'integer))))
+            (cond
+             ((and (not existed) (null attributes)))
+             ((not existed)
+              (push (majutsu-workspace--trash-target-failure
+                     target "a filesystem object appeared there after confirmation")
+                    failures))
+             ((null attributes)
+              (push (majutsu-workspace--trash-target-failure
+                     target "the confirmed directory disappeared")
+                    failures))
+             ((or (not (eq (file-attribute-type attributes) t))
+                  (not (equal identity
+                              (majutsu-workspace--directory-identity attributes))))
+              (push (majutsu-workspace--trash-target-failure
+                     target "the directory identity changed after confirmation")
+                    failures))
+             ((majutsu-workspace--repo-store-p root)
+              (push (majutsu-workspace--trash-target-failure
+                     target "the directory now owns the shared .jj/repo store")
+                    failures))
+             (t
+              (let ((delete-by-moving-to-trash t))
+                (delete-directory root t t)))))
+        (error
+         (push (majutsu-workspace--trash-target-failure
+                target (error-message-string err))
+               failures))))
+    (nreverse failures)))
+
+(defun majutsu-workspace--signal-trash-failures (failures)
+  "Signal one user error that reports every entry in FAILURES."
+  (when failures
+    (user-error
+     "Workspace forget succeeded, but these directories were not moved to trash:\n%s\nMove them manually"
+     (mapconcat
+      (lambda (failure)
+        (format "- %s (%s): %s"
+                (plist-get failure :name)
+                (majutsu-workspace--quoted-root
+                 (plist-get failure :root))
+                (plist-get failure :reason)))
+      failures "\n"))))
+
+(defun majutsu-workspace--trash-target-label (target)
+  "Return a confirmation label for identity-bound TARGET."
+  (let ((name (plist-get target :name))
+        (root (plist-get target :root)))
+    (if (and root (not (string-empty-p root)))
+        (format "%s at %s" name (majutsu-workspace--quoted-root root))
+      (format "%s (root unavailable)" name))))
 
 (defun majutsu-workspace--transient-trash-p ()
   "Return non-nil when the active workspace transient has `--trash' enabled."
@@ -395,10 +492,16 @@ state."
   "Return the workspace root directory for NAME, or nil.
 
 This calls `jj workspace root --name NAME' (available since jj v0.38.0)
-and returns a directory name with a trailing slash."
-  (let ((line (car (majutsu-jj-lines "workspace" "root" "--name" name))))
-    (when (and line (not (string-empty-p line)))
-      (majutsu-jj-expand-directory-from-jj line default-directory))))
+and returns a directory name with a trailing slash.  Only the one newline
+written by jj is removed; embedded or trailing newlines belonging to the
+actual path are preserved."
+  (let ((output (or (majutsu-jj-buffer-string
+                     "workspace" "root" "--name" name)
+                    "")))
+    (when (string-suffix-p "\n" output)
+      (setq output (substring output 0 -1)))
+    (when (not (string-empty-p output))
+      (majutsu-jj-expand-directory-from-jj output default-directory))))
 
 (defun majutsu-workspace--sibling-root (name root)
   "Return a sibling directory of ROOT named NAME if it is a matching workspace.
@@ -582,18 +685,23 @@ workspace roots only."
     (let* ((action (if trash 'workspace-trash 'workspace-forget))
            (root-alist (when trash
                          (majutsu-workspace--roots-for-names
-                          names (majutsu--toplevel-safe)))))
-      (when trash
-        (majutsu-workspace--validate-trash-roots root-alist))
+                          names (majutsu--toplevel-safe))))
+           (trash-targets (when trash
+                            (majutsu-workspace--prepare-trash-targets root-alist))))
       (unless (majutsu-confirm action
                                (format "%s workspace(s) %s? "
                                        (if trash "Forget and trash" "Forget")
-                                       (string-join names ", ")))
+                                       (if trash
+                                           (mapconcat
+                                            #'majutsu-workspace--trash-target-label
+                                            trash-targets ", ")
+                                         (string-join names ", "))))
         (user-error "Forget canceled"))
       (if (zerop (apply #'majutsu-run-jj (append '("workspace" "forget") names)))
           (progn
             (when trash
-              (majutsu-workspace--trash-roots root-alist))
+              (majutsu-workspace--signal-trash-failures
+               (majutsu-workspace--trash-roots trash-targets)))
             (message (if trash
                          "Workspace(s) forgotten; available directories trashed"
                        "Workspace(s) forgotten")))

--- a/test/majutsu-diff-test.el
+++ b/test/majutsu-diff-test.el
@@ -165,6 +165,136 @@
         (should-not (string-match-p (regexp-quote "\e[")
                                     (buffer-string)))))))
 
+(ert-deftest majutsu-diff-file-metadata/preserves-ambiguous-and-quoted-paths ()
+  "JSON sidecar parsing must preserve paths Git display syntax cannot delimit."
+  (let* ((output (concat
+                  "[\"renamed\",\"foo b/bar.bin\","
+                  "\"literal\\\"old.bin\",\"foo b/bar.bin\"]\n"
+                  "[\"copied\",\"line\\nbreak.bin\","
+                  "\"source.bin\",\"line\\nbreak.bin\"]\n"))
+         (entries (majutsu-diff--parse-file-metadata-output output)))
+    (should (equal entries
+                   '((:status "renamed" :path "foo b/bar.bin"
+                      :source "literal\"old.bin" :target "foo b/bar.bin")
+                     (:status "copied" :path "line\nbreak.bin"
+                      :source "source.bin" :target "line\nbreak.bin"))))))
+
+(ert-deftest majutsu-diff-file-metadata/validates-git-c-quoted-controls ()
+  "Header validation should understand Git escapes without sourcing paths from them."
+  (let* ((path (concat "café\t\"" (string 7)))
+         (header (concat
+                  "diff --git \"a/caf\\303\\251\\t\\042\\a\" "
+                  "\"b/caf\\303\\251\\t\\042\\a\"\n"))
+         (entry (list :status "modified" :path path
+                      :source path :target path)))
+    (should (majutsu-diff--git-header-paths-match-p header entry))
+    (should-not (majutsu-diff--git-quoted-token-value "\"\\777\""))))
+
+(ert-deftest majutsu-diff-file-metadata/query-matches-range-and-filesets ()
+  "The sidecar query must use the displayed diff's exact range and filesets."
+  (let (seen)
+    (cl-letf (((symbol-function 'majutsu-jj-insert)
+               (lambda (&rest args)
+                 (setq seen args)
+                 (insert "[\"modified\",\"src/a.el\",\"src/a.el\",\"src/a.el\"]\n")
+                 0)))
+      (should (equal
+               (majutsu-diff--query-file-metadata
+                '("--from=A" "--to=B") '("src/a.el"))
+               '((:status "modified" :path "src/a.el"
+                  :source "src/a.el" :target "src/a.el"))))
+      (should (equal (seq-take seen 4)
+                     (list "--ignore-working-copy" "diff" "-T"
+                           majutsu-diff--file-metadata-template)))
+      (should (equal (seq-drop seen 4)
+                     '("--from=A" "--to=B" "--" "src/a.el"))))))
+
+(ert-deftest majutsu-diff-file-metadata/count-mismatch-fails-closed ()
+  "Metadata is not attached when its count differs from washed file sections."
+  (with-temp-buffer
+    (magit-section-mode)
+    (let ((inhibit-read-only t)
+          (magit-section-inhibit-markers t))
+      (magit-insert-section (root)
+        (insert "diff --git a/one.bin b/one.bin\nnew file mode 100644\nBinary files /dev/null and b/one.bin differ\n")
+        (save-restriction
+          (narrow-to-region (point-min) (point-max))
+          (majutsu-diff-wash-diffs '("--git"))))
+      (let ((section (car (oref magit-root-section children))))
+        (majutsu-diff--attach-file-metadata
+         '((:status "added" :path "one.bin" :source "one.bin" :target "one.bin")
+           (:status "added" :path "two.bin" :source "two.bin" :target "two.bin")))
+        (should-not (majutsu-diff-file-metadata section))))))
+
+(ert-deftest majutsu-diff-file-metadata/reordered-sidecar-fails-closed ()
+  "Equal counts must not authorize reordered sidecar entries."
+  (with-temp-buffer
+    (magit-section-mode)
+    (let ((inhibit-read-only t)
+          (magit-section-inhibit-markers t))
+      (magit-insert-section (root)
+        (insert "diff --git a/one.bin b/one.bin\nindex 1..2 100644\nBinary files a/one.bin and b/one.bin differ\n"
+                "diff --git a/two.bin b/two.bin\nindex 3..4 100644\nBinary files a/two.bin and b/two.bin differ\n")
+        (save-restriction
+          (narrow-to-region (point-min) (point-max))
+          (majutsu-diff-wash-diffs '("--git"))))
+      (let ((sections (oref magit-root-section children)))
+        (majutsu-diff--attach-file-metadata
+         '((:status "modified" :path "two.bin"
+            :source "two.bin" :target "two.bin")
+           (:status "modified" :path "one.bin"
+            :source "one.bin" :target "one.bin")))
+        (should-not (seq-some #'majutsu-diff-file-metadata sections))))))
+
+(ert-deftest majutsu-diff-file-metadata/raw-order-validation-rejects-reorder ()
+  "Pre-wash validation must reject same-count metadata in a different order."
+  (with-temp-buffer
+    (insert "diff --git a/one.bin b/one.bin\nindex 1..2 100644\nBinary files a/one.bin and b/one.bin differ\n"
+            "diff --git a/two.bin b/two.bin\nindex 3..4 100644\nBinary files a/two.bin and b/two.bin differ\n")
+    (let* ((one '(:status "modified" :path "one.bin"
+                  :source "one.bin" :target "one.bin"))
+           (two '(:status "modified" :path "two.bin"
+                  :source "two.bin" :target "two.bin")))
+      (should (majutsu-diff--raw-file-metadata-consistent-p (list one two)))
+      (should-not
+       (majutsu-diff--raw-file-metadata-consistent-p (list two one))))))
+
+(ert-deftest majutsu-diff-wash-file/accepts-quoted-git-display-header ()
+  "A quoted Git display header should still form a section for sidecar binding."
+  (with-temp-buffer
+    (magit-section-mode)
+    (let ((inhibit-read-only t)
+          (magit-section-inhibit-markers t))
+      (magit-insert-section (root)
+        (insert "diff --git \"a/old\\\"name.bin\" \"b/new\\\"name.bin\"\n"
+                "similarity index 100%\nrename from old\nrename to new\n")
+        (save-restriction
+          (narrow-to-region (point-min) (point-max))
+          (majutsu-diff-wash-diffs '("--git"))))
+      (let ((section (car (oref magit-root-section children)))
+            (metadata '(:status "renamed" :path "new\"name.bin"
+                        :source "old\"name.bin" :target "new\"name.bin")))
+        (should (oref section header))
+        (majutsu-diff--attach-file-metadata (list metadata))
+        (should (equal (oref section value) "new\"name.bin"))
+        (should (equal (majutsu-diff-file-metadata section) metadata))))))
+
+(ert-deftest majutsu-diff-wash-diffs/malformed-header-always-advances ()
+  "A future or malformed `diff --git' header must not trap the washer loop."
+  (with-temp-buffer
+    (magit-section-mode)
+    (let ((inhibit-read-only t)
+          (magit-section-inhibit-markers t))
+      (magit-insert-section (root)
+        (insert "diff --git malformed-header\nunrecognized extended data\n"
+                "diff --git a/good.bin b/good.bin\nindex 1..2 100644\n"
+                "Binary files a/good.bin and b/good.bin differ\n")
+        (save-restriction
+          (narrow-to-region (point-min) (point-max))
+          (with-timeout (1 (ert-fail "diff washer did not advance"))
+            (majutsu-diff-wash-diffs '("--git")))))
+      (should (= (length (oref magit-root-section children)) 2)))))
+
 (ert-deftest majutsu-insert-diff/puts-filesets-after-separator ()
   "Diff command construction should pass filesets after --."
   (let (called heading)

--- a/test/majutsu-interactive-test.el
+++ b/test/majutsu-interactive-test.el
@@ -13,8 +13,8 @@
 (require 'ert)
 (require 'majutsu-interactive)
 
-(defun majutsu-interactive-test--insert-diff (diff &optional file)
-  "Wash DIFF and return its real jj-file section, optionally matching FILE."
+(defun majutsu-interactive-test--insert-diff (diff &optional file metadata)
+  "Wash DIFF, attach METADATA, and return the real section matching FILE."
   (majutsu-diff-mode)
   (let ((inhibit-read-only t)
         (magit-section-inhibit-markers t))
@@ -22,7 +22,9 @@
       (insert diff)
       (save-restriction
         (narrow-to-region (point-min) (point-max))
-        (majutsu-diff-wash-diffs '("--git")))))
+        (majutsu-diff-wash-diffs '("--git"))))
+    (when metadata
+      (majutsu-diff--attach-file-metadata metadata)))
   (let (result)
     (magit-map-sections
      (lambda (section)
@@ -46,9 +48,9 @@
   "Patch runner should keep jj options before filesets."
   (let (called)
     (cl-letf (((symbol-function 'majutsu-interactive--write-patch)
-               (lambda (_patch) "/tmp/patch.diff"))
+               (lambda (_patch &optional _directory) "/tmp/patch.diff"))
               ((symbol-function 'majutsu-interactive--build-tool-config)
-               (lambda (_patch-file _reverse &optional _file-ops)
+               (lambda (_patch-file _reverse &optional _file-ops _directory)
                  '("--config" "merge-tools.majutsu-applypatch.program=/tmp/applypatch")))
               ((symbol-function 'majutsu-run-jj-with-editor)
                (lambda (&rest args)
@@ -65,9 +67,9 @@
   "Patch runner should also normalize transient-files groups."
   (let (called)
     (cl-letf (((symbol-function 'majutsu-interactive--write-patch)
-               (lambda (_patch) "/tmp/patch.diff"))
+               (lambda (_patch &optional _directory) "/tmp/patch.diff"))
               ((symbol-function 'majutsu-interactive--build-tool-config)
-               (lambda (_patch-file _reverse &optional _file-ops)
+               (lambda (_patch-file _reverse &optional _file-ops _directory)
                  '("--config" "tool=config")))
               ((symbol-function 'majutsu-run-jj-with-editor)
                (lambda (&rest args)
@@ -84,7 +86,7 @@
   "Tool config should pass local remote paths to jj merge-tool args."
   (let ((config
          (cl-letf (((symbol-function 'majutsu-interactive--write-applypatch-script)
-                    (lambda (_reverse &optional _file-ops)
+                    (lambda (_reverse &optional _file-ops _directory)
                       "/ssh:demo:/tmp/applypatch.sh"))
                    ((symbol-function 'majutsu-convert-filename-for-jj)
                     (lambda (path)
@@ -100,89 +102,146 @@
     (should-not (string-match-p "/ssh:demo:" (nth 1 config)))
     (should-not (string-match-p "/ssh:demo:" (nth 3 config)))))
 
-(ert-deftest majutsu-interactive--temp-dir/uses-nearby-temp-file ()
-  "Temp dir helper should allocate directories near current workspace."
-  (let ((majutsu-interactive--temp-dir nil)
-        (majutsu-interactive--temp-dir-remote nil)
-        seen)
-    (cl-letf (((symbol-function 'file-directory-p)
-               (lambda (_path) nil))
-              ((symbol-function 'make-nearby-temp-file)
+(ert-deftest majutsu-interactive--make-operation-temp-dir/uses-nearby-temp-file ()
+  "Each operation should allocate a nearby private directory."
+  (let (seen)
+    (cl-letf (((symbol-function 'make-nearby-temp-file)
                (lambda (prefix dir-flag &optional suffix)
                  (setq seen (list prefix dir-flag suffix))
                  "/tmp/majutsu-interactive-dir")))
-      (should (equal (majutsu-interactive--temp-dir)
+      (should (equal (majutsu-interactive--make-operation-temp-dir)
                      "/tmp/majutsu-interactive-dir"))
       (should (equal seen '("majutsu-interactive-" t nil))))))
 
-(ert-deftest majutsu-interactive--temp-dir/recreates-when-remote-prefix-changes ()
-  "Temp dir cache should be invalidated when host context changes."
-  (let ((default-directory "/tmp/")
-        (majutsu-interactive--temp-dir nil)
-        (majutsu-interactive--temp-dir-remote nil)
-        seen)
-    (cl-letf (((symbol-function 'file-directory-p)
-               (lambda (_path) t))
-              ((symbol-function 'file-remote-p)
-               (lambda (path &optional identification _connected)
-                 (when (and (equal path default-directory)
-                            (null identification))
-                   (if (string-prefix-p "/ssh:demo:" default-directory)
-                       "/ssh:demo:"
-                     nil))))
-              ((symbol-function 'make-nearby-temp-file)
-               (lambda (_prefix _dir-flag &optional _suffix)
-                 (let ((value (format "/tmp/majutsu-interactive-%d" (length seen))))
-                   (push value seen)
-                   value))))
-      (let ((local (majutsu-interactive--temp-dir)))
-        (setq default-directory "/ssh:demo:/tmp/")
-        (let ((remote (majutsu-interactive--temp-dir)))
-          (should (not (equal local remote)))
-          (should (equal (length seen) 2)))))))
+(ert-deftest majutsu-interactive-run-with-patch/uses-private-directory-per-run ()
+  "Overlapping async operations must never share patch or helper paths."
+  (let (created writes configs cleaned)
+    (cl-letf (((symbol-function 'majutsu-interactive--make-operation-temp-dir)
+               (lambda ()
+                 (let ((dir (format "/tmp/majutsu-operation-%d" (length created))))
+                   (push dir created)
+                   dir)))
+              ((symbol-function 'majutsu-interactive--write-patch)
+               (lambda (_patch &optional directory)
+                 (push directory writes)
+                 (expand-file-name "patch.diff" directory)))
+              ((symbol-function 'majutsu-interactive--build-tool-config)
+               (lambda (_patch _reverse &optional _ops directory)
+                 (push directory configs)
+                 nil))
+              ((symbol-function 'majutsu-run-jj-with-editor)
+               (lambda (&rest _args) nil))
+              ((symbol-function 'majutsu-interactive--delete-operation-temp-dir)
+               (lambda (directory) (push directory cleaned))))
+      (majutsu-interactive-run-with-patch "split" nil nil "one")
+      (majutsu-interactive-run-with-patch "split" nil nil "two")
+      (should (= (length (delete-dups (copy-sequence created))) 2))
+      (should (equal writes configs))
+      (should (= (length cleaned) 2)))))
+
+(ert-deftest majutsu-interactive-retain-temp-dir/closes-installation-race ()
+  "An exit between liveness check and sentinel install cleans immediately."
+  (let ((checks 0)
+        installed
+        cleaned
+        properties
+        (original (lambda (&rest _))))
+    (cl-letf (((symbol-function 'processp) (lambda (_process) t))
+              ((symbol-function 'process-live-p)
+               (lambda (_process) (= (cl-incf checks) 1)))
+              ((symbol-function 'process-sentinel)
+               (lambda (_process) original))
+              ((symbol-function 'process-put)
+               (lambda (_process key value)
+                 (setf (alist-get key properties) value)))
+              ((symbol-function 'set-process-sentinel)
+               (lambda (_process sentinel) (push sentinel installed)))
+              ((symbol-function 'majutsu-interactive--delete-operation-temp-dir)
+               (lambda (directory) (push directory cleaned))))
+      (should (majutsu-interactive--retain-temp-dir-for-process
+               'fake "/tmp/private-operation"))
+      (should (= checks 2))
+      (should (equal installed
+                     (list original
+                           #'majutsu-interactive--temp-dir-process-sentinel)))
+      (should (equal cleaned '("/tmp/private-operation")))
+      (should-not (alist-get 'majutsu-interactive-temp-dir properties))
+      (should-not
+       (alist-get 'majutsu-interactive-original-sentinel properties)))))
+
+(ert-deftest majutsu-interactive-temp-dir-sentinel/cleans-on-exit-and-signal ()
+  "The wrapper runs the original sentinel and cleans for both terminal states."
+  (dolist (status '(exit signal))
+    (let (original-called cleaned)
+      (cl-letf (((symbol-function 'process-get)
+                 (lambda (_process key)
+                   (pcase key
+                     ('majutsu-interactive-original-sentinel
+                      (lambda (&rest _) (setq original-called t)))
+                     ('majutsu-interactive-temp-dir "/tmp/private-operation"))))
+                ((symbol-function 'process-status) (lambda (_process) status))
+                ((symbol-function 'majutsu-interactive--delete-operation-temp-dir)
+                 (lambda (directory) (setq cleaned directory))))
+        (majutsu-interactive--temp-dir-process-sentinel 'fake "done")
+        (should original-called)
+        (should (equal cleaned "/tmp/private-operation"))))))
 
 (ert-deftest majutsu-interactive-file-operation/parses-explicit-actions ()
-  "Whole-file actions must come from diff metadata, including rename/copy."
+  "Whole-file actions must come only from structured jj metadata."
   (dolist
       (case
        '(("diff --git a/add.bin b/add.bin\nnew file mode 100644\nBinary files /dev/null and b/add.bin differ\n"
-          "add.bin" (:action add :path "add.bin"))
+          "add.bin" (:status "added" :path "add.bin" :source "add.bin" :target "add.bin")
+          (:action add :path "add.bin"))
          ("diff --git a/mod.bin b/mod.bin\nindex 123..456 100644\nBinary files a/mod.bin and b/mod.bin differ\n"
-          "mod.bin" (:action modify :path "mod.bin"))
+          "mod.bin" (:status "modified" :path "mod.bin" :source "mod.bin" :target "mod.bin")
+          (:action modify :path "mod.bin"))
          ("diff --git a/del.bin b/del.bin\ndeleted file mode 100644\nBinary files a/del.bin and /dev/null differ\n"
-          "del.bin" (:action delete :path "del.bin"))
+          "del.bin" (:status "removed" :path "del.bin" :source "del.bin" :target "del.bin")
+          (:action delete :path "del.bin"))
          ("diff --git a/old.bin b/new.bin\nsimilarity index 100%\nrename from old.bin\nrename to new.bin\n"
-          "new.bin" (:action rename :source "old.bin" :path "new.bin"))
+          "new.bin" (:status "renamed" :path "new.bin" :source "old.bin" :target "new.bin")
+          (:action rename :source "old.bin" :path "new.bin"))
          ("diff --git a/src.bin b/copy.bin\nsimilarity index 100%\ncopy from src.bin\ncopy to copy.bin\n"
-          "copy.bin" (:action copy :source "src.bin" :path "copy.bin"))
-         ("diff --git a/x b/x\nsimilarity index 100%\nrename from \"old\\040name.bin\"\nrename to \"new\\040name.bin\"\n"
-          "x" (:action rename :source "old name.bin" :path "new name.bin"))
-         ("diff --git a/x b/x\nsimilarity index 100%\ncopy from \"src\\042quote\\134path.bin\"\ncopy to \"dst\\040name.bin\"\n"
-          "x" (:action copy :source "src\"quote\\path.bin"
-               :path "dst name.bin"))))
+          "copy.bin" (:status "copied" :path "copy.bin" :source "src.bin" :target "copy.bin")
+          (:action copy :source "src.bin" :path "copy.bin"))
+         ("diff --git a/foo b/bar.bin b/foo b/bar.bin\nindex 123..456 100644\nBinary files a/foo b/bar.bin and b/foo b/bar.bin differ\n"
+          "foo b/bar.bin"
+          (:status "modified" :path "foo b/bar.bin"
+           :source "foo b/bar.bin" :target "foo b/bar.bin")
+          (:action modify :path "foo b/bar.bin"))
+         ("diff --git \"a/literal\\\"old.bin\" \"b/literal\\\"new.bin\"\nsimilarity index 100%\nrename from \"literal\\\"old.bin\"\nrename to \"literal\\\"new.bin\"\n"
+          "literal\"new.bin"
+          (:status "renamed" :path "literal\"new.bin"
+           :source "literal\"old.bin" :target "literal\"new.bin")
+          (:action rename :source "literal\"old.bin"
+           :path "literal\"new.bin"))))
     (with-temp-buffer
-      (pcase-let ((`(,diff ,file ,expected) case))
-        (let ((section (majutsu-interactive-test--insert-diff diff file)))
+      (pcase-let ((`(,diff ,file ,metadata ,expected) case))
+        (let ((section (majutsu-interactive-test--insert-diff
+                        diff file (list metadata))))
           (should section)
           (should (equal (majutsu-interactive--file-operation section)
                          expected)))))))
 
-(ert-deftest majutsu-interactive-header-path/rejects-malformed-git-quoting ()
-  "Malformed Git C-style paths must not silently become filesystem paths."
-  (should-error
-   (majutsu-interactive--header-path
-    "rename from \"unterminated\\040path\n" "rename from ")
-   :type 'user-error)
-  (should-error
-   (majutsu-interactive--header-path
-    "copy from \"valid\"trailing\n" "copy from ")
-   :type 'user-error))
+(ert-deftest majutsu-interactive-toggle-file/fails-closed-without-machine-metadata ()
+  "Rendered Git headers alone must never authorize a whole-file operation."
+  (with-temp-buffer
+    (let* ((diff "diff --git a/bin.dat b/bin.dat\nnew file mode 100644\nBinary files /dev/null and b/bin.dat differ\n")
+           (section (majutsu-interactive-test--insert-diff diff "bin.dat"))
+           (transient-current-command 'majutsu-split))
+      (goto-char (oref section start))
+      (should-error (majutsu-interactive-toggle-file) :type 'user-error)
+      (should-not (majutsu-interactive-has-selections-p)))))
 
 (ert-deftest majutsu-interactive-toggle-file/selects-hunkless-file-for-split ()
   "A binary file section is selectable as a whole-file split operation."
   (with-temp-buffer
     (let* ((diff "diff --git a/bin.dat b/bin.dat\nnew file mode 100644\nBinary files /dev/null and b/bin.dat differ\n")
-           (section (majutsu-interactive-test--insert-diff diff "bin.dat"))
+           (section (majutsu-interactive-test--insert-diff
+                     diff "bin.dat"
+                     '((:status "added" :path "bin.dat"
+                        :source "bin.dat" :target "bin.dat"))))
            (transient-current-command 'majutsu-split))
       (goto-char (oref section start))
       (majutsu-interactive-toggle-file)
@@ -210,7 +269,12 @@
                   "@@ -10 +10 @@\n-old two\n+unselected two\n"
                   "diff --git a/bin.dat b/bin.dat\nnew file mode 100644\n"
                   "Binary files /dev/null and b/bin.dat differ\n"))
-           (text (majutsu-interactive-test--insert-diff diff "text.txt"))
+           (text (majutsu-interactive-test--insert-diff
+                  diff "text.txt"
+                  '((:status "modified" :path "text.txt"
+                     :source "text.txt" :target "text.txt")
+                    (:status "added" :path "bin.dat"
+                     :source "bin.dat" :target "bin.dat"))))
            (binary (majutsu-interactive--file-section-for-file "bin.dat"))
            (hunk (car (majutsu-interactive--file-section-hunks text))))
       (majutsu-interactive--set-selection
@@ -231,10 +295,13 @@
          (right (expand-file-name "right" dir))
          (patch-file (expand-file-name "patch.diff" dir))
          (ops '((:action add :path "added.bin")
+                (:action add :path "line\nbreak.bin")
                 (:action modify :path "modified.bin")
                 (:action delete :path "deleted.bin")
                 (:action delete :path "collision")
                 (:action rename :source "old.bin" :path "renamed.bin")
+                (:action rename :source "literal\"old.bin"
+                 :path "literal\"new.bin")
                 (:action copy :source "source.bin" :path "copied.bin"))))
     (unwind-protect
         (progn
@@ -245,13 +312,16 @@
                            ("deleted.bin" . "delete-me")
                            ("collision" . "left-file")
                            ("old.bin" . "rename-me")
+                           ("literal\"old.bin" . "quoted-rename")
                            ("source.bin" . "copy-me")))
             (with-temp-file (expand-file-name (car entry) left)
               (insert (cdr entry))))
           (dolist (entry '(("text.txt" . "unselected-right\n")
                            ("added.bin" . "added")
+                           ("line\nbreak.bin" . "newline")
                            ("modified.bin" . "new-mod")
                            ("renamed.bin" . "rename-me")
+                           ("literal\"new.bin" . "quoted-rename")
                            ("source.bin" . "copy-me")
                            ("copied.bin" . "copy-me")
                            ("unselected.bin" . "must-disappear")))
@@ -264,11 +334,8 @@
             (insert "unrelated"))
           (with-temp-file patch-file
             (insert "diff --git a/text.txt b/text.txt\n--- a/text.txt\n+++ b/text.txt\n@@ -1 +1 @@\n-old\n+selected\n"))
-          (let (script)
-            (cl-letf (((symbol-function 'majutsu-interactive--temp-dir)
-                       (lambda () dir)))
-              (setq script
-                    (majutsu-interactive--write-applypatch-script t ops)))
+          (let ((script (majutsu-interactive--write-applypatch-script
+                         t ops dir)))
             (should (zerop (call-process script nil nil nil
                                          left right patch-file))))
           (should (equal (majutsu-interactive-test--file-contents
@@ -277,18 +344,90 @@
           (should (equal (majutsu-interactive-test--file-contents
                           (expand-file-name "added.bin" right)) "added"))
           (should (equal (majutsu-interactive-test--file-contents
+                          (expand-file-name "line\nbreak.bin" right)) "newline"))
+          (should (equal (majutsu-interactive-test--file-contents
                           (expand-file-name "modified.bin" right)) "new-mod"))
           (should-not (file-exists-p (expand-file-name "deleted.bin" right)))
           (should-not (file-exists-p (expand-file-name "collision" right)))
           (should-not (file-exists-p (expand-file-name "old.bin" right)))
           (should (equal (majutsu-interactive-test--file-contents
                           (expand-file-name "renamed.bin" right)) "rename-me"))
+          (should-not (file-exists-p
+                       (expand-file-name "literal\"old.bin" right)))
+          (should (equal (majutsu-interactive-test--file-contents
+                          (expand-file-name "literal\"new.bin" right))
+                         "quoted-rename"))
           (should (equal (majutsu-interactive-test--file-contents
                           (expand-file-name "source.bin" right)) "copy-me"))
           (should (equal (majutsu-interactive-test--file-contents
                           (expand-file-name "copied.bin" right)) "copy-me"))
           (should-not (file-exists-p (expand-file-name "unselected.bin" right))))
       (delete-directory dir t))))
+
+(ert-deftest majutsu-interactive/integration-machine-paths-with-minimum-jj ()
+  "Exercise sidecar binding against the jj binary named by MAJUTSU_TEST_JJ."
+  (let ((jj (getenv "MAJUTSU_TEST_JJ")))
+    (skip-unless (and jj (file-executable-p jj)))
+    (let* ((parent (make-temp-file "majutsu-jj-integration-" t))
+           (repo (expand-file-name "repo" parent)))
+      (unwind-protect
+          (progn
+            (should (zerop (call-process jj nil nil nil "git" "init" repo)))
+            (let* ((default-directory (file-name-as-directory repo))
+                   (majutsu-jj-executable jj)
+                   (odd "foo b/bar.bin")
+                   (old "literal\"old.bin")
+                   (new "literal\"new.bin")
+                   (odd-file (expand-file-name odd repo))
+                   (old-file (expand-file-name old repo))
+                   (new-file (expand-file-name new repo)))
+              (make-directory (file-name-directory odd-file) t)
+              (cl-labels ((write-bytes
+                           (file bytes)
+                           (with-temp-buffer
+                             (set-buffer-multibyte nil)
+                             (insert bytes)
+                             (let ((coding-system-for-write 'binary))
+                               (write-region (point-min) (point-max)
+                                             file nil 'silent)))))
+                (write-bytes odd-file (unibyte-string 0 1 2))
+                (with-temp-file old-file (insert "rename me"))
+                (should (zerop (call-process jj nil nil nil
+                                             "commit" "-m" "base")))
+                (write-bytes odd-file (unibyte-string 0 3 4))
+                (rename-file old-file new-file))
+              ;; The rendered diff snapshots first; the sidecar intentionally
+              ;; reads that snapshot without doing a second one.
+              (let* ((git-output (majutsu-jj-buffer-string "diff" "--git"))
+                     (metadata (majutsu-diff--query-file-metadata nil nil)))
+                (with-temp-buffer
+                  (majutsu-diff-mode)
+                  (let ((inhibit-read-only t)
+                        (magit-section-inhibit-markers t)
+                        (majutsu-diff--active-file-metadata metadata)
+                        (majutsu-diff--file-metadata-queue
+                         (copy-sequence metadata)))
+                    (magit-insert-section (root)
+                      (insert git-output)
+                      (save-restriction
+                        (narrow-to-region (point-min) (point-max))
+                        (majutsu-diff-wash-diffs '("--git")))))
+                  (majutsu-diff--attach-file-metadata metadata)
+                  (let ((odd-section (majutsu-interactive--file-section-for-file odd))
+                        (rename-section
+                         (majutsu-interactive--file-section-for-file new)))
+                    (unless odd-section
+                      (ert-fail (format "odd path not bound; metadata=%S git=%S"
+                                        metadata git-output)))
+                    (unless rename-section
+                      (ert-fail (format "rename path not bound; metadata=%S git=%S"
+                                        metadata git-output)))
+                    (should (equal (majutsu-interactive--file-operation odd-section)
+                                   `(:action modify :path ,odd)))
+                    (should (equal
+                             (majutsu-interactive--file-operation rename-section)
+                             `(:action rename :source ,old :path ,new))))))))
+        (delete-directory parent t)))))
 
 (provide 'majutsu-interactive-test)
 ;;; majutsu-interactive-test.el ends here

--- a/test/majutsu-workspace-test.el
+++ b/test/majutsu-workspace-test.el
@@ -18,6 +18,12 @@
 (require 'ert)
 (require 'majutsu-workspace)
 
+(defun majutsu-workspace-test--row (&rest fields)
+  "Return one JSON-encoded structured workspace row for FIELDS."
+  (concat (mapconcat #'json-serialize fields
+                     majutsu-workspace--field-separator)
+          "\n"))
+
 (ert-deftest majutsu-workspace-template-plan/default-fields ()
   "The default workspace template plan should transport the default fields."
   (let ((plan (majutsu-workspace--ensure-template-plan)))
@@ -26,11 +32,12 @@
 
 (ert-deftest majutsu-workspace-parse-list-output/basic ()
   "Parse structured `jj workspace list -T ...` output."
-  (let* ((sep majutsu-workspace--field-separator)
-         (default-directory "/tmp/main/")
+  (let* ((default-directory "/tmp/main/")
          (output (concat
-                  "@" sep "default" sep "wnurqwps" sep "6acd46b7" sep "Main wc" sep "/tmp/main" "\n"
-                  ""  sep "w2"      sep "lvolzxkz" sep "32e07e11" sep ""        sep "/tmp/w2"   "\n"))
+                  (majutsu-workspace-test--row
+                   "@" "default" "wnurqwps" "6acd46b7" "Main wc" "/tmp/main")
+                  (majutsu-workspace-test--row
+                   "" "w2" "lvolzxkz" "32e07e11" "" "/tmp/w2")))
          (entries (majutsu-workspace-parse-list-output output)))
     (should (equal (length entries) 2))
     (should (equal (plist-get (nth 0 entries) :name) "default"))
@@ -49,7 +56,8 @@
   (let* ((sep majutsu-workspace--field-separator)
          (default-directory "/tmp/main/")
          (output (concat
-                  "@" sep "default" sep "wnurqwps" sep "6acd46b7" sep "Main wc"
+                  "\"@\"" sep "\"default\"" sep "\"wnurqwps\"" sep
+                  "\"6acd46b7\"" sep "\"Main wc\""
                   sep "<Error: Failed to resolve workspace root>" "\n"))
          (entries (majutsu-workspace-parse-list-output output)))
     (should (equal (length entries) 1))
@@ -58,9 +66,9 @@
 (ert-deftest majutsu-workspace-parse-list-output/root-preserves-remote-prefix ()
   "Structured workspace roots should keep the current TRAMP prefix."
   (let ((default-directory "/ssh:demo:/tmp/main/"))
-    (let* ((sep majutsu-workspace--field-separator)
-           (output (concat "@" sep "default" sep "wnurqwps" sep "6acd46b7" sep "Main wc"
-                           sep "/home/demo/repo-main" "\n"))
+    (let* ((output (majutsu-workspace-test--row
+                    "@" "default" "wnurqwps" "6acd46b7" "Main wc"
+                    "/home/demo/repo-main"))
            (entries (majutsu-workspace-parse-list-output output)))
       (should (equal (plist-get (car entries) :root)
                      "/ssh:demo:/home/demo/repo-main/")))))
@@ -70,12 +78,12 @@
   (let* ((sep majutsu-workspace--field-separator)
          (default-directory "/tmp/main/")
          (output (concat
-                  "\x1b[1m@\x1b[0m" sep
-                  "\x1b[35mdefault\x1b[0m" sep
-                  "\x1b[36mwnurqwps\x1b[0m" sep
-                  "\x1b[32m6acd46b7\x1b[0m" sep
-                  "\x1b[33mMain wc\x1b[0m" sep
-                  "\x1b[34m/tmp/main\x1b[0m\n"))
+                  "\x1b[1m\"@\"\x1b[0m" sep
+                  "\x1b[35m\"default\"\x1b[0m" sep
+                  "\x1b[36m\"wnurqwps\"\x1b[0m" sep
+                  "\x1b[32m\"6acd46b7\"\x1b[0m" sep
+                  "\x1b[33m\"Main wc\"\x1b[0m" sep
+                  "\x1b[34m\"/tmp/main\"\x1b[0m\n"))
          (entries (majutsu-workspace-parse-list-output output)))
     (should (equal (length entries) 1))
     (should (equal (plist-get (car entries) :name) "default"))
@@ -84,6 +92,18 @@
     (should (equal (plist-get (car entries) :commit-id) "6acd46b7"))
     (should (equal (plist-get (car entries) :desc) "Main wc"))
     (should (equal (plist-get (car entries) :root) "/tmp/main/"))))
+
+(ert-deftest majutsu-workspace-parse-list-output/preserves-control-characters ()
+  "JSON transport must not split a legal root containing newline or separators."
+  (let* ((default-directory "/tmp/main/")
+         (root (concat "/tmp/line\nbreak" majutsu-workspace--field-separator "tail"))
+         (output (majutsu-workspace-test--row
+                  "@" "odd" "wnurqwps" "6acd46b7" "desc\ncontrol" root))
+         (entries (majutsu-workspace-parse-list-output output)))
+    (should (= (length entries) 1))
+    (should (equal (plist-get (car entries) :root)
+                   (file-name-as-directory root)))
+    (should (equal (plist-get (car entries) :desc) "desc\ncontrol"))))
 
 (ert-deftest majutsu-workspace--names/uses-structured-list-entries ()
   "Workspace names should be derived from structured entries."
@@ -183,10 +203,13 @@
 (ert-deftest majutsu-workspace-wash-list-transforms-buffer ()
   "Structured wash should transform the buffer into workspace sections."
   (let* ((sep majutsu-workspace--field-separator)
-         (lines (concat "@" sep "default" sep "wqps1234" sep "6acd46b7" sep "Main"
-                        sep "/workspaces/default" "\n"
-                        sep "feature" sep "lvolzxkz" sep "32e07e11" sep "Feature work"
-                        sep "/workspaces/feature" "\n"))
+         (lines (concat
+                 (majutsu-workspace-test--row
+                  "@" "default" "wqps1234" "6acd46b7" "Main"
+                  "/workspaces/default")
+                 (majutsu-workspace-test--row
+                  "" "feature" "lvolzxkz" "32e07e11" "Feature work"
+                  "/workspaces/feature")))
          (default-directory "/tmp/test-repo/")
          (majutsu--default-directory "/tmp/test-repo/"))
     (with-temp-buffer
@@ -207,7 +230,8 @@
 (ert-deftest majutsu-workspace-wash-list-renders-missing-root-placeholder ()
   "Missing structured roots should render as a fixed placeholder."
   (let* ((sep majutsu-workspace--field-separator)
-         (lines (concat "@" sep "default" sep "wqps1234" sep "6acd46b7" sep "Main"
+         (lines (concat "\"@\"" sep "\"default\"" sep "\"wqps1234\"" sep
+                        "\"6acd46b7\"" sep "\"Main\""
                         sep "<Error: Failed to resolve workspace root>" "\n"))
          (default-directory "/tmp/test-repo/")
          (majutsu--default-directory "/tmp/test-repo/"))
@@ -224,9 +248,9 @@
 
 (ert-deftest majutsu-workspace-wash-list-hides-single-workspace ()
   "Wash-list should hide a single workspace when show-single is nil."
-  (let* ((sep majutsu-workspace--field-separator)
-         (line (concat "@" sep "default" sep "wqps1234" sep "6acd46b7" sep "Main"
-                       sep "/workspaces/default" "\n")))
+  (let ((line (majutsu-workspace-test--row
+               "@" "default" "wqps1234" "6acd46b7" "Main"
+               "/workspaces/default")))
     (with-temp-buffer
       (require 'magit-section)
       (magit-section-mode)
@@ -241,8 +265,8 @@
 
 (ert-deftest majutsu-workspace--root-for-name/returns-directory ()
   "Test that root-for-name returns a directory path from jj output."
-  (cl-letf (((symbol-function 'majutsu-jj-lines)
-             (lambda (&rest _args) '("/home/user/repo-secondary"))))
+  (cl-letf (((symbol-function 'majutsu-jj-buffer-string)
+             (lambda (&rest _args) "/home/user/repo-secondary\n")))
     (should (equal (majutsu-workspace--root-for-name "secondary")
                    "/home/user/repo-secondary/"))))
 
@@ -254,16 +278,23 @@
                  (when (and (equal path default-directory)
                             (null identification))
                    "/ssh:demo:")))
-              ((symbol-function 'majutsu-jj-lines)
-               (lambda (&rest _args) '("/home/demo/repo-secondary"))))
+              ((symbol-function 'majutsu-jj-buffer-string)
+               (lambda (&rest _args) "/home/demo/repo-secondary\n")))
       (should (equal (majutsu-workspace--root-for-name "secondary")
                      "/ssh:demo:/home/demo/repo-secondary/")))))
 
 (ert-deftest majutsu-workspace--root-for-name/returns-nil-on-error ()
   "Test that root-for-name returns nil when jj fails (no output)."
-  (cl-letf (((symbol-function 'majutsu-jj-lines)
-             (lambda (&rest _args) nil)))
+  (cl-letf (((symbol-function 'majutsu-jj-buffer-string)
+             (lambda (&rest _args) "")))
     (should (null (majutsu-workspace--root-for-name "nonexistent")))))
+
+(ert-deftest majutsu-workspace--root-for-name/preserves-embedded-newline ()
+  "Root lookup removes only jj's record terminator, not path newlines."
+  (cl-letf (((symbol-function 'majutsu-jj-buffer-string)
+             (lambda (&rest _args) "/tmp/line\nbreak\n")))
+    (should (equal (majutsu-workspace--root-for-name "odd")
+                   "/tmp/line\nbreak/"))))
 
 (ert-deftest majutsu-workspace--read-root/prefers-section-root ()
   "Read-root should reuse a structured root from the current section first."
@@ -447,6 +478,33 @@ The Emacs-facing path remains unchanged for visiting the new workspace."
       (when (file-directory-p feature)
         (delete-directory feature t)))))
 
+(ert-deftest majutsu-workspace-forget/trashes-exact-control-character-root ()
+  "Trash must receive the complete root, not a line-truncated prefix."
+  (let* ((parent (make-temp-file "majutsu-control-root-" t))
+         (odd (file-name-as-directory
+               (expand-file-name "line\nbreak" parent)))
+         prompt deleted)
+    (make-directory odd)
+    (unwind-protect
+        (cl-letf (((symbol-function 'majutsu--toplevel-safe)
+                   (lambda (&optional _directory) "/tmp/main/"))
+                  ((symbol-function 'majutsu-workspace-list-entries)
+                   (lambda (&optional _directory)
+                     `((:name "odd" :root ,odd))))
+                  ((symbol-function 'majutsu-confirm)
+                   (lambda (_action text)
+                     (setq prompt text)
+                     t))
+                  ((symbol-function 'majutsu-run-jj)
+                   (lambda (&rest _args) 0))
+                  ((symbol-function 'delete-directory)
+                   (lambda (directory &rest _args)
+                     (setq deleted directory))))
+          (majutsu-workspace-forget '("odd") t)
+          (should (equal deleted odd))
+          (should (string-match-p "\\\\n" prompt)))
+      (delete-directory parent t))))
+
 (ert-deftest majutsu-workspace-forget/refuses-to-trash-repo-store-root ()
   "Trash flow should not delete a root that owns the shared .jj/repo store."
   (let* ((primary (make-temp-file "majutsu-primary-" t))
@@ -524,11 +582,73 @@ The Emacs-facing path remains unchanged for visiting the new workspace."
                 (should-error (majutsu-workspace-forget '("feature") t)
                               :type 'user-error))
           (should ran-jj)
-          (should (string-match-p
-                   "was forgotten.*was not moved to trash.*move it manually"
-                   (error-message-string condition))))
+          (let ((message (error-message-string condition)))
+            (should (string-match-p "forget succeeded" message))
+            (should (string-match-p "not moved to trash" message))
+            (should (string-match-p "Move them manually" message))))
       (when (file-directory-p feature)
         (delete-directory feature t)))))
+
+(ert-deftest majutsu-workspace-forget/binds-directory-identity-across-confirmation ()
+  "A replacement at the confirmed path must not be trashed after forget."
+  (let* ((parent (make-temp-file "majutsu-identity-" t))
+         (feature (expand-file-name "feature" parent))
+         (displaced (expand-file-name "confirmed-feature" parent))
+         condition)
+    (make-directory feature)
+    (unwind-protect
+        (cl-letf (((symbol-function 'majutsu--toplevel-safe)
+                   (lambda (&optional _directory) "/tmp/main/"))
+                  ((symbol-function 'majutsu-workspace-list-entries)
+                   (lambda (&optional _directory)
+                     `((:name "feature"
+                        :root ,(file-name-as-directory feature)))))
+                  ((symbol-function 'majutsu-confirm)
+                   (lambda (&rest _args) t))
+                  ((symbol-function 'majutsu-run-jj)
+                   (lambda (&rest _args)
+                     (rename-file feature displaced)
+                     (make-directory feature)
+                     0)))
+          (setq condition
+                (should-error (majutsu-workspace-forget '("feature") t)
+                              :type 'user-error))
+          (should (file-directory-p feature))
+          (should (file-directory-p displaced))
+          (should (string-match-p "identity changed after confirmation"
+                                  (error-message-string condition))))
+      (delete-directory parent t))))
+
+(ert-deftest majutsu-workspace-forget/continues-and-reports-all-trash-failures ()
+  "Every selected root is attempted and all trash errors are reported together."
+  (let ((one (make-temp-file "majutsu-one-" t))
+        (two (make-temp-file "majutsu-two-" t))
+        attempts condition)
+    (unwind-protect
+        (cl-letf (((symbol-function 'majutsu--toplevel-safe)
+                   (lambda (&optional _directory) "/tmp/main/"))
+                  ((symbol-function 'majutsu-workspace-list-entries)
+                   (lambda (&optional _directory)
+                     `((:name "one" :root ,(file-name-as-directory one))
+                       (:name "two" :root ,(file-name-as-directory two)))))
+                  ((symbol-function 'majutsu-confirm)
+                   (lambda (&rest _args) t))
+                  ((symbol-function 'majutsu-run-jj)
+                   (lambda (&rest _args) 0))
+                  ((symbol-function 'delete-directory)
+                   (lambda (directory &rest _args)
+                     (push directory attempts)
+                     (error "trash failed for %s" directory))))
+          (setq condition
+                (should-error (majutsu-workspace-forget '("one" "two") t)
+                              :type 'user-error))
+          (should (equal (nreverse attempts)
+                         (list (file-name-as-directory one)
+                               (file-name-as-directory two))))
+          (should (string-match-p "one" (error-message-string condition)))
+          (should (string-match-p "two" (error-message-string condition))))
+      (delete-directory one t)
+      (delete-directory two t))))
 
 (ert-deftest majutsu-workspace-forget/trash-with-missing-root-does-not-prompt ()
   "Trash flow should forget but not prompt or delete when root is unavailable."
@@ -584,6 +704,34 @@ The Emacs-facing path remains unchanged for visiting the new workspace."
           (should-not deleted))
       (when (file-directory-p feature)
         (delete-directory feature t)))))
+
+(ert-deftest majutsu-workspace/integration-control-root-with-minimum-jj ()
+  "Exercise JSON/root transport against the jj binary named by MAJUTSU_TEST_JJ."
+  (let ((jj (getenv "MAJUTSU_TEST_JJ")))
+    (skip-unless (and jj (file-executable-p jj)))
+    (let* ((parent (make-temp-file "majutsu-workspace-integration-" t))
+           (repo (expand-file-name "repo" parent))
+           (odd-root (concat (expand-file-name "line\nbreak" parent)
+                             majutsu-workspace--field-separator
+                             "tail")))
+      (unwind-protect
+          (progn
+            (should (zerop (call-process jj nil nil nil "git" "init" repo)))
+            (let ((default-directory (file-name-as-directory repo))
+                  (majutsu-jj-executable jj))
+              (should (zerop (call-process jj nil nil nil
+                                           "workspace" "add" odd-root
+                                           "--name" "odd")))
+              (let ((entry (cl-find "odd" (majutsu-workspace-list-entries)
+                                    :key (lambda (item)
+                                           (plist-get item :name))
+                                    :test #'equal)))
+                (should entry)
+                (should (equal (plist-get entry :root)
+                               (file-name-as-directory odd-root))))
+              (should (equal (majutsu-workspace--root-for-name "odd")
+                             (file-name-as-directory odd-root)))))
+        (delete-directory parent t)))))
 
 (provide 'majutsu-workspace-test)
 ;;; majutsu-workspace-test.el ends here


### PR DESCRIPTION
Follow-up hardening for workspace trash and binary/whole-file split support.

- transports workspace roots and diff paths as structured JSON
- validates directory identity after confirmation and aggregates multi-target failures
- binds whole-file actions to a validated machine-readable diff sidecar
- guarantees parser progress for malformed Git headers
- isolates and reliably cleans per-operation temporary directories
- raises the minimum supported jj version to 0.40, where `WorkspaceRef.root()` became available

Validation:
- 792 ERT tests: 790 passed, 2 environment-gated skips
- 828/828 combined stack with the real jj 0.40 binary
- real jj 0.43 integration gate also passed
- 50 source files byte-compiled; Info manual regenerated