### PR TITLE
Inhibit redisplay while capturing washer subprocess output

### DIFF
--- a/majutsu-jj.el
+++ b/majutsu-jj.el
@@ -912,7 +912,12 @@ optionally colorized based on `majutsu-process-apply-ansi-colors'."
   (let* ((beg (point))
          (err-file (make-nearby-temp-file "majutsu-jj-err")))
     (unwind-protect
-        (let* ((exit (majutsu-process-jj (list t err-file) args))
+        (let* ((exit
+                ;; jj log's structured row protocol is temporarily inserted
+                ;; as raw subprocess output.  Do not let it be redisplayed
+                ;; before the washer replaces it with sections.
+                (let ((inhibit-redisplay t))
+                  (majutsu-process-jj (list t err-file) args)))
                (error-text
                 (when (and keep-error (not (= exit 0)))
                   (let ((text

--- a/test/majutsu-jj-test.el
+++ b/test/majutsu-jj-test.el
@@ -202,6 +202,18 @@
                          0))
           (should (equal seen-columns "80")))))))
 
+(ert-deftest majutsu-jj-wash/inhibits-redisplay-while-capturing-output ()
+  "Raw washer output must not be redisplayed before it is parsed."
+  (cl-letf (((symbol-function 'majutsu-process-file)
+             (lambda (&rest _args)
+               (should inhibit-redisplay)
+               (insert "raw output\n")
+               0)))
+    (with-temp-buffer
+      (should (= 0 (majutsu-jj-wash (lambda (&rest _) (goto-char (point-max)))
+                                     nil "log")))
+      (should (equal (buffer-string) "raw output\n")))))
+
 (ert-deftest majutsu-jj-wash/discards-stderr-on-success ()
   "Successful wash output should exclude warning stderr."
   (cl-letf (((symbol-function 'majutsu-process-file)


### PR DESCRIPTION
Avoid display garbage for a split second.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented JJ’s temporary structured output from being shown prematurely while the washer processes and formats command results.
  * Kept the existing output parsing, ANSI coloring, error extraction, and exit-status behavior unchanged.
* **Tests**
  * Added an ERT test to ensure redisplay is inhibited during output capture and that only the fully processed “washed” result is returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->