### PR TITLE
fix(log): refresh tail alignment after window resize

### DIFF
--- a/majutsu-log.el
+++ b/majutsu-log.el
@@ -523,8 +523,8 @@ When WINDOW is nil, use the current row tail owner window."
   (majutsu-log--refresh-tail-window (selected-window)))
 
 (defun majutsu-log--after-window-size-change (window)
-  "Refresh tail alignment after the selected log WINDOW changes size."
-  (when (eq window (selected-window))
+  "Refresh tail alignment after log WINDOW changes size."
+  (when (eq (window-buffer window) (current-buffer))
     (majutsu-log--refresh-tail-window window)))
 
 (defun majutsu-log--wash-logs (_args)

--- a/test/majutsu-log-test.el
+++ b/test/majutsu-log-test.el
@@ -718,7 +718,15 @@
                 ((symbol-function 'majutsu-log--refresh-tail-window)
                  (lambda (window) (setq refreshed window))))
         (majutsu-log--after-window-size-change 'resized-log-window))
-      (should (eq refreshed 'resized-log-window)))))
+      (should (eq refreshed 'resized-log-window))
+      ;; Unrelated windows (showing a different buffer) should be ignored.
+      (cl-letf (((symbol-function 'window-buffer)
+                 (lambda (_window) (get-buffer-create "majutsu-log-test-unrelated")))
+                ((symbol-function 'majutsu-log--refresh-tail-window)
+                 (lambda (window) (setq refreshed window))))
+        (setq refreshed nil)
+        (majutsu-log--after-window-size-change 'resized-log-window))
+      (should (null refreshed)))))
 
 (ert-deftest majutsu-log-filter-buffer-substring-drops-tail-when-heading-present ()
   "Copying mixed heading+tail text should drop the tail by default."

--- a/test/majutsu-log-test.el
+++ b/test/majutsu-log-test.el
@@ -708,6 +708,18 @@
     (should (memq #'majutsu-log--after-text-scale-change text-scale-mode-hook))
     (should (memq #'majutsu-log--after-window-size-change window-size-change-functions))))
 
+(ert-deftest majutsu-log-window-size-change-refreshes-resized-log-window ()
+  "The buffer-local resize hook should refresh the window it receives."
+  (let (refreshed)
+    (with-temp-buffer
+      (majutsu-log-mode)
+      (cl-letf (((symbol-function 'window-buffer)
+                 (lambda (_window) (current-buffer)))
+                ((symbol-function 'majutsu-log--refresh-tail-window)
+                 (lambda (window) (setq refreshed window))))
+        (majutsu-log--after-window-size-change 'resized-log-window))
+      (should (eq refreshed 'resized-log-window)))))
+
 (ert-deftest majutsu-log-filter-buffer-substring-drops-tail-when-heading-present ()
   "Copying mixed heading+tail text should drop the tail by default."
   (let* ((compiled (majutsu-log-test--tail-compiled))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Log views now refresh their tail alignment correctly when a resized window shows the affected log buffer, even if it isn’t the currently selected window.

* **Tests**
  * Added a new ERT test to verify the tail refresh triggers for the correct resized log window and does not trigger when the displayed buffer doesn’t match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->