### PR TITLE
Add optional Embark actions for bookmarks and workspaces

### DIFF
--- a/Eask
+++ b/Eask
@@ -28,4 +28,5 @@
 (source 'jcs-elpa)
 
 (development
- (depends-on "ellsp"))
+ (depends-on "ellsp")
+ (depends-on "embark"))

--- a/README.org
+++ b/README.org
@@ -46,6 +46,13 @@ see a Git repository and remotes.  Forge sections also depend on a configured,
 tracked repository and populated Forge database.  Pull-request commit lists shown
 by Forge's Git-oriented renderer are replaced by a placeholder in Majutsu buffers.
 
+** Optional Embark Integration
+
+When [[https://github.com/oantolin/embark][Embark]] is installed, Majutsu automatically adds actions for workspace
+and bookmark completion candidates.  Workspace actions can visit, open in
+Dired, or copy the root.  Bookmark actions can edit, diff, inspect evolution,
+move, rename, delete, or forget the selected bookmark.
+
 ** Essential Keybindings
 
 | Key (Vanilla / Evil) | Action                    |

--- a/docs/majutsu.org
+++ b/docs/majutsu.org
@@ -771,6 +771,18 @@ Bookmark lists nest tracked remote bookmarks under their local bookmark.
 When a bookmark target is conflicted, its removed and added targets appear as
 child revision sections identified by their full commit IDs.
 
+** Bookmark Embark Actions
+When Embark is installed, bookmark completion candidates provide these actions:
+
+- Key: RET / e (majutsu-edit-revision) :: Edit the selected bookmark's target.
+- Key: D (majutsu-diff-revset) :: Show the selected bookmark's diff.
+- Key: v (majutsu-evolog) :: Show its evolution log.
+- Key: p / s / m / M / r :: Advance, set, move, move backwards, or rename it.
+- Key: d / f :: Delete it with remote propagation, or forget it locally.
+
+The bookmark action map inherits Embark's general actions, including ~w~ for
+copying the bookmark name.
+
 * Tags
 ** Understanding Tags
 In Jujutsu, tags are lightweight refs that point to revisions, similar to Git tags.
@@ -891,6 +903,16 @@ description, and resolved root path when available. If jj cannot resolve a
 workspace root, Majutsu treats it as unavailable instead of showing the raw
 =<Error: ...>= text in the section body. Workspace paths containing embedded
 newlines or other control characters are preserved as complete values.
+
+** Embark Actions
+When Embark is installed, workspace completion candidates provide these actions:
+
+- Key: RET / v (majutsu-workspace-visit-name) :: Visit the selected workspace.
+- Key: d (majutsu-workspace-dired) :: Open the selected workspace root in Dired.
+- Key: W (majutsu-workspace-copy-root) :: Copy the selected workspace root.
+
+Embark is optional; Majutsu registers these actions automatically after Embark
+is loaded.
 
 * Conflict Resolution
 ** Detecting Conflicts

--- a/docs/majutsu.texi
+++ b/docs/majutsu.texi
@@ -1813,6 +1813,7 @@ Runs: @samp{jj simplify-parents [--source REVSET] [--revision REVSET]}
 @menu
 * Understanding Bookmarks::
 * Bookmark Transient::
+* Bookmark Embark Actions::
 @end menu
 
 @node Understanding Bookmarks
@@ -1886,6 +1887,35 @@ Untrack a remote bookmark.
 Bookmark lists nest tracked remote bookmarks under their local bookmark.
 When a bookmark target is conflicted@comma{} its removed and added targets appear as
 child revision sections identified by their full commit IDs.
+
+@node Bookmark Embark Actions
+@section Bookmark Embark Actions
+
+When Embark is installed@comma{} bookmark completion candidates provide these actions:
+
+@table @asis
+@item @kbd{@key{RET} / e} (@code{majutsu-edit-revision})
+@kindex RET / e
+@findex majutsu-edit-revision
+Edit the selected bookmark's target.
+@item @kbd{D} (@code{majutsu-diff-revset})
+@kindex D
+@findex majutsu-diff-revset
+Show the selected bookmark's diff.
+@item @kbd{v} (@code{majutsu-evolog})
+@kindex v
+@findex majutsu-evolog
+Show its evolution log.
+@item @kbd{p / s / m / M / r}
+@kindex p / s / m / M / r
+Advance@comma{} set@comma{} move@comma{} move backwards@comma{} or rename it.
+@item @kbd{d / f}
+@kindex d / f
+Delete it with remote propagation@comma{} or forget it locally.
+@end table
+
+The bookmark action map inherits Embark's general actions@comma{} including @samp{w} for
+copying the bookmark name.
 
 @node Tags
 @chapter Tags
@@ -2147,6 +2177,7 @@ Show the Git directory path (@samp{jj git root}).
 @menu
 * Understanding Workspaces::
 * Workspace Transient::
+* Embark Actions::
 @end menu
 
 @node Understanding Workspaces
@@ -2202,6 +2233,29 @@ description@comma{} and resolved root path when available. If jj cannot resolve 
 workspace root@comma{} Majutsu treats it as unavailable instead of showing the raw
 @samp{<Error: ...>} text in the section body. Workspace paths containing embedded
 newlines or other control characters are preserved as complete values.
+
+@node Embark Actions
+@section Embark Actions
+
+When Embark is installed@comma{} workspace completion candidates provide these actions:
+
+@table @asis
+@item @kbd{@key{RET} / v} (@code{majutsu-workspace-visit-name})
+@kindex RET / v
+@findex majutsu-workspace-visit-name
+Visit the selected workspace.
+@item @kbd{d} (@code{majutsu-workspace-dired})
+@kindex d
+@findex majutsu-workspace-dired
+Open the selected workspace root in Dired.
+@item @kbd{W} (@code{majutsu-workspace-copy-root})
+@kindex W
+@findex majutsu-workspace-copy-root
+Copy the selected workspace root.
+@end table
+
+Embark is optional; Majutsu registers these actions automatically after Embark
+is loaded.
 
 @node Conflict Resolution
 @chapter Conflict Resolution

--- a/majutsu-base.el
+++ b/majutsu-base.el
@@ -264,11 +264,14 @@ is `any', require non-empty input without requiring a candidate match."
 (defun majutsu-completing-read-payload
     (prompt payload &optional predicate require-match initial-input hist def category context directory)
   "Read one value from structured completion PAYLOAD.
-PAYLOAD may provide :category and richer completion metadata.  CONTEXT and
-DIRECTORY are accepted for API compatibility within Majutsu and are ignored.
+PAYLOAD may provide :category and richer completion metadata.  CONTEXT is
+bound as `majutsu-completion-context' while the reader is active.  DIRECTORY
+is bound as `default-directory', allowing completion actions to operate in the
+repository that produced the candidates.
 REQUIRE-MATCH follows `majutsu-completing-read'."
-  (ignore context directory)
-  (let* ((completion-extra-properties
+  (let* ((default-directory (or directory default-directory))
+         (majutsu-completion-context context)
+         (completion-extra-properties
           (majutsu-completion-payload-properties payload category))
          (collection (plist-get payload :candidates))
          (value (completing-read (format-prompt prompt def)
@@ -305,11 +308,14 @@ requiring a candidate match."
 (defun majutsu-completing-read-multiple-payload
     (prompt payload &optional predicate require-match initial-input hist def category context directory)
   "Read multiple values from structured completion PAYLOAD.
-PAYLOAD may provide :category and richer completion metadata.  CONTEXT and
-DIRECTORY are accepted for API compatibility within Majutsu and are ignored.
+PAYLOAD may provide :category and richer completion metadata.  CONTEXT is
+bound as `majutsu-completion-context' while the reader is active.  DIRECTORY
+is bound as `default-directory', allowing completion actions to operate in the
+repository that produced the candidates.
 REQUIRE-MATCH follows `majutsu-completing-read-multiple'."
-  (ignore context directory)
-  (let* ((completion-extra-properties
+  (let* ((default-directory (or directory default-directory))
+         (majutsu-completion-context context)
+         (completion-extra-properties
           (majutsu-completion-payload-properties payload category))
          (collection (plist-get payload :candidates))
          (values (completing-read-multiple (format-prompt prompt def)

--- a/majutsu-completion.el
+++ b/majutsu-completion.el
@@ -33,6 +33,11 @@
   :type 'string
   :group 'majutsu-completion)
 
+(defvar majutsu-completion-context nil
+  "Dynamically bound domain context for the active Majutsu completion reader.
+Embark actions can use this value to recover structured candidate metadata
+without querying the repository again.")
+
 (defface majutsu-completion-key
   '((t :inherit font-lock-keyword-face))
   "Face used for primary completion labels such as kinds or categories."

--- a/majutsu-edit.el
+++ b/majutsu-edit.el
@@ -19,6 +19,18 @@
 (require 'majutsu-process)
 
 ;;;###autoload
+(defun majutsu-edit-revision (revset &optional arg)
+  "Edit REVSET.
+With prefix ARG, pass --ignore-immutable.  Return non-nil on success."
+  (interactive (list (majutsu-read-single-revset "Edit revision")
+                     current-prefix-arg))
+  (when (zerop (apply #'majutsu-run-jj
+                      (append (list "edit" revset)
+                              (when arg (list "--ignore-immutable")))))
+    (message "Now editing commit %s" revset)
+    t))
+
+;;;###autoload
 (defun majutsu-edit-changeset (&optional arg)
   "Edit commit at point.
 
@@ -29,11 +41,8 @@ When called from a blob buffer, also visit the workspace file."
                       majutsu-buffer-blob-root
                       majutsu-buffer-blob-path)))
     (if-let* ((revset (or (majutsu-thing-at-point 'jj-revision t)
-                          (majutsu-revision-at-point)))
-              (args (append (list "edit" revset)
-                            (when arg (list "--ignore-immutable")))))
-        (when (zerop (apply #'majutsu-run-jj args))
-          (message "Now editing commit %s" revset)
+                          (majutsu-revision-at-point))))
+        (when (majutsu-edit-revision revset arg)
           (when in-blob
             (let ((file (expand-file-name majutsu-buffer-blob-path
                                           majutsu-buffer-blob-root)))

--- a/majutsu-embark.el
+++ b/majutsu-embark.el
@@ -1,0 +1,71 @@
+;;; majutsu-embark.el --- Embark actions for Majutsu  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 0WD0
+
+;; Author: 0WD0 <wd.1105848296@gmail.com>
+;; Maintainer: 0WD0 <wd.1105848296@gmail.com>
+;; Keywords: tools, vc
+;; URL: https://github.com/0WD0/majutsu
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; Optional Embark actions for Majutsu completion categories.  Loading
+;; `majutsu' registers this integration after Embark becomes available; Embark
+;; remains an optional dependency.
+
+;;; Code:
+
+(require 'majutsu-bookmark)
+(require 'majutsu-diff)
+(require 'majutsu-edit)
+(require 'majutsu-evolog)
+(require 'majutsu-workspace)
+
+(defvar embark-general-map)
+(defvar embark-keymap-alist)
+
+(defvar-keymap majutsu-embark-workspace-map
+  :doc "Embark actions for Majutsu workspace candidates.")
+
+;; Set these outside `defvar-keymap' so reloading the integration updates an
+;; already-bound action map.
+(keymap-set majutsu-embark-workspace-map "RET" #'majutsu-workspace-visit-name)
+(keymap-set majutsu-embark-workspace-map "v" #'majutsu-workspace-visit-name)
+(keymap-set majutsu-embark-workspace-map "d" #'majutsu-workspace-dired)
+(keymap-set majutsu-embark-workspace-map "W" #'majutsu-workspace-copy-root)
+
+(defvar-keymap majutsu-embark-bookmark-map
+  :doc "Embark actions for Majutsu bookmark candidates.")
+
+;; Keep Embark's general bindings (notably `w' for copying) available through
+;; the parent map.  These keys mirror Majutsu's bookmark and revision commands.
+(keymap-set majutsu-embark-bookmark-map "RET" #'majutsu-edit-revision)
+(keymap-set majutsu-embark-bookmark-map "e" #'majutsu-edit-revision)
+(keymap-set majutsu-embark-bookmark-map "D" #'majutsu-diff-revset)
+(keymap-set majutsu-embark-bookmark-map "v" #'majutsu-evolog)
+(keymap-set majutsu-embark-bookmark-map "p" #'majutsu-bookmark-advance-patterns)
+(keymap-set majutsu-embark-bookmark-map "s" #'majutsu-bookmark-set)
+(keymap-set majutsu-embark-bookmark-map "m" #'majutsu-bookmark-move)
+(keymap-set majutsu-embark-bookmark-map "M" #'majutsu-bookmark-move-allow-backwards)
+(keymap-set majutsu-embark-bookmark-map "r" #'majutsu-bookmark-rename)
+(keymap-set majutsu-embark-bookmark-map "d" #'majutsu-bookmark-delete)
+(keymap-set majutsu-embark-bookmark-map "f" #'majutsu-bookmark-forget)
+
+(defun majutsu-embark--register ()
+  "Register Majutsu completion categories and action maps with Embark."
+  (set-keymap-parent majutsu-embark-workspace-map embark-general-map)
+  (set-keymap-parent majutsu-embark-bookmark-map embark-general-map)
+  (add-to-list 'embark-keymap-alist
+               '(majutsu-workspace . majutsu-embark-workspace-map))
+  (add-to-list 'embark-keymap-alist
+               '(majutsu-bookmark . majutsu-embark-bookmark-map)))
+
+(if (featurep 'embark)
+    (majutsu-embark--register)
+  (with-eval-after-load 'embark
+    (majutsu-embark--register)))
+
+(provide 'majutsu-embark)
+;;; majutsu-embark.el ends here

--- a/majutsu-workspace.el
+++ b/majutsu-workspace.el
@@ -312,22 +312,34 @@ DIRECTORY is captured so suffix rendering stays stable in the minibuffer."
 (defvar majutsu-workspace-name-history nil
   "Minibuffer history for workspace-name input.")
 
+(defun majutsu-workspace--prompt-name (&optional prompt root default)
+  "Prompt for a workspace name from ROOT.
+DEFAULT is the default candidate; otherwise use the current workspace."
+  (let* ((root (or root default-directory))
+         (payload (majutsu-workspace-candidate-data root))
+         (current (cl-find-if (lambda (entry)
+                                (plist-get entry :current))
+                              (plist-get payload :entry-list)))
+         (default (or default (plist-get current :name) ""))
+         (prompt (or prompt "Workspace")))
+    (majutsu-completing-read-payload prompt payload
+                                     nil t nil 'majutsu-workspace-name-history
+                                     default 'majutsu-workspace payload root)))
+
 (defun majutsu-workspace--read-name (&optional prompt root default)
   "Read a workspace name.
 
-Prefer the workspace section at point, otherwise use completion over
-the workspaces for ROOT."
+Prefer the workspace section at point, otherwise prompt over the workspaces
+for ROOT."
   (or (majutsu-workspace--section-name)
-      (let* ((root (or root default-directory))
-             (payload (majutsu-workspace-candidate-data root))
-             (current (cl-find-if (lambda (entry)
-                                    (plist-get entry :current))
-                                  (plist-get payload :entry-list)))
-             (default (or default (plist-get current :name) ""))
-             (prompt (or prompt "Workspace")))
-        (majutsu-completing-read-payload prompt payload
-                                         nil t nil 'majutsu-workspace-name-history
-                                         default 'majutsu-workspace nil root))))
+      (majutsu-workspace--prompt-name prompt root default)))
+
+(defun majutsu-workspace--completion-context-entry (name)
+  "Return the structured completion entry for workspace NAME, if available."
+  (when (listp majutsu-completion-context)
+    (when-let* ((entries (plist-get majutsu-completion-context :entries))
+                ((hash-table-p entries)))
+      (gethash name entries))))
 
 (defun majutsu-workspace--read-root (name &optional root)
   "Return the workspace root directory for NAME.
@@ -338,9 +350,11 @@ that fails \(e.g. workspace created before jj v0.38.0), try a sibling
 directory of ROOT whose name matches NAME. Falls back to prompting the user."
   (let* ((root (file-name-as-directory (or root default-directory)))
          (entry (majutsu-workspace--section-entry))
+         (completion-entry (majutsu-workspace--completion-context-entry name))
          (dir (or (and entry
                        (equal (plist-get entry :name) name)
                        (plist-get entry :root))
+                  (plist-get completion-entry :root)
                   (majutsu-workspace--root-for-name name)
                   (majutsu-workspace--sibling-root name root)
                   (read-directory-name (format "Workspace root for %s: " name)
@@ -644,6 +658,28 @@ workspace root automatically; if not found, prompt for it."
     (setq majutsu--default-directory dir)
     (if (majutsu-refresh)
         (dired dir))))
+
+(defun majutsu-workspace-visit-name (name &optional root)
+  "Visit workspace NAME from repository ROOT.
+ROOT defaults to `default-directory'.  This command is suitable as an Embark
+action because NAME is its first argument."
+  (interactive (list (majutsu-workspace--prompt-name "Workspace: ")))
+  (majutsu-workspace-visit (majutsu-workspace--read-root name root)))
+
+(defun majutsu-workspace-dired (name &optional root)
+  "Open the root of workspace NAME in Dired.
+ROOT defaults to `default-directory'."
+  (interactive (list (majutsu-workspace--prompt-name "Workspace: ")))
+  (dired (majutsu-workspace--read-root name root)))
+
+(defun majutsu-workspace-copy-root (name &optional root)
+  "Copy the root directory of workspace NAME to the kill ring.
+ROOT defaults to `default-directory'."
+  (interactive (list (majutsu-workspace--prompt-name "Workspace: ")))
+  (let* ((directory (majutsu-workspace--read-root name root))
+         (path (directory-file-name directory)))
+    (kill-new path)
+    (message "%s (copied)" path)))
 
 ;;; Commands
 

--- a/majutsu.el
+++ b/majutsu.el
@@ -128,4 +128,7 @@ Instead of invoking this alias for `majutsu-log' using
 (with-eval-after-load 'evil
   (require 'majutsu-evil nil t))
 
+(with-eval-after-load 'embark
+  (require 'majutsu-embark))
+
 ;;; majutsu.el ends here

--- a/test/majutsu-base-test.el
+++ b/test/majutsu-base-test.el
@@ -96,6 +96,24 @@
       (should (eq seen-history 'majutsu-branch-history))
       (should (equal seen-annotation " default branch")))))
 
+(ert-deftest majutsu-completing-read-payload/binds-context-and-directory ()
+  "Payload readers should expose repository context to completion actions."
+  (let ((context '(:domain workspace))
+        seen-context
+        seen-directory)
+    (cl-letf (((symbol-function 'completing-read)
+               (lambda (&rest _args)
+                 (setq seen-context majutsu-completion-context
+                       seen-directory default-directory)
+                 "ws-a")))
+      (should (equal
+               (majutsu-completing-read-payload
+                "Workspace" '(:candidates ("ws-a")) nil t nil nil nil
+                'majutsu-workspace context "/tmp/repo/")
+               "ws-a"))
+      (should (eq seen-context context))
+      (should (equal seen-directory "/tmp/repo/")))))
+
 (ert-deftest majutsu-completing-read-multiple-payload/uses-payload-category ()
   (let (seen-category seen-history)
     (cl-letf (((symbol-function 'completing-read-multiple)

--- a/test/majutsu-edit-test.el
+++ b/test/majutsu-edit-test.el
@@ -12,6 +12,19 @@
 (require 'cl-lib)
 (require 'majutsu-edit)
 
+(ert-deftest majutsu-edit-revision/runs-explicit-target ()
+  "Explicit revision editing should be reusable by completion actions."
+  (let (captured)
+    (cl-letf (((symbol-function 'majutsu-run-jj)
+               (lambda (&rest args)
+                 (setq captured args)
+                 0))
+              ((symbol-function 'message) #'ignore))
+      (should (majutsu-edit-revision "main"))
+      (should (equal captured '("edit" "main")))
+      (should (majutsu-edit-revision "main" '(4)))
+      (should (equal captured '("edit" "main" "--ignore-immutable"))))))
+
 (ert-deftest majutsu-edit-test-edit-changeset-prefers-literal-revision-at-point ()
   "Edit changeset should prefer the literal revision/ref under point."
   (let (captured)

--- a/test/majutsu-embark-test.el
+++ b/test/majutsu-embark-test.el
@@ -1,0 +1,49 @@
+;;; majutsu-embark-test.el --- Tests for Majutsu Embark actions  -*- lexical-binding: t; -*-
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; Tests for optional Embark category action registration.
+
+;;; Code:
+
+(require 'ert)
+(require 'embark)
+(require 'majutsu-embark)
+
+(ert-deftest majutsu-embark-registers-bookmark-actions ()
+  "Bookmark candidates should expose domain actions without hiding general ones."
+  (should (eq (alist-get 'majutsu-bookmark embark-keymap-alist)
+              'majutsu-embark-bookmark-map))
+  (dolist (binding '(("RET" . majutsu-edit-revision)
+                     ("e" . majutsu-edit-revision)
+                     ("D" . majutsu-diff-revset)
+                     ("v" . majutsu-evolog)
+                     ("p" . majutsu-bookmark-advance-patterns)
+                     ("s" . majutsu-bookmark-set)
+                     ("m" . majutsu-bookmark-move)
+                     ("M" . majutsu-bookmark-move-allow-backwards)
+                     ("r" . majutsu-bookmark-rename)
+                     ("d" . majutsu-bookmark-delete)
+                     ("f" . majutsu-bookmark-forget)))
+    (should (eq (keymap-lookup majutsu-embark-bookmark-map (car binding))
+                (cdr binding))))
+  (should (eq (keymap-lookup majutsu-embark-bookmark-map "w")
+              #'embark-copy-as-kill)))
+
+(ert-deftest majutsu-embark-registers-workspace-actions ()
+  "Workspace completion candidates should expose their domain actions."
+  (should (eq (alist-get 'majutsu-workspace embark-keymap-alist)
+              'majutsu-embark-workspace-map))
+  (should (eq (keymap-lookup majutsu-embark-workspace-map "RET")
+              #'majutsu-workspace-visit-name))
+  (should (eq (keymap-lookup majutsu-embark-workspace-map "v")
+              #'majutsu-workspace-visit-name))
+  (should (eq (keymap-lookup majutsu-embark-workspace-map "d")
+              #'majutsu-workspace-dired))
+  (should (eq (keymap-lookup majutsu-embark-workspace-map "W")
+              #'majutsu-workspace-copy-root)))
+
+(provide 'majutsu-embark-test)
+;;; majutsu-embark-test.el ends here

--- a/test/majutsu-workspace-test.el
+++ b/test/majutsu-workspace-test.el
@@ -272,6 +272,19 @@
       (should (eq seen-history 'majutsu-workspace-name-history))
       (should (eq seen-category 'majutsu-workspace)))))
 
+(ert-deftest majutsu-workspace-read-root/uses-completion-context ()
+  "Workspace actions should reuse roots captured by the completion payload."
+  (let ((entries (make-hash-table :test #'equal)))
+    (puthash "feature" '(:name "feature" :root "/tmp/feature/") entries)
+    (let ((majutsu-completion-context (list :entries entries)))
+      (cl-letf (((symbol-function 'majutsu-workspace--section-entry)
+                 (lambda () nil))
+                ((symbol-function 'majutsu-workspace--root-for-name)
+                 (lambda (_name)
+                   (ert-fail "should not query jj when completion supplied the root"))))
+        (should (equal (majutsu-workspace--read-root "feature" "/tmp/main/")
+                       "/tmp/feature/"))))))
+
 (ert-deftest majutsu-workspace-visit/binds-default-directory ()
   "Ensure visiting another workspace updates buffer context."
   (let ((new-dir (make-temp-file "majutsu-test-" t))
@@ -288,6 +301,45 @@
           (should (equal seen-default (file-name-as-directory (expand-file-name new-dir))))
           (should (equal seen-root (file-name-as-directory (expand-file-name new-dir)))))
       (delete-directory new-dir t))))
+
+(ert-deftest majutsu-workspace-actions/interactive-always-prompts ()
+  "Embark target injection should reach a minibuffer instead of point context."
+  (let (visited)
+    (cl-letf (((symbol-function 'majutsu-workspace--prompt-name)
+               (lambda (&rest _args) "feature"))
+              ((symbol-function 'majutsu-workspace--read-name)
+               (lambda (&rest _args)
+                 (ert-fail "workspace actions must not use point context")))
+              ((symbol-function 'majutsu-workspace--read-root)
+               (lambda (name &optional _root)
+                 (should (equal name "feature"))
+                 "/tmp/feature/"))
+              ((symbol-function 'majutsu-workspace-visit)
+               (lambda (directory) (setq visited directory))))
+      (call-interactively #'majutsu-workspace-visit-name)
+      (should (equal visited "/tmp/feature/")))))
+
+(ert-deftest majutsu-workspace-actions/resolve-selected-name ()
+  "Workspace candidate actions should resolve the selected name once."
+  (let (visited dired-root copied)
+    (cl-letf (((symbol-function 'majutsu-workspace--read-root)
+               (lambda (name &optional root)
+                 (should (equal name "feature"))
+                 (should (equal root "/tmp/main/"))
+                 "/tmp/feature/"))
+              ((symbol-function 'majutsu-workspace-visit)
+               (lambda (directory) (setq visited directory)))
+              ((symbol-function 'dired)
+               (lambda (directory) (setq dired-root directory)))
+              ((symbol-function 'kill-new)
+               (lambda (value) (setq copied value)))
+              ((symbol-function 'message) #'ignore))
+      (majutsu-workspace-visit-name "feature" "/tmp/main/")
+      (majutsu-workspace-dired "feature" "/tmp/main/")
+      (majutsu-workspace-copy-root "feature" "/tmp/main/")
+      (should (equal visited "/tmp/feature/"))
+      (should (equal dired-root "/tmp/feature/"))
+      (should (equal copied "/tmp/feature")))))
 
 ;;; Wash tests
 


### PR DESCRIPTION
Expose completion context and repository directories to Embark actions, including workspace root reuse and reusable revision editing commands. Document the integration and add comprehensive tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Embark integration for workspace and bookmark completion candidates.
  * Added actions to visit, open, copy, edit, diff, inspect, move, rename, delete, and forget selected items.
  * Workspace actions now support opening roots in Dired and copying root paths.
* **Improvements**
  * Completion prompts now preserve relevant workspace context and directory information for more accurate actions.
  * Added a dedicated command for editing selected revisions.
* **Documentation**
  * Added Quick Start and reference documentation for Embark actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->