### PR TITLE
transient: Add primary actions (RET) to diff, ediff, and log

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -217,6 +217,10 @@
 - Squash and split execute consistently with ~RET~ ::
   Their transients keep ~s~ while also using the shared default action key.
 
+- Diff, Ediff, and log transients execute with ~RET~ ::
+  Their primary actions now use the shared default action key alongside the
+  existing ~d~, ~e~, and ~g~ bindings.
+
 - Quitting Ediff resolve without edits keeps conflicts unresolved ::
   ~majutsu-ediff-resolve~ no longer writes a resolved result in that case.
 

--- a/majutsu-diff.el
+++ b/majutsu-diff.el
@@ -2082,7 +2082,8 @@ REVSET is passed to jj diff using `--revisions='."
     (majutsu-diff:-w)
     (majutsu-diff:-b)]
    ["Actions"
-    ("d" "Execute" majutsu-diff-dwim)
+    ("d" "Execute" majutsu-diff-dwim
+     :class majutsu-transient-default-action-suffix)
     ("s" "Save as default" majutsu-diff-save-arguments)
     ("W" "Save as repo default" majutsu-transient-save-repository-defaults)
     ("g" "Refresh" majutsu-diff-refresh)]]

--- a/majutsu-ediff.el
+++ b/majutsu-ediff.el
@@ -712,7 +712,8 @@ Called by `jj resolve` merge editor command via emacsclient."
     (majutsu-ediff:--to)
     ("c" "Clear selections" majutsu-selection-clear :transient t)]
    ["Actions"
-    ("e" "Ediff (blob)" majutsu-ediff-dwim)
+    ("e" "Ediff (blob)" majutsu-ediff-dwim
+     :class majutsu-transient-default-action-suffix)
     ("E" "Ediff (diffedit)" majutsu-ediff-edit)]
    ["Resolve"
     ("m" "Resolve (ediff)" majutsu-ediff-resolve)

--- a/majutsu-log.el
+++ b/majutsu-log.el
@@ -936,7 +936,8 @@ minibuffer for editing.  Empty input clears the filter."
    ["Paths"
     (majutsu-log:--)]
    ["Actions"
-    ("g" "buffer" majutsu-log-transient)
+    ("g" "buffer" majutsu-log-transient
+     :class majutsu-transient-default-action-suffix)
     ("s" "buffer and set defaults" transient-set-and-exit)
     ("w" "buffer and save defaults" transient-save-and-exit)
     ("W" "buffer and save repo defaults" majutsu-transient-save-repository-defaults)


### PR DESCRIPTION
The rebase, restore, absorb, split, and squash transients run their primary action through `majutsu-transient-default-action-suffix`, so `majutsu-transient-default-action` RET by default) finishes them. The diff, ediff, and log transients only bound their letter keys, so RET silently did nothing there.

We give diff, ediff and log a primary action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diff, Ediff, and log actions can now be executed with **Return**, alongside their existing keyboard shortcuts.

* **Documentation**
  * Updated the unreleased changelog to document the new Return-key behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->