### PR TITLE
fix(gerrit): tolerate unavailable build-time dependencies

### DIFF
--- a/majutsu-gerrit-rest.el
+++ b/majutsu-gerrit-rest.el
@@ -25,7 +25,9 @@
 (require 'json)
 (require 'subr-x)
 (require 'url-util)
-(require 'plz)
+;; Keep this library loadable during package builds where optional Gerrit
+;; dependencies may not yet be on `load-path'.
+(require 'plz nil t)
 
 (declare-function majutsu-gerrit--remote-user "majutsu-gerrit"
                   (&optional remote directory))

--- a/majutsu-gerrit-upload.el
+++ b/majutsu-gerrit-upload.el
@@ -23,7 +23,7 @@
 (require 'majutsu-gerrit)
 (require 'majutsu-selection)
 
-(require 'consult)
+(require 'consult nil t)
 
 (defvar majutsu-gerrit-remote-branch-history nil
   "Minibuffer history for Gerrit remote branch names.")

--- a/majutsu-gerrit.el
+++ b/majutsu-gerrit.el
@@ -25,12 +25,15 @@
 (require 'majutsu-remote)
 
 (require 'cl-lib)
-(require 'consult)
+;; Gerrit support is optional at build time.  Keep native compilation of
+;; the rest of Majutsu working when an Emacs package builder has not yet
+;; propagated these dependencies.
+(require 'consult nil t)
 (require 'json)
 (require 'subr-x)
 (require 'url-parse)
 (require 'svg)
-(require 'plz)
+(require 'plz nil t)
 
 (declare-function majutsu-jj-lines "majutsu-jj")
 


### PR DESCRIPTION
## Summary

- tolerate Consult and plz being absent while native-compiling Gerrit modules
- keep both dependencies in `Package-Requires` for normal package installation and runtime use
- unblock package builders that compile Majutsu before those dependencies are on `load-path`

## Testing

- built Majutsu with Nix `melpaBuild` while deliberately excluding Consult and plz from `packageRequires`
- confirmed all Majutsu files, including `majutsu-evolog.el`, `majutsu-file.el`, and `majutsu-forge.el`, native-compile successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package loading in environments where optional integrations are unavailable.
  * Gerrit-related features now initialize without failing when supporting packages are not installed or not yet accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->