### PR TITLE
Use workspace name for destination default

### DIFF
--- a/majutsu-workspace.el
+++ b/majutsu-workspace.el
@@ -741,6 +741,21 @@ workspace roots only."
                        "Workspace(s) forgotten")))
         (message "Workspace forget failed")))))
 
+(defun majutsu-workspace--read-add-destination (root name)
+  "Read a sibling destination for a new workspace named NAME at ROOT.
+The initial input is \"PREFIX_NAME\", where PREFIX is the basename of
+ROOT up to its first underscore.  Slashes in NAME are replaced with dashes."
+  (let* ((path (directory-file-name root))
+         (basename (file-name-nondirectory path))
+         (prefix (if (string-match "_" basename)
+                     (substring basename 0 (match-beginning 0))
+                   basename)))
+    (read-directory-name
+     "Create workspace at: " (file-name-directory path) nil nil
+     (concat prefix "_"
+             (unless (string-empty-p name)
+               (string-replace "/" "-" name))))))
+
 ;;;###autoload
 (defun majutsu-workspace-add (destination &optional name revision sparse-patterns)
   "Add a workspace.
@@ -750,8 +765,6 @@ Optional NAME, REVISION (revset), and SPARSE-PATTERNS correspond to
   `jj workspace add` options."
   (interactive
    (let* ((root (majutsu--toplevel-safe))
-          (parent (file-name-directory (directory-file-name root)))
-          (destination (read-directory-name "Create workspace at: " parent nil nil))
           (name (string-trim
                  (or (majutsu-completing-read
                       "Workspace name (empty = default)"
@@ -759,6 +772,7 @@ Optional NAME, REVISION (revset), and SPARSE-PATTERNS correspond to
                       nil nil nil 'majutsu-workspace-name-history
                       nil 'majutsu-workspace)
                      "")))
+          (destination (majutsu-workspace--read-add-destination root name))
           (revision (or (majutsu-read-optional-revset
                          "Parent revset (-r, empty = default)"
                          nil nil 'majutsu-read-revset-history)

--- a/test/majutsu-workspace-test.el
+++ b/test/majutsu-workspace-test.el
@@ -467,6 +467,53 @@
     (should (equal (majutsu-workspace--read-root "feature")
                    "/tmp/feature/"))))
 
+(ert-deftest majutsu-workspace--read-add-destination/uses-name-as-sibling-default ()
+  "Workspace destinations should default to PREFIX_NAME beside the root."
+  (let (seen-args)
+    (cl-letf (((symbol-function 'read-directory-name)
+               (lambda (&rest args)
+                 (setq seen-args args)
+                 "/tmp/majutsu_FEATURE_B")))
+      (should (equal (majutsu-workspace--read-add-destination
+                      "/tmp/majutsu_OLD/" "FEATURE/B")
+                     "/tmp/majutsu_FEATURE_B"))
+      (should (equal seen-args
+                     '("Create workspace at: " "/tmp/" nil nil
+                       "majutsu_FEATURE-B"))))))
+
+(ert-deftest majutsu-workspace-add/interactive-reads-name-before-destination ()
+  "Interactive workspace add should use the name to default the destination."
+  (let (calls seen-args)
+    (cl-letf (((symbol-function 'majutsu--toplevel-safe)
+               (lambda (&optional _directory) "/tmp/majutsu/"))
+              ((symbol-function 'majutsu-workspace--names)
+               (lambda (&optional _directory) nil))
+              ((symbol-function 'majutsu-completing-read)
+               (lambda (prompt &rest _args)
+                 (cond
+                  ((string-prefix-p "Workspace name" prompt)
+                   (push 'name calls)
+                   "FEATURE_B")
+                  ((equal prompt "Sparse patterns") "copy"))))
+              ((symbol-function 'read-directory-name)
+               (lambda (_prompt directory _default _must-match initial)
+                 (push 'destination calls)
+                 (should (equal directory "/tmp/"))
+                 (should (equal initial "majutsu_FEATURE_B"))
+                 "/tmp/majutsu_FEATURE_B"))
+              ((symbol-function 'majutsu-read-optional-revset)
+               (lambda (&rest _args) nil))
+              ((symbol-function 'majutsu-run-jj)
+               (lambda (&rest args)
+                 (setq seen-args args)
+                 0))
+              ((symbol-function 'majutsu-workspace-visit) #'ignore))
+      (call-interactively #'majutsu-workspace-add)
+      (should (equal (nreverse calls) '(name destination)))
+      (should (equal seen-args
+                     '("workspace" "add" "/tmp/majutsu_FEATURE_B"
+                       "--name" "FEATURE_B"))))))
+
 (ert-deftest majutsu-workspace-add/uses-local-destination-for-jj ()
   "Workspace add should pass a local destination path to remote jj.
 The Emacs-facing path remains unchanged for visiting the new workspace."


### PR DESCRIPTION
Derive a sibling path from the root basename, prefixing the name and
replacing slashes with dashes. Add tests for the default and interactive
input order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workspace creation now suggests a sibling destination based on the repository name and selected workspace name.
  - Workspace names containing slashes are converted to dashes in the suggested destination.

- **Bug Fixes**
  - Workspace creation now prompts for the workspace name before selecting its destination, improving the default path selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->