### PR TITLE
Honor jj interactive diff-editor configuration.

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -90,6 +90,17 @@
   Use ~F~ to select whole-file changes, including binary and other hunkless
   changes, for Split, Squash, and Restore.
 
+- Configured jj diff editors ::
+  Split, Squash, and Restore honor =--interactive= and =--tool= using jj's
+  configured diff editor.  An explicit editor request takes precedence over
+  an Emacs patch selection.  Split also opens the editor when neither a patch
+  selection nor a fileset is supplied.
+
+- Terminal diff editors through Ghostel ::
+  Optional Ghostel integration hosts jj's built-in terminal diff editor.
+  ~majutsu-diff-editor-host~ selects the host; external non-terminal tools
+  can also run without Ghostel.
+
 - Revision information in diff buffers ::
   Single-revision change diffs show collapsible commit metadata and the full
   description.  Comparisons using =--from= / =--to= do not show a single commit's
@@ -198,6 +209,11 @@
 
 - Patch selection safety ::
   Concurrent patch operations no longer overwrite each other's patch input.
+
+- Cancelled editor sessions preserve selections ::
+  When a jj editor exits without changing the repository, the Emacs patch
+  selection remains available.  A changed or unverifiable repository state
+  invalidates the selection before it can be reused.
 
 - Files without a final newline ::
   Partial patch selections no longer join added text onto an unselected final

--- a/docs/majutsu.org
+++ b/docs/majutsu.org
@@ -930,6 +930,8 @@ Transient arguments:
 #+attr_reference: :kind transient-argument :interface "Squash transient"
 - Key: -f :: Source revisions (=--from=).
 - Key: -t :: Destination revision (=--into=).
+- Key: -i :: Open jj's configured diff editor for partial selection.
+- Key: ~=t~ :: Choose jj's diff editor with =--tool=NAME=.
 - Key: -o :: Onto destination.
 - Key: -A / -B :: Insert after or before constraints.
 - Key: -- :: Limit squash to specific filesets.
@@ -1008,6 +1010,8 @@ Transient arguments:
 #+attr_reference: :kind transient-argument :interface "Split transient"
 - Key: -r :: Specify the revision to split.
 - Key: -o :: Specify the destination (=--onto=).
+- Key: -i :: Open jj's configured diff editor for partial selection.
+- Key: ~=t~ :: Choose jj's diff editor with =--tool=NAME=.
 - Key: -A / -B :: Insert after or before constraints.
 - Key: -m :: Set a message for the first part.
 - Key: -p :: Parallel split mode.
@@ -1022,6 +1026,8 @@ Transient arguments:
 #+attr_reference: :kind transient-argument :interface "Restore transient"
 - Key: -f :: Restore from a specific revision (=--from=).
 - Key: -t :: Restore to a specific revision (=--to=).
+- Key: -i :: Open jj's configured diff editor for partial selection.
+- Key: ~=t~ :: Choose jj's diff editor with =--tool=NAME=.
 - Key: -c :: Undo changes introduced by a revision (=--changes-in=).
 - Key: -d :: Restore descendants as well.
 - Key: -- :: Limit restore to selected files or filesets.
@@ -1095,10 +1101,12 @@ operation is executed.
 *** Diff Context Inheritance
 When opening Split, Squash, or Restore from a Diff buffer, each transient maps
 the compatible part of the diff context to its own command:
-- Split converts a single =--revisions= source to =--revision=.
-- Squash converts =--revisions= sources to repeatable =--from= arguments.
-- Restore converts =--revisions= to =--changes-in= and also inherits explicit
-  =--from= / =--to= ranges.
+- Split inherits exactly one resolvable =--revisions= source as =--revision=; it
+  never passes a diff's arbitrary =--from= / =--to= range to =jj split=.
+- Squash turns =--revisions= into =--from= sources. An arbitrary =--from= /
+  =--to= tree diff is not treated as a Squash source.
+- Restore turns =--revisions= into =--changes-in= and additionally inherits
+  =--from= / =--to= parameters.
 
 Use a revision diff for Split or Squash. An arbitrary =--from= / =--to= range
 is meaningful as inherited context only for Restore.
@@ -1116,8 +1124,45 @@ face (green background by default). Selected regions within hunks use the
 changes with no text hunks use the
 =majutsu-interactive-selected-file= face.
 
+*** jj Diff Editors and Terminal Hosts
+Majutsu patch selection and jj's own diff-editor selection are separate
+workflows.  The =-i= / =--interactive= and =--tool=NAME= infixes start jj's
+configured diff editor without replacing it with Majutsu's patch helper.  This
+uses =--tool= exactly as jj defines it; =-t= remains a destination option for
+Squash and Restore, not a tool abbreviation.
+
+If an Emacs patch selection is active and you explicitly request a jj editor,
+the jj editor wins and the Emacs selection is retained.  With no explicit jj
+editor flag, =RET= applies the active Majutsu patch selection as before.  A
+selection is retained when an editor is cancelled or fails, and is cleared
+before a successful repository refresh so raw buffer positions cannot apply to
+a different diff.
+
+The default jj editor, =:builtin=, is a terminal TUI.  Customize
+=majutsu-diff-editor-host= to choose how Majutsu hosts it:
+
+- =auto= (the default) uses Ghostel when available with a local
+  =emacsclient=.  Otherwise it only falls back to a normal process for a known
+  external editor such as Meld.
+- =ghostel= requires Ghostel and supports jj's built-in TUI and external
+  terminal editors.
+- =process= is for external non-terminal tools only; Majutsu rejects
+  =:builtin= rather than trying to render it in a process buffer.
+
+Ghostel is optional.  Ghostel-hosted sessions require a local working
+=emacsclient= for jj's later description-editor invocation.  On TRAMP,
+=auto= routes a configured external editor through Majutsu's ordinary process
+path; the built-in =:builtin= recorder is rejected because Ghostel cannot
+bridge the later description editor there.  The same external-editor fallback
+is used locally when no usable =emacsclient= is configured.
+
 *** Selection Semantics
 The meaning of "selected" differs by operation:
+
+A Majutsu patch selection belongs to the Split, Squash, or Restore transient
+where it was first made.  It cannot silently be reused by a different command:
+clear it first.  Explicit jj editor requests are independent and do not inspect
+or consume that selection.
 
 **** Split and Squash
 For Split and Squash, *selected content is what gets moved*:
@@ -1150,8 +1195,10 @@ operation with selections:
    hunks and whole-file changes.  Hunkless whole-file changes are represented
    by structured jj metadata rather than inferred from rendered Git headers.
 
-2. *Tool Invocation*: Jujutsu's =-i --tool= mechanism is used with a custom
-   =majutsu-applypatch= tool.
+2. *Tool Invocation*: On the Majutsu patch-selection path, Jujutsu's
+   =-i --tool= mechanism is used with a custom =majutsu-applypatch= tool.
+   An explicitly requested user =--tool= instead takes the jj diff-editor path
+   described above.
 
    Each operation stores its patch file and helper script in a separate
    temporary directory, so overlapping asynchronous operations do not share

--- a/docs/majutsu.texi
+++ b/docs/majutsu.texi
@@ -139,6 +139,7 @@ Interactive Patching
 * How It Works::
 * Diff Context Inheritance::
 * Visual Feedback::
+* jj Diff Editors and Terminal Hosts::
 * Selection Semantics::
 * Technical Implementation::
 * Edge Cases::
@@ -1669,6 +1670,12 @@ Source revisions (@samp{--from}).
 @item @kbd{-t}
 @kindex -t
 Destination revision (@samp{--into}).
+@item @kbd{-i}
+@kindex -i
+Open jj's configured diff editor for partial selection.
+@item @kbd{@code{=t}}
+@kindex @code{=t}
+Choose jj's diff editor with @samp{--tool=NAME}.
 @item @kbd{-o}
 @kindex -o
 Onto destination.
@@ -1831,6 +1838,12 @@ Specify the revision to split.
 @item @kbd{-o}
 @kindex -o
 Specify the destination (@samp{--onto}).
+@item @kbd{-i}
+@kindex -i
+Open jj's configured diff editor for partial selection.
+@item @kbd{@code{=t}}
+@kindex @code{=t}
+Choose jj's diff editor with @samp{--tool=NAME}.
 @item @kbd{-A / -B}
 @kindex -A / -B
 Insert after or before constraints.
@@ -1864,6 +1877,12 @@ Restore from a specific revision (@samp{--from}).
 @item @kbd{-t}
 @kindex -t
 Restore to a specific revision (@samp{--to}).
+@item @kbd{-i}
+@kindex -i
+Open jj's configured diff editor for partial selection.
+@item @kbd{@code{=t}}
+@kindex @code{=t}
+Choose jj's diff editor with @samp{--tool=NAME}.
 @item @kbd{-c}
 @kindex -c
 Undo changes introduced by a revision (@samp{--changes-in}).
@@ -1969,6 +1988,7 @@ session ends; they are not a persistent staging area.
 * How It Works::
 * Diff Context Inheritance::
 * Visual Feedback::
+* jj Diff Editors and Terminal Hosts::
 * Selection Semantics::
 * Technical Implementation::
 * Edge Cases::
@@ -2015,12 +2035,14 @@ When opening Split@comma{} Squash@comma{} or Restore from a Diff buffer@comma{} 
 the compatible part of the diff context to its own command:
 @itemize
 @item
-Split converts a single @samp{--revisions} source to @samp{--revision}.
+Split inherits exactly one resolvable @samp{--revisions} source as @samp{--revision}; it
+never passes a diff's arbitrary @samp{--from} / @samp{--to} range to @samp{jj split}.
 @item
-Squash converts @samp{--revisions} sources to repeatable @samp{--from} arguments.
+Squash turns @samp{--revisions} into @samp{--from} sources. An arbitrary @samp{--from} /
+@samp{--to} tree diff is not treated as a Squash source.
 @item
-Restore converts @samp{--revisions} to @samp{--changes-in} and also inherits explicit
-@samp{--from} / @samp{--to} ranges.
+Restore turns @samp{--revisions} into @samp{--changes-in} and additionally inherits
+@samp{--from} / @samp{--to} parameters.
 @end itemize
 
 Use a revision diff for Split or Squash. An arbitrary @samp{--from} / @samp{--to} range
@@ -2047,10 +2069,54 @@ face (green background by default). Selected regions within hunks use the
 changes with no text hunks use the
 @samp{majutsu-interactive-selected-file} face.
 
+@node jj Diff Editors and Terminal Hosts
+@subsection jj Diff Editors and Terminal Hosts
+
+Majutsu patch selection and jj's own diff-editor selection are separate
+workflows.  The @samp{-i} / @samp{--interactive} and @samp{--tool=NAME} infixes start jj's
+configured diff editor without replacing it with Majutsu's patch helper.  This
+uses @samp{--tool} exactly as jj defines it; @samp{-t} remains a destination option for
+Squash and Restore@comma{} not a tool abbreviation.
+
+If an Emacs patch selection is active and you explicitly request a jj editor@comma{}
+the jj editor wins and the Emacs selection is retained.  With no explicit jj
+editor flag@comma{} @samp{RET} applies the active Majutsu patch selection as before.  A
+selection is retained when an editor is cancelled or fails@comma{} and is cleared
+before a successful repository refresh so raw buffer positions cannot apply to
+a different diff.
+
+The default jj editor@comma{} @samp{:builtin}@comma{} is a terminal TUI@.  Customize
+@samp{majutsu-diff-editor-host} to choose how Majutsu hosts it:
+
+@itemize
+@item
+@samp{auto} (the default) uses Ghostel when available with a local
+@samp{emacsclient}.  Otherwise it only falls back to a normal process for a known
+external editor such as Meld.
+@item
+@samp{ghostel} requires Ghostel and supports jj's built-in TUI and external
+terminal editors.
+@item
+@samp{process} is for external non-terminal tools only; Majutsu rejects
+@samp{:builtin} rather than trying to render it in a process buffer.
+@end itemize
+
+Ghostel is optional.  Ghostel-hosted sessions require a local working
+@samp{emacsclient} for jj's later description-editor invocation.  On TRAMP@comma{}
+@samp{auto} routes a configured external editor through Majutsu's ordinary process
+path; the built-in @samp{:builtin} recorder is rejected because Ghostel cannot
+bridge the later description editor there.  The same external-editor fallback
+is used locally when no usable @samp{emacsclient} is configured.
+
 @node Selection Semantics
 @subsection Selection Semantics
 
 The meaning of "selected" differs by operation:
+
+A Majutsu patch selection belongs to the Split@comma{} Squash@comma{} or Restore transient
+where it was first made.  It cannot silently be reused by a different command:
+clear it first.  Explicit jj editor requests are independent and do not inspect
+or consume that selection.
 
 @enumerate
 @item
@@ -2110,8 +2176,10 @@ hunks and whole-file changes.  Hunkless whole-file changes are represented
 by structured jj metadata rather than inferred from rendered Git headers.
 
 @item
-@strong{Tool Invocation}: Jujutsu's @samp{-i --tool} mechanism is used with a custom
-@samp{majutsu-applypatch} tool.
+@strong{Tool Invocation}: On the Majutsu patch-selection path@comma{} Jujutsu's
+@samp{-i --tool} mechanism is used with a custom @samp{majutsu-applypatch} tool.
+An explicitly requested user @samp{--tool} instead takes the jj diff-editor path
+described above.
 
 Each operation stores its patch file and helper script in a separate
 temporary directory@comma{} so overlapping asynchronous operations do not share

--- a/majutsu-diff-editor.el
+++ b/majutsu-diff-editor.el
@@ -1,0 +1,628 @@
+;;; majutsu-diff-editor.el --- Host jj diff-editor sessions  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 0WD0
+
+;; Author: 0WD0 <me@0wd0.com>
+;; Maintainer: 0WD0 <me@0wd0.com>
+;; Keywords: tools, vc
+;; URL: https://github.com/0WD0/majutsu
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; Shared argument handling and terminal hosting for jj diff-editor sessions.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'majutsu-jj)
+(require 'majutsu-process)
+(require 'majutsu-interactive)
+
+(declare-function ghostel-exec "ghostel" (buffer program &optional args))
+(declare-function ghostel-mode "ghostel" ())
+(declare-function majutsu-start-jj-with-editor "majutsu-process"
+                  (args &optional success-msg finish-callback inhibit-refresh))
+
+(defvar ghostel-exit-functions)
+(defvar ghostel-kill-buffer-on-exit)
+(defvar majutsu-process--start-created-callback)
+
+;;; Customization
+
+(defgroup majutsu-diff-editor nil
+  "jj diff-editor sessions in Majutsu."
+  :group 'majutsu)
+
+(defcustom majutsu-diff-editor-host 'auto
+  "How Majutsu hosts jj diff-editor sessions.
+
+`auto' uses Ghostel when it is available, otherwise it permits an
+ordinary process only for a known external editor.  `ghostel' requires
+Ghostel.  `process' always uses an ordinary process, which cannot host
+jj's built-in terminal editor."
+  :type '(choice (const :tag "Automatic" auto)
+                 (const :tag "Ghostel terminal" ghostel)
+                 (const :tag "Ordinary process (external editor only)" process))
+  :group 'majutsu-diff-editor)
+
+;;; Arguments
+
+(defun majutsu-diff-editor--inline-tool-value (arg)
+  "Return the tool value embedded in ARG, or nil when there is none."
+  (when (and (stringp arg) (string-prefix-p "--tool=" arg))
+    (substring arg (length "--tool="))))
+
+(defun majutsu-diff-editor--tool-option-p (arg)
+  "Return non-nil when ARG is a supported explicit tool option."
+  (or (equal arg "--tool")
+      (majutsu-diff-editor--inline-tool-value arg)))
+
+(defun majutsu-diff-editor-interactive-arguments-p (args)
+  "Return non-nil when ARGS request jj's diff-editor.
+
+Recognize `-i', `--interactive', and `--tool' spellings.
+Options after `--' are filesets, not command options."
+  (catch 'interactive
+    (dolist (arg args)
+      (cond
+       ((equal arg "--") (throw 'interactive nil))
+       ((or (member arg '("-i" "--interactive"))
+            (majutsu-diff-editor--tool-option-p arg))
+        (throw 'interactive t))))
+    nil))
+
+(defun majutsu-diff-editor-strip-interactive-arguments (args)
+  "Return ARGS without jj diff-editor options.
+
+Remove `-i', `--interactive', `--tool VALUE', and `--tool=VALUE' before
+`--'.  Preserve the separator and every following fileset exactly."
+  (let (result filesets)
+    (while args
+      (let ((arg (pop args)))
+        (cond
+         (filesets
+          (push arg result))
+         ((equal arg "--")
+          (setq filesets t)
+          (push arg result))
+         ((member arg '("-i" "--interactive")))
+         ((equal arg "--tool")
+          ;; Do not swallow the fileset separator when the option is malformed.
+          (when (and args (not (equal (car args) "--")))
+            (pop args)))
+         ((majutsu-diff-editor--inline-tool-value arg))
+         (t
+          (push arg result)))))
+    (nreverse result)))
+
+(defun majutsu-diff-editor-tool-from-arguments (args)
+  "Return the last explicit jj diff-editor tool in ARGS, or nil.
+
+Ignore tokens after `--'."
+  (let (tool filesets)
+    (while args
+      (let ((arg (pop args)))
+        (cond
+         (filesets)
+         ((equal arg "--")
+          (setq filesets t))
+         ((equal arg "--tool")
+          (when (and args (not (equal (car args) "--")))
+            (setq tool (pop args))))
+         ((let ((value (majutsu-diff-editor--inline-tool-value arg)))
+            (when value
+              (setq tool value)))))))
+    tool))
+
+(defun majutsu-diff-editor--missing-tool-value-p (args)
+  "Return non-nil when ARGS has a malformed explicit tool option."
+  (let (missing filesets)
+    (while (and args (not missing))
+      (let ((arg (pop args)))
+        (cond
+         (filesets)
+         ((equal arg "--")
+          (setq filesets t))
+         ((equal arg "--tool")
+          (if (and args (not (equal (car args) "--")))
+              (pop args)
+            (setq missing t)))
+         ((let ((value (majutsu-diff-editor--inline-tool-value arg)))
+            (and value (string-empty-p value)))
+          (setq missing t)))))
+    missing))
+
+;;; Host selection
+
+(defun majutsu-diff-editor-ghostel-available-p ()
+  "Return non-nil when Ghostel's public execution API is available.
+
+Ghostel remains an optional dependency, so it is only required when a
+diff-editor session needs it."
+  (and (require 'ghostel nil t)
+       (fboundp 'ghostel-exec)
+       (fboundp 'ghostel-mode)))
+
+(defun majutsu-diff-editor--config-overrides (args)
+  "Return global config overrides in ARGS, before its fileset separator."
+  (let (result filesets)
+    (while args
+      (let ((arg (pop args)))
+        (cond
+         (filesets)
+         ((equal arg "--")
+          (setq filesets t))
+         ((member arg '("--config" "--config-file"))
+          (push arg result)
+          (when (and args (not (equal (car args) "--")))
+            (push (pop args) result)))
+         ((and (stringp arg)
+               (or (string-prefix-p "--config=" arg)
+                   (string-prefix-p "--config-file=" arg)))
+          (push arg result)))))
+    (nreverse result)))
+
+(defun majutsu-diff-editor--configured-tool (args)
+  "Return the configured `ui.diff-editor' value for ARGS, or nil.
+
+`majutsu-jj-string' itself prepends `majutsu-jj-global-arguments'; repeat only
+the invocation-specific config overrides here so the probe has the same order
+as the eventual jj invocation.
+A missing setting deliberately returns nil: jj then defaults to `:builtin'."
+  (condition-case nil
+      (when-let* ((value
+                   (apply #'majutsu-jj-string
+                          (append (majutsu-diff-editor--config-overrides args)
+                                  '("--ignore-working-copy"
+                                    "config" "get" "ui.diff-editor")))))
+        (string-trim value))
+    (error nil)))
+
+(defun majutsu-diff-editor--effective-tool (args)
+  "Return the known effective diff-editor tool for ARGS.
+
+An explicit tool wins over `ui.diff-editor'; absent or unreadable config
+has jj's documented `:builtin' default."
+  (or (majutsu-diff-editor-tool-from-arguments args)
+      (majutsu-diff-editor--configured-tool args)
+      ":builtin"))
+
+(defun majutsu-diff-editor--builtin-tool-p (tool)
+  "Return non-nil when TOOL is jj's built-in terminal editor."
+  (equal tool ":builtin"))
+
+(defvar majutsu-diff-editor--process-fallback-noticed nil
+  "Whether this Emacs session has explained the external process fallback.")
+
+(defun majutsu-diff-editor--note-process-fallback ()
+  "Explain the limitations of an ordinary process fallback once."
+  (unless majutsu-diff-editor--process-fallback-noticed
+    (setq majutsu-diff-editor--process-fallback-noticed t)
+    (message (concat "Using an ordinary process for the external jj diff "
+                     "editor. Terminal editors require Ghostel."))))
+
+(defun majutsu-diff-editor-select-host (args)
+  "Return the host symbol to use for a jj diff-editor session with ARGS.
+
+Signal `user-error' rather than starting a terminal editor in a pipe.
+The return value is either `ghostel' or `process'."
+  (when (majutsu-diff-editor--missing-tool-value-p args)
+    (user-error "jj --tool requires a tool name"))
+  (pcase majutsu-diff-editor-host
+    ('ghostel
+     (if (majutsu-diff-editor-ghostel-available-p)
+         'ghostel
+       (user-error "Ghostel is required for the selected diff-editor host")))
+    ('auto
+     (let ((tool (majutsu-diff-editor--effective-tool args)))
+       (cond
+        ;; Ghostel cannot bridge with-editor's sleeping-editor protocol over
+        ;; TRAMP.  An external tool can still use Majutsu's ordinary remote
+        ;; process path; the built-in recorder cannot.
+        ((file-remote-p default-directory)
+         (if (majutsu-diff-editor--builtin-tool-p tool)
+             (user-error (concat "jj's :builtin diff editor needs a terminal host; "
+                                 "Ghostel sessions over TRAMP are unsupported, so "
+                                 "configure an external editor"))
+           (majutsu-diff-editor--note-process-fallback)
+           'process))
+        ((and (majutsu-diff-editor-ghostel-available-p)
+              with-editor-emacsclient-executable)
+         'ghostel)
+        ((majutsu-diff-editor--builtin-tool-p tool)
+         (user-error (concat "jj's :builtin diff editor requires Ghostel and a "
+                             "working emacsclient; configure an external editor "
+                             "or set `with-editor-emacsclient-executable'")))
+        (t
+         (majutsu-diff-editor--note-process-fallback)
+         'process))))
+    ('process
+     (if (majutsu-diff-editor--builtin-tool-p
+          (majutsu-diff-editor--effective-tool args))
+         (user-error (concat "jj's :builtin diff editor requires a terminal host; "
+                             "select Ghostel instead"))
+       'process))
+    (_
+     (user-error "Invalid `majutsu-diff-editor-host': %S"
+                 majutsu-diff-editor-host))))
+
+;;; Sessions
+
+(cl-defstruct (majutsu-diff-editor-session
+               (:constructor majutsu-diff-editor-session-create))
+  "A running jj diff-editor session."
+  command args filesets origin-buffer repository-root
+  host terminal-buffer process
+  operation-id-before selection-context started-at completed-p)
+
+(defvar-local majutsu-diff-editor--session nil
+  "The `majutsu-diff-editor-session' associated with this terminal buffer.")
+
+(defvar majutsu-diff-editor--live-sessions (make-hash-table :test 'equal)
+  "Majutsu-owned diff-editor sessions indexed by repository root.")
+
+(defun majutsu-diff-editor--session-active-p (_session)
+  "Return non-nil while SESSION still owns its repository interaction slot."
+  ;; Do not use `process-live-p' here.  A child may have exited while its
+  ;; zero-delay completion timer has not yet run; releasing the slot in that
+  ;; window would allow a second history rewrite to overlap completion.
+  t)
+
+(defun majutsu-diff-editor--register-session (session)
+  "Reserve SESSION's repository slot, or signal if another session owns it."
+  (let* ((root (majutsu-diff-editor-session-repository-root session))
+         (existing (gethash root majutsu-diff-editor--live-sessions)))
+    (when existing
+      (if (majutsu-diff-editor--session-active-p existing)
+          (user-error "A jj diff-editor session is already active for this repository")
+        (remhash root majutsu-diff-editor--live-sessions)))
+    (puthash root session majutsu-diff-editor--live-sessions)))
+
+(defun majutsu-diff-editor--unregister-session (session)
+  "Release SESSION's repository slot if it is still its owner."
+  (let ((root (majutsu-diff-editor-session-repository-root session)))
+    (when (eq (gethash root majutsu-diff-editor--live-sessions) session)
+      (remhash root majutsu-diff-editor--live-sessions))))
+
+(defun majutsu-diff-editor--session-lifecycle-process (session)
+  "Return SESSION's known lifecycle process, if one has been created."
+  (or (majutsu-diff-editor-session-process session)
+      (when-let* ((buffer (majutsu-diff-editor-session-terminal-buffer session))
+                  ((buffer-live-p buffer)))
+        ;; This is a public Emacs association.  It also covers a non-local
+        ;; exit from `ghostel-exec' after the PTY process exists but before it
+        ;; could return its lifecycle object to us.
+        (get-buffer-process buffer))))
+
+(defun majutsu-diff-editor--cleanup-unstarted-terminal-buffer (session)
+  "Remove SESSION bookkeeping and kill its terminal buffer before spawn.
+
+The function is deliberately quiet and idempotent so it is safe from the
+inner Ghostel startup cleanup and the outer session-start cleanup."
+  (when-let* ((buffer (majutsu-diff-editor-session-terminal-buffer session))
+              ((buffer-live-p buffer)))
+    (let ((inhibit-quit t))
+      (with-current-buffer buffer
+        (setq-local majutsu-diff-editor--session nil)
+        (remove-hook 'kill-buffer-hook
+                     #'majutsu-diff-editor--terminal-buffer-killed t)
+        (remove-hook 'ghostel-exit-functions
+                     #'majutsu-diff-editor--ghostel-exit t))
+      (ignore-errors (kill-buffer buffer)))))
+
+(defun majutsu-diff-editor--abort-session-start (session)
+  "Clean up SESSION after a non-local exit during startup.
+
+If a session-owned child exists, retain its repository slot until completion:
+it may have exited just before its deferred callback runs.  A child that never
+received a completion owner is stopped and treated as an unknown outcome."
+  (let ((process (majutsu-diff-editor--session-lifecycle-process session)))
+    (when (and process (not (majutsu-diff-editor-session-process session)))
+      (setf (majutsu-diff-editor-session-process session) process))
+    (cond
+     ;; No child exists, so this is a pure setup failure.  The user selection
+     ;; remains valid and the slot can be released immediately.
+     ((not process)
+      (let ((inhibit-quit t))
+        (majutsu-diff-editor--cleanup-unstarted-terminal-buffer session)
+        (majutsu-diff-editor--unregister-session session)))
+     ;; Ghostel installs its exit hook before spawning.  Even a dead lifecycle
+     ;; process may already have queued that hook, so retain the slot.  Queue a
+     ;; duplicate-safe fallback only after the reaper is no longer live.
+     ((eq (majutsu-diff-editor-session-host session) 'ghostel)
+      (unless (and (processp process) (process-live-p process))
+        (run-at-time 0 nil #'majutsu-diff-editor--complete-session session)))
+     ;; The ordinary runner's callback is installed before its sentinel.  Keep
+     ;; its slot even after the child exits: that callback alone has the real
+     ;; exit status needed to distinguish failure from a clean editor cancel.
+     ((and (processp process) (process-get process 'finish-callback))
+      nil)
+     ;; A child was created but setup was interrupted before it gained a
+     ;; completion owner.  It could have mutated the repo, so make selection
+     ;; state conservative before freeing the slot.
+     (t
+      (let ((inhibit-quit t))
+        (when (and (processp process) (process-live-p process))
+          (ignore-errors (delete-process process)))
+        (majutsu-diff-editor--cleanup-unstarted-terminal-buffer session)
+        (majutsu-diff-editor--abort-session-completion session)
+        (majutsu-diff-editor--unregister-session session))))))
+
+(defvar majutsu-diff-editor-session-exit-hook nil
+  "Functions called after a Ghostel diff-editor session ends.
+
+Each function receives SESSION and Ghostel's EVENT string.  It runs via a
+zero-delay timer, outside Ghostel's process sentinel.")
+
+(defun majutsu-diff-editor--operation-id (root)
+  "Return ROOT's current jj operation id without snapshotting its working copy.
+
+Return nil when jj cannot provide an id.  Callers must treat that result as an
+unknown session outcome rather than as success or cancellation."
+  (condition-case nil
+      (let ((default-directory root))
+        (when-let* ((id (majutsu-jj-string
+                         "--ignore-working-copy" "operation" "log"
+                         "--no-graph" "-n" "1" "-T" "id")))
+          (unless (string-empty-p id)
+            id)))
+    (error nil)))
+
+(defun majutsu-diff-editor--invalidate-origin-selection (session)
+  "Invalidate SESSION's origin-buffer patch selection, if it is still live."
+  (when-let* ((buffer (majutsu-diff-editor-session-origin-buffer session))
+              ((buffer-live-p buffer)))
+    (with-current-buffer buffer
+      (when (fboundp 'majutsu-interactive-invalidate)
+        (majutsu-interactive-invalidate)))))
+
+(defun majutsu-diff-editor--refresh-origin (session)
+  "Refresh SESSION's live origin buffer after a repository state change."
+  (when-let* ((buffer (majutsu-diff-editor-session-origin-buffer session))
+              ((buffer-live-p buffer)))
+    (with-current-buffer buffer
+      (let ((default-directory
+             (majutsu-diff-editor-session-repository-root session)))
+        (when (derived-mode-p 'majutsu-mode)
+          (majutsu-refresh))))))
+
+(defun majutsu-diff-editor--abort-session-completion (session)
+  "Conservatively invalidate SESSION when its completion is interrupted."
+  ;; A quit during the operation-id probe leaves the repository outcome
+  ;; unknown.  Never leave position-based selections usable in that state.
+  (let ((inhibit-quit t))
+    (majutsu-diff-editor--invalidate-origin-selection session)
+    ;; Refresh later, outside the interrupted synchronous probe.  The origin
+    ;; may already be gone; `majutsu-diff-editor--refresh-origin' handles it.
+    (run-at-time 0 nil #'majutsu-diff-editor--refresh-origin session)))
+
+(defun majutsu-diff-editor--complete-session (session &optional event)
+  "Complete SESSION after EVENT, conservatively handling unknown outcomes.
+
+Ghostel's lifecycle process does not expose jj's child exit status.  The
+operation id therefore determines whether rendered selections remain safe.
+For process-hosted sessions it also avoids treating a zero-status cancel as a
+successful history rewrite."
+  (unless (majutsu-diff-editor-session-completed-p session)
+    (setf (majutsu-diff-editor-session-completed-p session) t)
+    (let (outcome completed-normally)
+      ;; Include the operation-id probe in the protected form.  `quit' is not
+      ;; an `error', and must not leave a completed session registered forever.
+      (unwind-protect
+          (let* ((before (majutsu-diff-editor-session-operation-id-before session))
+                 (after (majutsu-diff-editor--operation-id
+                         (majutsu-diff-editor-session-repository-root session))))
+            (setq outcome
+                  (cond
+                   ((and before after (equal before after)) 'unchanged)
+                   ((and before after) 'changed)
+                   (t 'unknown)))
+            (pcase outcome
+              ('unchanged
+               (message "jj diff editor ended without a repository operation"))
+              ('changed
+               (majutsu-diff-editor--invalidate-origin-selection session)
+               (majutsu-diff-editor--refresh-origin session))
+              ('unknown
+               ;; A failed probe is not evidence that the old buffer positions
+               ;; are still valid.  Clear and refresh rather than risking the
+               ;; wrong patch.
+               (majutsu-diff-editor--invalidate-origin-selection session)
+               (majutsu-diff-editor--refresh-origin session)
+               (message "jj diff editor ended; could not verify its repository result")))
+            (setq completed-normally t)
+            outcome)
+        (unless completed-normally
+          (majutsu-diff-editor--abort-session-completion session))
+        (majutsu-diff-editor--unregister-session session))
+      ;; Hooks are observers, not part of the transactional completion path.
+      ;; In particular they may immediately start another session for ROOT.
+      (when event
+        (run-hook-with-args 'majutsu-diff-editor-session-exit-hook
+                            session event))
+      outcome)))
+
+(defun majutsu-diff-editor--finish-process-session (session exit-code)
+  "Finish process-hosted SESSION after EXIT-CODE outside its sentinel."
+  (if (and (integerp exit-code) (zerop exit-code))
+      (majutsu-diff-editor--complete-session session)
+    ;; The process runner has reported the failure.  jj's transaction is
+    ;; expected to be atomic, so retain the user's patch selection.
+    (majutsu-diff-editor--unregister-session session)))
+
+(defun majutsu-diff-editor--session-jj-arguments (session)
+  "Return jj argv, after the executable, for SESSION."
+  (cons (majutsu-diff-editor-session-command session)
+        (majutsu-jj-append-filesets
+         (majutsu-diff-editor-session-args session)
+         (majutsu-diff-editor-session-filesets session))))
+
+(defun majutsu-diff-editor--terminal-buffer-name (session)
+  "Return a fresh Ghostel terminal buffer name for SESSION."
+  (format "*majutsu %s diff editor: %s*"
+          (majutsu-diff-editor-session-command session)
+          (abbreviate-file-name
+           (directory-file-name
+            (majutsu-diff-editor-session-repository-root session)))))
+
+(defun majutsu-diff-editor--finish-ghostel-session (session event)
+  "Run SESSION's Ghostel exit hook after EVENT outside its sentinel."
+  (majutsu-diff-editor--complete-session session event))
+
+(defun majutsu-diff-editor--ghostel-exit (buffer event)
+  "Defer completion of BUFFER's diff-editor session after Ghostel EVENT."
+  (when (buffer-live-p buffer)
+    (when-let* ((session
+                 (buffer-local-value 'majutsu-diff-editor--session buffer)))
+      (run-at-time 0 nil #'majutsu-diff-editor--finish-ghostel-session
+                   session event))))
+
+(defun majutsu-diff-editor--terminal-buffer-killed ()
+  "Finish the session associated with a manually killed Ghostel buffer."
+  (when majutsu-diff-editor--session
+    (run-at-time 0 nil #'majutsu-diff-editor--finish-terminal-kill
+                 majutsu-diff-editor--session)))
+
+(defun majutsu-diff-editor--finish-terminal-kill (session)
+  "Complete SESSION after its Ghostel lifecycle process has stopped.
+
+Killing the terminal buffer first closes its display.  Ghostel's native
+reaper may still be waiting for jj to finish and record an operation, so do
+not compare operation ids until that lifecycle process has exited."
+  (let ((process (majutsu-diff-editor-session-process session)))
+    (if (and (processp process) (process-live-p process))
+        (run-at-time 0.05 nil #'majutsu-diff-editor--finish-terminal-kill
+                     session)
+      (majutsu-diff-editor--complete-session session))))
+
+(defun majutsu-diff-editor--assert-ghostel-editor-support (root)
+  "Signal unless Ghostel can support jj's later `JJ_EDITOR' invocation.
+
+Ghostel's public execution API has no with-editor sleeping-editor filter.  A
+remote session, or a local Emacs without emacsclient, would render the control
+packet but leave jj waiting forever."
+  (when (file-remote-p root)
+    (user-error (concat "Ghostel jj diff-editor sessions over TRAMP are not yet "
+                        "supported; use an external terminal instead")))
+  (unless with-editor-emacsclient-executable
+    (user-error (concat "Ghostel jj diff-editor sessions require emacsclient for "
+                        "JJ_EDITOR; configure `with-editor-emacsclient-executable'"))))
+
+(defun majutsu-diff-editor--start-ghostel (session)
+  "Start SESSION through Ghostel's public API and return SESSION."
+  (let ((root (majutsu-diff-editor-session-repository-root session)))
+    (majutsu-diff-editor--assert-ghostel-editor-support root)
+    (let* ((buffer (generate-new-buffer
+                    (majutsu-diff-editor--terminal-buffer-name session)))
+           (command (majutsu-diff-editor--session-jj-arguments session))
+           (args (let ((default-directory root))
+                   (majutsu-process-jj-arguments command)))
+           (program (let ((default-directory root))
+                      (majutsu-jj--executable))))
+      (let ((started nil))
+        (unwind-protect
+            (progn
+              (setf (majutsu-diff-editor-session-terminal-buffer session) buffer)
+              (with-current-buffer buffer
+                (setq default-directory root)
+                ;; `ghostel-exec' initializes a non-Ghostel buffer by enabling
+                ;; its major mode.  Major-mode activation clears ordinary
+                ;; buffer-local variables, so do that public initialization
+                ;; first; the session hook and retained transcript settings must
+                ;; be installed afterwards.
+                (ghostel-mode)
+                (setq default-directory root)
+                (setq-local majutsu-diff-editor--session session)
+                (add-hook 'kill-buffer-hook
+                          #'majutsu-diff-editor--terminal-buffer-killed nil t)
+                ;; Preserve the transcript, and install the hook before the child exists.
+                (setq-local ghostel-kill-buffer-on-exit nil)
+                (add-hook 'ghostel-exit-functions
+                          #'majutsu-diff-editor--ghostel-exit nil t))
+              ;; `ghostel-exec' uses an undisplayed buffer's 80x24 fallback,
+              ;; which is unsuitable for jj's full-screen built-in editor.
+              (majutsu-display-buffer buffer)
+              (let ((default-directory root))
+                (majutsu-with-editor
+                  ;; `majutsu-with-editor' has installed JJ_EDITOR in the dynamic
+                  ;; environment.  Build Majutsu's normal jj environment after
+                  ;; that, so Ghostel inherits both JJ_EDITOR and user overrides.
+                  (let ((process-environment (majutsu-process-environment args)))
+                    (setf (majutsu-diff-editor-session-process session)
+                          (ghostel-exec buffer program args))))
+                (setq started t)
+                session))
+          (unless started
+            (majutsu-diff-editor--abort-session-start session)))))))
+
+(defun majutsu-diff-editor--start-process (session)
+  "Start SESSION in Majutsu's ordinary asynchronous process buffer."
+  (let ((args (majutsu-diff-editor--session-jj-arguments session))
+        (root (majutsu-diff-editor-session-repository-root session)))
+    (setf (majutsu-diff-editor-session-process session)
+          ;; The process API records these properties before installing its
+          ;; sentinel.  The callback then decides refresh from the operation
+          ;; id, so a normal editor cancel cannot discard Emacs selections.
+          (let ((default-directory root)
+                (majutsu-process--start-created-callback
+                 (lambda (process)
+                   (setf (majutsu-diff-editor-session-process session) process))))
+            (if (fboundp 'majutsu-start-jj-with-editor)
+                (majutsu-start-jj-with-editor
+                 args nil
+                 (lambda (_process exit-code)
+                   ;; Defer both the jj probe and refresh out of the process
+                   ;; sentinel.  A failed process leaves the selection intact.
+                   (run-at-time 0 nil
+                                #'majutsu-diff-editor--finish-process-session
+                                session exit-code))
+                 t)
+              (majutsu-run-jj-with-editor args))))
+    session))
+
+;;;###autoload
+(cl-defun majutsu-diff-editor-start
+    (command args filesets &key origin-buffer selection-context)
+  "Start jj COMMAND's configured diff-editor session.
+
+ARGS are command options and FILESETS are already separated fileset values.
+When ORIGIN-BUFFER is supplied it supplies the repository root; otherwise the
+current buffer does.  SELECTION-CONTEXT is retained for a later session owner
+to validate on completion.  Return a `majutsu-diff-editor-session'."
+  (unless (and (stringp command) (not (string-empty-p command)))
+    (user-error "A jj diff-editor command is required"))
+  (let* ((origin-buffer (or origin-buffer (current-buffer)))
+         (root (if (buffer-live-p origin-buffer)
+                   (with-current-buffer origin-buffer
+                     (or (majutsu--buffer-root origin-buffer)
+                         (majutsu--toplevel-safe default-directory)))
+                 (majutsu--toplevel-safe default-directory)))
+         (session
+          (majutsu-diff-editor-session-create
+           :command command
+           :args (copy-sequence (or args '()))
+           :filesets (copy-sequence (or filesets '()))
+           :origin-buffer origin-buffer
+           :repository-root (file-name-as-directory root)
+           :host (let ((default-directory (file-name-as-directory root)))
+                   (majutsu-diff-editor-select-host args))
+           :operation-id-before
+           (majutsu-diff-editor--operation-id (file-name-as-directory root))
+           :selection-context selection-context
+           :started-at (current-time))))
+    (majutsu-diff-editor--register-session session)
+    (let ((started nil))
+      (unwind-protect
+          (prog1
+              (pcase (majutsu-diff-editor-session-host session)
+                ('ghostel (majutsu-diff-editor--start-ghostel session))
+                ('process (majutsu-diff-editor--start-process session)))
+            (setq started t))
+        (unless started
+          (majutsu-diff-editor--abort-session-start session))))))
+
+;;; _
+(provide 'majutsu-diff-editor)
+;;; majutsu-diff-editor.el ends here

--- a/majutsu-interactive.el
+++ b/majutsu-interactive.el
@@ -61,6 +61,47 @@ region within a hunk.")
 (defvar-local majutsu-interactive--overlays nil
   "List of overlays for selection visualization.")
 
+(defvar-local majutsu-interactive--selection-operation nil
+  "Transient operation that owns the current patch selection.")
+
+(defun majutsu-interactive--current-operation ()
+  "Return the patch-selection operation active in the current transient."
+  (and (boundp 'transient-current-command)
+       (memq transient-current-command
+             '(majutsu-split majutsu-squash majutsu-restore))
+       transient-current-command))
+
+(defun majutsu-interactive--assert-selection-context (&optional operation)
+  "Signal if current selections belong to a different OPERATION.
+
+OPERATION is a transient command symbol such as `majutsu-split'.  A selection
+is deliberately not transferable between jj commands: its patch direction and
+the command's source semantics differ."
+  (when (and operation
+             (majutsu-interactive--has-selections-p)
+             (not (eq majutsu-interactive--selection-operation operation)))
+    (user-error "Patch selection belongs to %s; clear it before using %s"
+                (or majutsu-interactive--selection-operation "another context")
+                operation)))
+
+(defun majutsu-interactive--ensure-selection-context ()
+  "Bind a new selection to the current transient operation, or validate it."
+  (let ((operation (majutsu-interactive--current-operation)))
+    (if (majutsu-interactive--has-selections-p)
+        (majutsu-interactive--assert-selection-context operation)
+      (setq majutsu-interactive--selection-operation operation))))
+
+(defun majutsu-interactive-invalidate ()
+  "Discard selections whose rendered diff is about to be rebuilt.
+
+Interactive selection ranges are buffer positions, so retaining them across a
+diff refresh would make a later patch apply to unrelated text.  This helper is
+quiet on purpose; callers use it as part of refresh lifecycle rather than an
+explicit user action."
+  (setq majutsu-interactive--selections nil)
+  (setq majutsu-interactive--selection-operation nil)
+  (majutsu-interactive--clear-overlays))
+
 (defun majutsu-interactive--hunk-id (section)
   "Return unique identifier for hunk SECTION."
   (oref section value))
@@ -109,11 +150,14 @@ region within a hunk.")
   (with-current-buffer (or buffer (current-buffer))
     (majutsu-interactive--has-selections-p)))
 
-(defun majutsu-interactive-build-patch-if-selected (&optional buffer invert include-all-files)
+(defun majutsu-interactive-build-patch-if-selected
+    (&optional buffer invert include-all-files operation)
   "Return patch for BUFFER if there are selections, otherwise nil.
 When INVERT is non-nil, invert the selection within each hunk.
-When INCLUDE-ALL-FILES is non-nil, include hunks from all files in invert mode."
+When INCLUDE-ALL-FILES is non-nil, include hunks from all files in invert mode.
+OPERATION, when non-nil, must own BUFFER's patch selection."
   (with-current-buffer (or buffer (current-buffer))
+    (majutsu-interactive--assert-selection-context operation)
     (when (majutsu-interactive--has-selections-p)
       (majutsu-interactive--build-patch invert include-all-files))))
 
@@ -126,6 +170,7 @@ When INCLUDE-ALL-FILES is non-nil, include hunks from all files in invert mode."
     (when (cl-typep section 'majutsu-hunk-section)
       (let* ((hunk-id (majutsu-interactive--hunk-id section))
              (current (majutsu-interactive--get-selection hunk-id)))
+        (majutsu-interactive--ensure-selection-context)
         (majutsu-interactive--set-selection
          hunk-id (if current nil :all))
         (majutsu-interactive--render-overlays)
@@ -178,6 +223,7 @@ When INCLUDE-ALL-FILES is non-nil, include hunks from all files in invert mode."
   (unless (majutsu-diff-file-metadata file-section)
     (user-error
      "Cannot verify this whole-file selection against structured metadata from jj; refresh the diff and try again"))
+  (majutsu-interactive--ensure-selection-context)
   (let* ((id (majutsu-interactive--file-id (oref file-section value)))
          (current (majutsu-interactive--get-selection id)))
     (majutsu-interactive--set-selection id (unless current :all))
@@ -202,19 +248,21 @@ When INCLUDE-ALL-FILES is non-nil, include hunks from all files in invert mode."
         (let ((hunks (majutsu-interactive--file-section-hunks file-section)))
           (if (null hunks)
               (majutsu-interactive--toggle-whole-file file-section)
-            (let ((all-selected
-                   (cl-every
-                    (lambda (h)
-                      (majutsu-interactive--get-selection
-                       (majutsu-interactive--hunk-id h)))
-                    hunks)))
-              (dolist (hunk hunks)
-                (majutsu-interactive--set-selection
-                 (majutsu-interactive--hunk-id hunk)
-                 (unless all-selected :all)))
-              (majutsu-interactive--render-overlays)
-              (message "%s all hunks in file"
-                       (if all-selected "Deselected" "Selected")))))))))
+            (progn
+              (majutsu-interactive--ensure-selection-context)
+              (let ((all-selected
+                     (cl-every
+                      (lambda (h)
+                        (majutsu-interactive--get-selection
+                         (majutsu-interactive--hunk-id h)))
+                      hunks)))
+                (dolist (hunk hunks)
+                  (majutsu-interactive--set-selection
+                   (majutsu-interactive--hunk-id hunk)
+                   (unless all-selected :all)))
+                (majutsu-interactive--render-overlays)
+                (message "%s all hunks in file"
+                         (if all-selected "Deselected" "Selected"))))))))))
 
 (defun majutsu-interactive--normalize-line-range (start end limit-start limit-end)
   "Return a line-aligned range between START and END.
@@ -252,6 +300,7 @@ The range is clamped to LIMIT-START and LIMIT-END."
                     (region-beginning) (region-end)
                     (oref it content) (oref it end)))
             (current (majutsu-interactive--get-selection hunk-id)))
+       (majutsu-interactive--ensure-selection-context)
        (unless range
          (user-error "Region is outside hunk"))
        (cond
@@ -713,7 +762,8 @@ Returns patch string or nil if no selections."
         (majutsu-interactive--fixup-patch
          (mapconcat #'identity (nreverse patches) ""))))))
 
-(defun majutsu-interactive-build-replay-plan-if-selected (&optional buffer mode)
+(defun majutsu-interactive-build-replay-plan-if-selected
+    (&optional buffer mode operation)
   "Return a plan that reconstructs the editor's right tree from selections.
 MODE is `selected' for Split and Squash, or `complement' for Restore.  A
 selected plan starts from the editor's left tree and replays selected changes
@@ -722,8 +772,10 @@ tree and replays unselected changes from the left tree.  Both plans apply
 their text patches forward; this keeps new-file and copy patches valid.
 
 The returned plist contains :base, :payload-root, :patch, and :file-ops, or
-nil when BUFFER has no selections."
+nil when BUFFER has no selections.  OPERATION, when non-nil, must own
+BUFFER's patch selection."
   (with-current-buffer (or buffer (current-buffer))
+    (majutsu-interactive--assert-selection-context operation)
     (when (majutsu-interactive--has-selections-p)
       (pcase (or mode 'selected)
         ('selected
@@ -903,11 +955,51 @@ Remove its temporary directory when PROCESS exits or is signaled."
         t)
     nil))
 
+(defun majutsu-interactive--operation-id (root)
+  "Return ROOT's current jj operation id without snapshotting its worktree.
+
+Return nil if the id cannot be read.  Selection positions must be considered
+unsafe in that case, so callers treat nil as an unknown operation result."
+  (condition-case nil
+      (let ((default-directory root))
+        (when-let* ((id (majutsu-jj-string
+                         "--ignore-working-copy" "operation" "log"
+                         "--no-graph" "-n" "1" "-T" "id")))
+          (unless (string-empty-p id)
+            id)))
+    (error nil)))
+
+(defun majutsu-interactive--complete-patch-operation (buffer operation-before)
+  "Refresh BUFFER after a custom patch operation when its repository changed.
+
+When jj reports no new operation, retain BUFFER's Emacs-owned selection so a
+cancelled external editor or failed helper does not discard the user's work.
+An unreadable operation id is handled conservatively: positions are cleared
+before refresh rather than being reused against a different diff."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (let ((operation-after
+             (majutsu-interactive--operation-id
+              (majutsu--toplevel-safe default-directory))))
+        (cond
+         ((and operation-before operation-after
+               (equal operation-before operation-after))
+          (message "jj patch selection ended without a repository operation"))
+         (t
+          (majutsu-interactive-invalidate)
+          (majutsu-refresh)
+          (unless (and operation-before operation-after)
+            (message "jj patch selection ended; could not verify its repository result"))))))))
+
 (defun majutsu-interactive-run-replay-plan (command args filesets plan)
   "Run jj COMMAND with ARGS and FILESETS using replay PLAN.
 PLAN reconstructs the merge editor's right tree from its selected or
 complemented text and whole-file changes."
   (let ((directory (majutsu-interactive--make-operation-temp-dir))
+        (origin-buffer (current-buffer))
+        (operation-before
+         (majutsu-interactive--operation-id
+          (majutsu--toplevel-safe default-directory)))
         retained)
     (unwind-protect
         (let* ((patch-file (majutsu-interactive--write-patch
@@ -919,7 +1011,19 @@ complemented text and whole-file changes."
                              tool-config))
                (full-args
                 (cons command (majutsu-jj-append-filesets args filesets)))
-               (process (majutsu-run-jj-with-editor full-args)))
+               (process
+                (majutsu-start-jj-with-editor
+                 full-args nil
+                 (lambda (_process exit-code)
+                   ;; Process sentinels run with quitting inhibited.  Defer
+                   ;; refresh and selection invalidation until it is safe to
+                   ;; rebuild the originating diff buffer.  A reported jj
+                   ;; failure retains the user's selection.
+                   (when (and (integerp exit-code) (zerop exit-code))
+                     (run-at-time 0 nil
+                                  #'majutsu-interactive--complete-patch-operation
+                                  origin-buffer operation-before)))
+                 t)))
           (setq retained
                 (majutsu-interactive--retain-temp-dir-for-process
                  process directory))

--- a/majutsu-mode.el
+++ b/majutsu-mode.el
@@ -487,6 +487,12 @@ The returned value is a list of entries of the form:
 
 CREATED, INITIAL-SECTION, and SELECT-SECTION are for internal use."
   (when-let* ((refresh (majutsu--refresh-buffer-function)))
+    ;; Diff-buffer patch selections store rendered buffer positions.  They
+    ;; cannot safely survive the rebuild below, so invalidate them before the
+    ;; old sections and text disappear.  Keep this dynamic to avoid making the
+    ;; base mode depend on the optional interactive-selection feature.
+    (when (fboundp 'majutsu-interactive-invalidate)
+      (majutsu-interactive-invalidate))
     (let ((action (if created "Creating" "Refreshing")))
       (when (eq major-mode 'majutsu-mode)
         (majutsu--debug "%s buffer `%s'..." action (buffer-name)))

--- a/majutsu-process.el
+++ b/majutsu-process.el
@@ -94,6 +94,32 @@ the heading of each process section."
 (defvar majutsu-process--with-editor-file-roots (make-hash-table :test #'equal)
   "Map with-editor temp files to the repository roots that opened them.")
 
+(defvar majutsu-process--start-success-msg nil
+  "Success message captured by a process being started.
+
+This is dynamically bound by `majutsu-start-jj' so it can be installed on
+the child before its sentinel is installed.")
+
+(defvar majutsu-process--start-finish-callback nil
+  "Completion callback captured by a process being started.
+
+This is dynamically bound by `majutsu-start-jj' so it can be installed on
+the child before its sentinel is installed.")
+
+(defvar majutsu-process--inhibit-refresh nil
+  "Whether the process currently being started owns its refresh lifecycle.
+
+This is dynamically bound by `majutsu-start-jj'.  `majutsu-start-process'
+captures it on the child before installing the process sentinel, which is
+important for commands that can exit before their caller regains control.")
+
+(defvar majutsu-process--start-created-callback nil
+  "Function called with a process immediately after it is created.
+
+This dynamic hook is for a caller that must retain ownership of a child even
+if a non-local exit interrupts setup before `majutsu-start-process' returns.
+It runs before Majutsu installs the process sentinel.")
+
 (defun majutsu-process--with-editor-open-file (process line)
   "Return the file opened by with-editor control LINE from PROCESS."
   (save-match-data
@@ -404,6 +430,15 @@ is not a `magit-section', in which case the section slots are left unset."
   (process-put process 'section section)
   (process-put process 'command-buf (current-buffer))
   (process-put process 'default-dir root)
+  ;; These values must be present before installing SENTINEL.  A short-lived
+  ;; child can finish as soon as the sentinel is installed.
+  (when majutsu-process--start-success-msg
+    (process-put process 'success-msg majutsu-process--start-success-msg))
+  (when majutsu-process--start-finish-callback
+    (process-put process 'finish-callback
+                 majutsu-process--start-finish-callback))
+  (when majutsu-process--inhibit-refresh
+    (process-put process 'inhibit-refresh t))
   (when (magit-process-section-p section)
     (oset section process process)
     (oset section value process))
@@ -429,17 +464,31 @@ repository's log buffer (see `majutsu-refresh')."
          (section (with-current-buffer process-buf
                     (prog1 (majutsu--process-insert-section pwd program args nil nil)
                       (backward-char 1))))
-         (process (let ((process-environment (majutsu-process-environment args))
-                        (default-process-coding-system '(utf-8-unix . utf-8-unix)))
-                    (apply #'start-file-process (file-name-nondirectory program)
-                           process-buf program args))))
-    (majutsu--process-setup process section root #'majutsu--process-sentinel)
-    (when input
-      (with-current-buffer input
-        (process-send-region process (point-min) (point-max))
-        (process-send-eof process)))
-    (majutsu--process-display-buffer process)
-    process))
+         process
+         (setup-complete nil))
+    ;; A quit while configuring a just-created child must not leave an
+    ;; unowned process behind.  The creation callback lets session owners see
+    ;; the child early enough to make their own cleanup decision.
+    (unwind-protect
+        (progn
+          (setq process
+                (let ((process-environment (majutsu-process-environment args))
+                      (default-process-coding-system '(utf-8-unix . utf-8-unix)))
+                  (apply #'start-file-process (file-name-nondirectory program)
+                         process-buf program args)))
+          (when majutsu-process--start-created-callback
+            (funcall majutsu-process--start-created-callback process))
+          (majutsu--process-setup process section root #'majutsu--process-sentinel)
+          (setq setup-complete t)
+          (when input
+            (with-current-buffer input
+              (process-send-region process (point-min) (point-max))
+              (process-send-eof process)))
+          (majutsu--process-display-buffer process)
+          process)
+      (unless setup-complete
+        (when (and (processp process) (process-live-p process))
+          (ignore-errors (delete-process process)))))))
 
 (defun majutsu--with-editor-control-line-p (line)
   "Return non-nil when LINE is a with-editor sleeping OPEN packet."
@@ -750,23 +799,34 @@ Resolve the appropriate jj executable and prepare ARGS using
          nil destination nil
          (majutsu-process-jj-arguments args)))
 
-(defun majutsu-start-jj (args &optional success-msg finish-callback)
+(defun majutsu-start-jj (args &optional success-msg finish-callback inhibit-refresh)
   "Run jj ARGS asynchronously for side-effects and log output.
 
 Return the process object.
 
 SUCCESS-MSG is displayed on exit code 0.  When FINISH-CALLBACK is
 non-nil, call it as (FINISH-CALLBACK PROCESS EXIT-CODE) after the
-process terminates."
+process terminates.  When INHIBIT-REFRESH is non-nil, suppress the default
+sentinel refresh so FINISH-CALLBACK can own completion handling.
+
+All of these values are recorded on the child before its sentinel is
+installed, so they are reliable even for a short-lived process."
   (let* ((default-directory (majutsu--toplevel-safe default-directory))
          (jj (majutsu-jj--executable))
-         (args (majutsu-process-jj-arguments args))
-         (process (apply #'majutsu-start-process jj nil args)))
-    (when success-msg
-      (process-put process 'success-msg success-msg))
-    (when finish-callback
-      (process-put process 'finish-callback finish-callback))
-    process))
+         (args (majutsu-process-jj-arguments args)))
+    (let ((majutsu-process--start-success-msg success-msg)
+          (majutsu-process--start-finish-callback finish-callback)
+          (majutsu-process--inhibit-refresh inhibit-refresh))
+      (apply #'majutsu-start-process jj nil args))))
+
+(defun majutsu-start-jj-with-editor
+    (args &optional success-msg finish-callback inhibit-refresh)
+  "Start jj ARGS with `JJ_EDITOR' integration.
+
+SUCCESS-MSG, FINISH-CALLBACK, and INHIBIT-REFRESH have the same meaning as
+for `majutsu-start-jj'."
+  (majutsu-with-editor
+    (majutsu-start-jj args success-msg finish-callback inhibit-refresh)))
 
 (defun majutsu--process-wait (process &optional stderr-process)
   "Wait for PROCESS to finish while continuing to service Emacs subprocesses.
@@ -871,8 +931,15 @@ Process output goes into a new section in the buffer returned by
     exit))
 
 (defun majutsu-run-jj-with-editor (&rest args)
-  "Run JJ ARGS using with-editor."
-  (majutsu-with-editor (apply #'majutsu-run-jj-async args)))
+  "Run JJ ARGS using with-editor.
+
+This compatibility wrapper retains the existing variadic command interface.
+Use `majutsu-start-jj-with-editor' when completion handling is needed."
+  (let ((flat (flatten-tree args)))
+    (majutsu--message-with-log "Running %s %s"
+                               (majutsu-jj--executable)
+                               (string-join flat " ")))
+  (majutsu-start-jj-with-editor args))
 
 ;;; _
 (provide 'majutsu-process)

--- a/majutsu-restore.el
+++ b/majutsu-restore.el
@@ -17,6 +17,7 @@
 ;;; Code:
 
 (require 'majutsu)
+(require 'majutsu-diff-editor)
 
 (declare-function majutsu-diff--revision-metadata "majutsu-diff" ())
 (defvar majutsu-buffer-diff-range)
@@ -138,25 +139,34 @@ In diff buffer on a file section, restore only that file."
   :class 'majutsu-transient-default-action-suffix
   (interactive (list (transient-args 'majutsu-restore)))
   (pcase-let* ((`(,args ,filesets) (majutsu-filesets-split-transient-value args))
+               (jj-editor-p (majutsu-diff-editor-interactive-arguments-p args))
                ;; jj presents destination on the left and restore source on
                ;; the right.  The complement plan keeps that source tree and
                ;; replays only unselected changes forward from the left.
-               (plan (majutsu-interactive-build-replay-plan-if-selected
-                      nil 'complement))
-               (selector (and plan (majutsu-restore--patch-selector)))
-               (args (if plan
-                         (majutsu-restore--remove-interactive-tool-args args)
-                       args)))
-    (if plan
-        (progn
-          (majutsu-restore--check-patch-selector args selector)
-          (majutsu-interactive-run-replay-plan "restore" args filesets plan)
-          (majutsu-interactive-clear))
+               ;; A jj editor does not consume the Emacs selection, so avoid
+               ;; validating a possibly different selection owner here.
+               (plan (and (not jj-editor-p)
+                          (majutsu-interactive-build-replay-plan-if-selected
+                           nil 'complement 'majutsu-restore)))
+               (selector (and plan (majutsu-restore--patch-selector))))
+    (cond
+     ;; Explicit jj editor flags win over an existing Majutsu patch selection.
+     ;; Do not clear it: the user may return and apply it later.
+     (jj-editor-p
+      (majutsu-diff-editor-start
+       "restore" args filesets :origin-buffer (current-buffer)))
+     (plan
+      (majutsu-restore--check-patch-selector args selector)
+      (majutsu-interactive-run-replay-plan
+       "restore"
+       (majutsu-diff-editor-strip-interactive-arguments args)
+       filesets plan))
+     (t
       (let ((exit (apply #'majutsu-run-jj
                          "restore"
                          (majutsu-jj-append-filesets args filesets))))
         (when (zerop exit)
-          (message "Restored successfully"))))))
+          (message "Restored successfully")))))))
 
 ;;; Infix Commands
 
@@ -228,6 +238,7 @@ In diff buffer on a file section, restore only that file."
     (majutsu-restore:--)]
    ["Options"
     ("-i" "Interactive" ("-i" "--interactive"))
+    ("=t" "Tool" "--tool=")
     ("-d" "Restore descendants" "--restore-descendants")
     (majutsu-transient-arg-ignore-immutable)]
    ["Actions"

--- a/majutsu-split.el
+++ b/majutsu-split.el
@@ -17,6 +17,7 @@
 ;;; Code:
 
 (require 'majutsu)
+(require 'majutsu-diff-editor)
 
 (defun majutsu-split--diff-source-revision (&optional buffer)
   "Return the single Split source represented by diff BUFFER.
@@ -62,22 +63,34 @@ one change."
   :description "Execute split"
   :class 'majutsu-transient-default-action-suffix
   (interactive (list (transient-args 'majutsu-split)))
-  (pcase-let* ((`(,args ,filesets) (majutsu-filesets-split-transient-value args))
-               ;; Text hunks and hunkless files coexist in one operation.
-               (plan (majutsu-interactive-build-replay-plan-if-selected))
-               (patch-source
-                (and plan (majutsu-split--diff-source-revision)))
-               (args (if plan
-                         (majutsu-split--remove-interactive-tool-args args)
-                       args)))
-    (if plan
-        (progn
-          (majutsu-split--check-patch-source args patch-source)
+  (pcase-let ((`(,args ,filesets) (majutsu-filesets-split-transient-value args)))
+    ;; An explicit jj editor request takes precedence over an Emacs-owned
+    ;; patch selection.  Do not inspect its owner here: jj does not consume
+    ;; the selection, so it remains available for the originating command.
+    (if (majutsu-diff-editor-interactive-arguments-p args)
+        (majutsu-diff-editor-start
+         "split" args filesets :origin-buffer (current-buffer))
+      (let* (;; Text hunks and hunkless files coexist in one operation.
+             (plan (majutsu-interactive-build-replay-plan-if-selected
+                    nil nil 'majutsu-split))
+             (patch-source
+              (and plan (majutsu-split--diff-source-revision))))
+        (when plan
+          (majutsu-split--check-patch-source args patch-source))
+        (cond
+         (plan
           ;; Reset to the left tree, then replay precisely the selections.
-          (majutsu-interactive-run-replay-plan "split" args filesets plan)
-          (majutsu-interactive-clear))
-      (majutsu-run-jj-with-editor
-       (cons "split" (majutsu-jj-append-filesets args filesets))))))
+          (majutsu-interactive-run-replay-plan
+           "split"
+           (majutsu-diff-editor-strip-interactive-arguments args)
+           filesets plan))
+         ;; `jj split' selects interactively by default when no fileset is given.
+         ((null filesets)
+          (majutsu-diff-editor-start
+           "split" args filesets :origin-buffer (current-buffer)))
+         (t
+          (majutsu-run-jj-with-editor
+           (cons "split" (majutsu-jj-append-filesets args filesets)))))))))
 
 ;;;; Infix Commands
 
@@ -170,7 +183,7 @@ one change."
     ("-i" "Interactive" ("-i" "--interactive"))
     ("-p" "Parallel" ("-p" "--parallel"))
     ("-e" "Editor" "--editor")
-    ("-t" "Tool" "--tool=")
+    ("=t" "Tool" "--tool=")
     (majutsu-transient-arg-ignore-immutable)]
    ["Actions"
     ("s" "Execute split" majutsu-split-execute)]]

--- a/majutsu-squash.el
+++ b/majutsu-squash.el
@@ -18,6 +18,7 @@
 ;;; Code:
 
 (require 'majutsu)
+(require 'majutsu-diff-editor)
 
 (defvar majutsu-buffer-diff-range)
 
@@ -135,41 +136,53 @@ return the same context defaults that execution would use."
   :description "Execute squash"
   :class 'majutsu-transient-default-action-suffix
   (interactive (list (majutsu-squash-arguments)))
-  (pcase-let* ((`(,args ,filesets) (majutsu-filesets-split-transient-value args))
-               ;; Text hunks and whole-file changes both move into the destination.
-               (plan (majutsu-interactive-build-replay-plan-if-selected))
-               (patch-source (and plan (majutsu-squash--patch-source-revset))))
-    (when plan
-      (majutsu-squash--check-patch-source args patch-source)
-      (setq args (majutsu-squash--remove-interactive-tool-args args)))
-    (let* ((explicit-sources (majutsu-squash--source-values args))
-           (explicit-destination
-            (seq-some (lambda (arg) (transient-arg-value arg args))
-                      '("--into=" "--to=" "--onto=" "--destination="
-                        "--insert-after=" "--after="
-                        "--insert-before=" "--before=")))
-           (source-default (if explicit-destination
-                               '("--from=@")
-                             (or (majutsu-squash--default-args) '("--from=@")))))
-      (unless explicit-sources
-        (setq args (append args source-default)))
-      (let ((sources (majutsu-squash--source-values args)))
-        (unless (or explicit-destination
-                    (majutsu-squash--none-source-p sources))
-          (setq args (append
-                      args
-                      (list (concat
-                             "--into="
-                             (majutsu-squash--destination-revset
-                              (majutsu-squash--source-revset sources)
-                              explicit-sources))))))))
-    (if plan
-        (progn
-          ;; The selected plan rebuilds right from left, then applies forward.
-          (majutsu-interactive-run-replay-plan "squash" args filesets plan)
-          (majutsu-interactive-clear))
-      (majutsu-run-jj-with-editor
-       (cons "squash" (majutsu-jj-append-filesets args filesets))))))
+  (pcase-let ((`(,args ,filesets) (majutsu-filesets-split-transient-value args)))
+    (let* ((jj-editor-p (majutsu-diff-editor-interactive-arguments-p args))
+           ;; Text hunks and whole-file changes both move into the destination.
+           ;; A jj editor leaves an existing selection untouched, including
+           ;; one owned by another command.
+           (plan (and (not jj-editor-p)
+                      (majutsu-interactive-build-replay-plan-if-selected
+                       nil nil 'majutsu-squash)))
+           (patch-source (and plan (majutsu-squash--patch-source-revset))))
+      (when (and plan (not jj-editor-p))
+        (majutsu-squash--check-patch-source args patch-source))
+      (let* ((explicit-sources (majutsu-squash--source-values args))
+             (explicit-destination
+              (seq-some (lambda (arg) (transient-arg-value arg args))
+                        '("--into=" "--to=" "--onto=" "--destination="
+                          "--insert-after=" "--after="
+                          "--insert-before=" "--before=")))
+             (source-default (if explicit-destination
+                                 '("--from=@")
+                               (or (majutsu-squash--default-args) '("--from=@")))))
+        (unless explicit-sources
+          (setq args (append args source-default)))
+        (let ((sources (majutsu-squash--source-values args)))
+          (unless (or explicit-destination
+                      (majutsu-squash--none-source-p sources))
+            (setq args (append
+                        args
+                        (list (concat
+                               "--into="
+                               (majutsu-squash--destination-revset
+                                (majutsu-squash--source-revset sources)
+                                explicit-sources))))))))
+      (cond
+       ;; Do not replace a user's configured jj editor with Majutsu's patch
+       ;; tool.  The selection remains available after the session starts.
+       (jj-editor-p
+        (majutsu-diff-editor-start
+         "squash" args filesets :origin-buffer (current-buffer)))
+       (plan
+        ;; The selected plan rebuilds right from left, then applies forward.
+        (majutsu-interactive-run-replay-plan
+         "squash"
+         (majutsu-diff-editor-strip-interactive-arguments args)
+         filesets plan))
+       (t
+        (majutsu-run-jj-with-editor
+         (cons "squash" (majutsu-jj-append-filesets args filesets))))))))
 
 ;;;; Infix Commands
 
@@ -271,6 +284,8 @@ return the same context defaults that execution would use."
    ["Paths" :if-not majutsu-squash-interactive-selection-available-p
     (majutsu-squash:--)]
    ["Options"
+    ("-i" "Interactive" ("-i" "--interactive"))
+    ("=t" "Tool" "--tool=")
     ("-k" "Keep emptied commit" ("-k" "--keep-emptied"))
     ("-u" "Use destination message" ("-u" "--use-destination-message"))
     (majutsu-transient-arg-ignore-immutable)]

--- a/test/majutsu-diff-editor-test.el
+++ b/test/majutsu-diff-editor-test.el
@@ -1,0 +1,484 @@
+;;; majutsu-diff-editor-test.el --- Tests for jj diff-editor sessions  -*- lexical-binding: t; -*-
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; Focused tests for diff-editor argument normalization and host routing.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'majutsu-diff-editor)
+
+(ert-deftest majutsu-diff-editor-interactive-arguments-p/recognizes-options ()
+  "Recognize every supported diff-editor option spelling before `--'."
+  (dolist (args '(("-i")
+                  ("--interactive")
+                  ("--tool" "meld")
+                  ("--tool=meld")))
+    (should (majutsu-diff-editor-interactive-arguments-p args)))
+  ;; `-t' belongs to command-specific destination options (e.g. squash), not
+  ;; jj's diff editor.  Never reinterpret it as a tool request.
+  (should-not (majutsu-diff-editor-interactive-arguments-p '("-t" "target")))
+  (should-not (majutsu-diff-editor-interactive-arguments-p '("-t=target")))
+  (should-not
+   (majutsu-diff-editor-interactive-arguments-p
+    '("--from=@" "--" "-i" "--tool" ":builtin"))))
+
+(ert-deftest majutsu-diff-editor-strip-interactive-arguments/removes-options-only ()
+  "Strip editor options but preserve filesets and their `--' separator."
+  (let ((args '("--from=@" "-i" "--interactive"
+                "--tool" "meld" "--tool=vimdiff"
+                "-t" "legacy" "-t=older"
+                "--" "-i" "--tool" "literal")))
+    (should
+     (equal (majutsu-diff-editor-strip-interactive-arguments args)
+            '("--from=@" "-t" "legacy" "-t=older"
+              "--" "-i" "--tool" "literal")))
+    (should (equal args
+                   '("--from=@" "-i" "--interactive"
+                     "--tool" "meld" "--tool=vimdiff"
+                     "-t" "legacy" "-t=older"
+                     "--" "-i" "--tool" "literal")))))
+
+(ert-deftest majutsu-diff-editor-tool-from-arguments/uses-last-tool-before-filesets ()
+  "Return the effective explicit tool and ignore fileset text."
+  (should
+   (equal (majutsu-diff-editor-tool-from-arguments
+           '("--tool" "meld" "-t=vimdiff" "--tool=:builtin"
+             "--" "--tool" "literal"))
+          ":builtin"))
+  (should-not
+   (majutsu-diff-editor-tool-from-arguments
+    '("--tool" "--" ":builtin")))
+  (should-not
+   (majutsu-diff-editor-tool-from-arguments '("-t" "destination"))))
+
+(ert-deftest majutsu-diff-editor-missing-tool-value-p/rejects-only-malformed-tools ()
+  "A fileset separator cannot supply `--tool'."
+  (should (majutsu-diff-editor--missing-tool-value-p '("--tool")))
+  (should (majutsu-diff-editor--missing-tool-value-p
+           '("--tool" "--" "literal")))
+  (should (majutsu-diff-editor--missing-tool-value-p '("--tool=")))
+  (should-not (majutsu-diff-editor--missing-tool-value-p
+               '("--tool" "meld" "--" "literal"))))
+
+(ert-deftest majutsu-diff-editor-select-host/auto-prefers-ghostel ()
+  "Automatic mode uses Ghostel whenever it is available."
+  (let ((majutsu-diff-editor-host 'auto)
+        (with-editor-emacsclient-executable "emacsclient"))
+    (cl-letf (((symbol-function 'majutsu-diff-editor-ghostel-available-p)
+               (lambda () t))
+              ((symbol-function 'majutsu-diff-editor--effective-tool)
+               (lambda (_args) ":builtin")))
+      (should (eq (majutsu-diff-editor-select-host '("--interactive"))
+                  'ghostel)))))
+
+(ert-deftest majutsu-diff-editor-select-host/auto-falls-back-without-emacsclient ()
+  "External tools use the process bridge when Ghostel lacks `JJ_EDITOR' support."
+  (let ((majutsu-diff-editor-host 'auto)
+        (with-editor-emacsclient-executable nil))
+    (cl-letf (((symbol-function 'majutsu-diff-editor-ghostel-available-p)
+               (lambda () t))
+              ((symbol-function 'majutsu-diff-editor--effective-tool)
+               (lambda (_args) "meld"))
+              ((symbol-function 'message) (lambda (&rest _) nil)))
+      (should (eq (majutsu-diff-editor-select-host '("--tool" "meld"))
+                  'process)))))
+
+(ert-deftest majutsu-diff-editor-select-host/auto-rejects-builtin-without-emacsclient ()
+  "The built-in recorder cannot use Ghostel without `JJ_EDITOR' support."
+  (let ((majutsu-diff-editor-host 'auto)
+        (with-editor-emacsclient-executable nil))
+    (cl-letf (((symbol-function 'majutsu-diff-editor-ghostel-available-p)
+               (lambda () t))
+              ((symbol-function 'majutsu-diff-editor--effective-tool)
+               (lambda (_args) ":builtin")))
+      (should-error
+       (majutsu-diff-editor-select-host '("--interactive"))
+       :type 'user-error))))
+
+(ert-deftest majutsu-diff-editor-select-host/auto-falls-back-for-external-tool ()
+  "Automatic mode permits the ordinary process host for external tools."
+  (let ((majutsu-diff-editor-host 'auto))
+    (cl-letf (((symbol-function 'majutsu-diff-editor-ghostel-available-p)
+               (lambda () nil))
+              ((symbol-function 'majutsu-diff-editor--effective-tool)
+               (lambda (_args) "meld"))
+              ((symbol-function 'message) (lambda (&rest _) nil)))
+      (should (eq (majutsu-diff-editor-select-host '("--tool" "meld"))
+                  'process)))))
+
+(ert-deftest majutsu-diff-editor-select-host/auto-remote-external-uses-process ()
+  "TRAMP external editors use the ordinary process path, even with Ghostel."
+  (let ((majutsu-diff-editor-host 'auto))
+    (cl-letf (((symbol-function 'file-remote-p) (lambda (&rest _) t))
+              ((symbol-function 'majutsu-diff-editor-ghostel-available-p)
+               (lambda () t))
+              ((symbol-function 'majutsu-diff-editor--effective-tool)
+               (lambda (_args) "meld"))
+              ((symbol-function 'message) (lambda (&rest _) nil)))
+      (should (eq (majutsu-diff-editor-select-host '("--tool" "meld"))
+                  'process)))))
+
+(ert-deftest majutsu-diff-editor-select-host/auto-remote-rejects-builtin ()
+  "TRAMP cannot host jj's built-in recorder through Ghostel."
+  (let ((majutsu-diff-editor-host 'auto))
+    (cl-letf (((symbol-function 'file-remote-p) (lambda (&rest _) t))
+              ((symbol-function 'majutsu-diff-editor-ghostel-available-p)
+               (lambda () t))
+              ((symbol-function 'majutsu-diff-editor--effective-tool)
+               (lambda (_args) ":builtin")))
+      (should-error
+       (majutsu-diff-editor-select-host '("--interactive"))
+       :type 'user-error))))
+
+(ert-deftest majutsu-diff-editor-configured-tool/preserves-global-then-local-order ()
+  "The config probe must match jj's global-then-invocation argv order."
+  (let ((majutsu-jj-global-arguments
+         '("--config" "ui.diff-editor=:builtin"))
+        seen)
+    (cl-letf (((symbol-function 'majutsu-jj--executable) (lambda () "jj"))
+              ((symbol-function 'majutsu-process-file)
+               (lambda (_program _infile _destination _display &rest args)
+                 (setq seen args)
+                 (insert "meld\n")
+                 0)))
+      (should (equal (majutsu-diff-editor--configured-tool
+                      '("--config" "ui.diff-editor=meld"))
+                     "meld"))
+      (should (equal seen
+                     '("--color=never"
+                       "--config" "ui.diff-editor=:builtin"
+                       "--config" "ui.diff-editor=meld"
+                       "--ignore-working-copy" "config" "get"
+                       "ui.diff-editor"))))))
+
+(ert-deftest majutsu-diff-editor-select-host/rejects-builtin-without-terminal ()
+  "A process buffer must never receive jj's built-in terminal editor."
+  (dolist (host '(auto process))
+    (let ((majutsu-diff-editor-host host))
+      (cl-letf (((symbol-function 'majutsu-diff-editor-ghostel-available-p)
+                 (lambda () nil))
+                ((symbol-function 'majutsu-diff-editor--effective-tool)
+                 (lambda (_args) ":builtin")))
+        (should-error
+         (majutsu-diff-editor-select-host '("--tool=:builtin"))
+         :type 'user-error)))))
+
+(ert-deftest majutsu-diff-editor-select-host/explicit-ghostel-needs-package ()
+  "The explicit Ghostel setting reports an unavailable optional package."
+  (let ((majutsu-diff-editor-host 'ghostel))
+    (cl-letf (((symbol-function 'majutsu-diff-editor-ghostel-available-p)
+               (lambda () nil)))
+      (should-error
+       (majutsu-diff-editor-select-host '("--tool" "meld"))
+       :type 'user-error))))
+
+(ert-deftest majutsu-diff-editor-start/ghostel-rejects-sleeping-editor-before-buffer-creation ()
+  "Do not leak a terminal buffer when Ghostel cannot support `JJ_EDITOR'."
+  (let ((majutsu-diff-editor-host 'ghostel)
+        (with-editor-emacsclient-executable nil)
+        (before (buffer-list)))
+    (cl-letf (((symbol-function 'majutsu--toplevel-safe)
+               (lambda (&optional _directory) "/repo/"))
+              ((symbol-function 'majutsu-diff-editor-ghostel-available-p)
+               (lambda () t))
+              ((symbol-function 'majutsu-diff-editor--operation-id)
+               (lambda (&rest _) "before")))
+      (should-error
+       (majutsu-diff-editor-start "split" '("--tool=:builtin") nil)
+       :type 'user-error)
+      (should-not
+       (seq-some (lambda (buffer)
+                   (and (not (memq buffer before))
+                        (string-prefix-p "*majutsu split diff editor:" (buffer-name buffer))))
+                 (buffer-list))))))
+
+(ert-deftest majutsu-diff-editor-start/ghostel-displays-and-prepares-buffer ()
+  "Ghostel starts only after its session buffer is displayed and prepared."
+  (let ((majutsu-diff-editor-host 'ghostel)
+        (with-editor-emacsclient-executable "emacsclient")
+        (majutsu-jj-environment '("MAJUTSU_DIFF_EDITOR_TEST=enabled"))
+        (majutsu-diff-editor--live-sessions (make-hash-table :test 'equal))
+        terminal
+        seen)
+    (save-window-excursion
+      (with-temp-buffer
+        (let ((origin (current-buffer)))
+          (cl-letf (((symbol-function 'majutsu--toplevel-safe)
+                     (lambda (&optional _directory) "/repo/"))
+                    ((symbol-function 'majutsu-diff-editor-ghostel-available-p)
+                     (lambda () t))
+                    ;; Major-mode activation clears ordinary buffer locals.
+                    ;; The session hook must therefore be installed after it.
+                    ((symbol-function 'ghostel-mode)
+                     (lambda ()
+                       (kill-all-local-variables)
+                       (setq major-mode 'ghostel-mode)
+                       (setq-local ghostel-kill-buffer-on-exit t)
+                       (setq-local ghostel-exit-functions nil)))
+                    ((symbol-function 'majutsu-jj--executable)
+                     (lambda () "jj"))
+                    ((symbol-function 'majutsu-diff-editor--operation-id)
+                     (lambda (&rest _) "before"))
+                    ((symbol-function 'majutsu-process-jj-arguments)
+                     (lambda (args) (cons "--global" args)))
+                    ((symbol-function 'majutsu-display-buffer)
+                     (lambda (buffer)
+                       (set-window-buffer (selected-window) buffer)))
+                    ((symbol-function 'ghostel-exec)
+                     (lambda (buffer program args)
+                       (with-current-buffer buffer
+                         (setq terminal buffer
+                               seen
+                               (list :displayed (get-buffer-window buffer t)
+                                     :program program
+                                     :args args
+                                     :directory default-directory
+                                     :environment process-environment
+                                     :kill-on-exit ghostel-kill-buffer-on-exit
+                                     :exit-hook
+                                     (memq #'majutsu-diff-editor--ghostel-exit
+                                           ghostel-exit-functions))))
+                       'ghostel-process)))
+            (let ((session
+                   (majutsu-diff-editor-start
+                    "split" '("--tool=:builtin") '("src/a.el")
+                    :origin-buffer origin)))
+              (should (majutsu-diff-editor-session-p session))
+              (should (eq (majutsu-diff-editor-session-host session) 'ghostel))
+              (should (eq (majutsu-diff-editor-session-process session)
+                          'ghostel-process))
+              (should (buffer-live-p terminal))
+              (should (plist-get seen :displayed))
+              (should (equal (plist-get seen :program) "jj"))
+              (should (equal (plist-get seen :args)
+                             '("--global" "split" "--tool=:builtin"
+                               "--" "src/a.el")))
+              (should (equal (plist-get seen :directory) "/repo/"))
+              (should (member "MAJUTSU_DIFF_EDITOR_TEST=enabled"
+                              (plist-get seen :environment)))
+              (should-not (plist-get seen :kill-on-exit))
+              (should (plist-get seen :exit-hook))
+              (with-current-buffer terminal
+                (should (eq majutsu-diff-editor--session session)))))
+          (when (buffer-live-p terminal)
+            (with-current-buffer terminal
+              (setq-local majutsu-diff-editor--session nil)
+              (remove-hook 'kill-buffer-hook
+                           #'majutsu-diff-editor--terminal-buffer-killed t))
+            (kill-buffer terminal)))))))
+
+(ert-deftest majutsu-diff-editor-start/process-uses-session-aware-runner ()
+  "Use the process worker's session-aware API when it is available."
+  (let ((majutsu-diff-editor-host 'process)
+        (majutsu-diff-editor--live-sessions (make-hash-table :test 'equal))
+        called host-directory process-directory)
+    (cl-letf (((symbol-function 'majutsu--toplevel-safe)
+               (lambda (&optional _directory) "/repo/"))
+              ((symbol-function 'majutsu-diff-editor-select-host)
+               (lambda (_args)
+                 (setq host-directory default-directory)
+                 'process))
+              ((symbol-function 'majutsu-diff-editor--operation-id)
+               (lambda (&rest _) "before"))
+              ((symbol-function 'majutsu-start-jj-with-editor)
+               (lambda (&rest args)
+                 (setq called args
+                       process-directory default-directory)
+                 'process)))
+      (let ((session
+             (majutsu-diff-editor-start
+              "restore" '("--tool" "meld") '("src/a.el"))))
+        (should (eq (majutsu-diff-editor-session-host session) 'process))
+        (should (eq (majutsu-diff-editor-session-process session) 'process))
+        (should (equal (car called)
+                       '("restore" "--tool" "meld" "--" "src/a.el")))
+        (should-not (nth 1 called))
+        (should (functionp (nth 2 called)))
+        (should (eq (nth 3 called) t))
+        (should (equal host-directory "/repo/"))
+        (should (equal process-directory "/repo/"))))))
+
+(ert-deftest majutsu-diff-editor-start/allows-one-live-session-per-repository ()
+  "Reject concurrent rewrite sessions, then release the slot at completion."
+  (let ((majutsu-diff-editor-host 'process)
+        (majutsu-diff-editor--live-sessions (make-hash-table :test 'equal))
+        session)
+    (cl-letf (((symbol-function 'majutsu--toplevel-safe)
+               (lambda (&optional _directory) "/repo/"))
+              ((symbol-function 'majutsu-diff-editor-select-host)
+               (lambda (&rest _) 'process))
+              ((symbol-function 'majutsu-diff-editor--operation-id)
+               (lambda (&rest _) "before"))
+              ((symbol-function 'majutsu-start-jj-with-editor)
+               (lambda (&rest _) 'fake-process))
+              ((symbol-function 'message) (lambda (&rest _) nil)))
+      (setq session
+            (majutsu-diff-editor-start "split" '("--tool" "meld") nil))
+      (should-error
+       (majutsu-diff-editor-start "restore" '("--tool" "meld") nil)
+       :type 'user-error)
+      (should (eq (majutsu-diff-editor--complete-session session) 'unchanged))
+      (should
+       (majutsu-diff-editor-start "restore" '("--tool" "meld") nil)))))
+
+(ert-deftest majutsu-diff-editor-start/quit-releases-an-unstarted-session ()
+  "C-g during startup must not leave a repository session lock behind."
+  (let ((majutsu-diff-editor--live-sessions (make-hash-table :test 'equal)))
+    (cl-letf (((symbol-function 'majutsu--toplevel-safe)
+               (lambda (&optional _directory) "/repo/"))
+              ((symbol-function 'majutsu-diff-editor-select-host)
+               (lambda (&rest _) 'ghostel))
+              ((symbol-function 'majutsu-diff-editor--operation-id)
+               (lambda (&rest _) "before"))
+              ((symbol-function 'majutsu-diff-editor--start-ghostel)
+               (lambda (&rest _) (signal 'quit nil))))
+      (let (quit)
+        (condition-case nil
+            (majutsu-diff-editor-start "split" '("--tool=:builtin") nil)
+          (quit (setq quit t)))
+        (should quit))
+      (should-not (gethash "/repo/" majutsu-diff-editor--live-sessions)))))
+
+(ert-deftest majutsu-diff-editor-abort-session-start/waits-for-process-callback ()
+  "A dead ordinary child still owns its slot until its exit callback runs."
+  (let* ((majutsu-diff-editor--live-sessions (make-hash-table :test 'equal))
+         (session (majutsu-diff-editor-session-create
+                   :repository-root "/repo/" :host 'process :process 'child))
+         scheduled)
+    (puthash "/repo/" session majutsu-diff-editor--live-sessions)
+    (cl-letf (((symbol-function 'processp) (lambda (_process) t))
+              ((symbol-function 'process-live-p) (lambda (_process) nil))
+              ((symbol-function 'process-get)
+               (lambda (_process property)
+                 (and (eq property 'finish-callback) #'ignore)))
+              ((symbol-function 'run-at-time)
+               (lambda (&rest args) (setq scheduled args))))
+      (majutsu-diff-editor--abort-session-start session)
+      (should (eq (gethash "/repo/" majutsu-diff-editor--live-sessions)
+                  session))
+      ;; ERT itself may schedule an undo-boundary timer while this dynamic
+      ;; mock is active; only a session-completion timer would be a regression.
+      (should-not (and scheduled
+                       (eq (nth 2 scheduled)
+                           #'majutsu-diff-editor--complete-session))))))
+
+(ert-deftest majutsu-diff-editor-finish-terminal-kill/waits-for-live-reaper ()
+  "Do not compare operation ids until Ghostel's reaper has exited."
+  (let ((session (majutsu-diff-editor-session-create :process 'reaper))
+        scheduled completed)
+    (cl-letf (((symbol-function 'processp) (lambda (_process) t))
+              ((symbol-function 'process-live-p) (lambda (_process) t))
+              ((symbol-function 'run-at-time)
+               (lambda (&rest args) (setq scheduled args)))
+              ((symbol-function 'majutsu-diff-editor--complete-session)
+               (lambda (&rest _) (setq completed t))))
+      (majutsu-diff-editor--finish-terminal-kill session)
+      (should-not completed)
+      (should (equal scheduled
+                     (list 0.05 nil
+                           #'majutsu-diff-editor--finish-terminal-kill
+                           session))))))
+
+(ert-deftest majutsu-diff-editor-finish-terminal-kill/completes-after-reaper ()
+  "A stopped lifecycle process completes the session immediately."
+  (let ((session (majutsu-diff-editor-session-create :process 'reaper))
+        completed)
+    (cl-letf (((symbol-function 'processp) (lambda (_process) t))
+              ((symbol-function 'process-live-p) (lambda (_process) nil))
+              ((symbol-function 'majutsu-diff-editor--complete-session)
+               (lambda (value &rest _) (setq completed value))))
+      (majutsu-diff-editor--finish-terminal-kill session)
+      (should (eq completed session)))))
+
+(ert-deftest majutsu-diff-editor-complete-session/refreshes-only-after-operation-change ()
+  "Keep a cancelled editor's selection; clear stale selections after a change."
+  (let ((origin (generate-new-buffer " *majutsu-diff-editor-origin*"))
+        invalidated refreshed ids)
+    (unwind-protect
+        (with-current-buffer origin
+          (majutsu-diff-mode)
+          (cl-letf (((symbol-function 'majutsu-diff-editor--operation-id)
+                     (lambda (&rest _)
+                       (pop ids)))
+                    ((symbol-function 'majutsu-interactive-invalidate)
+                     (lambda () (setq invalidated (1+ (or invalidated 0)))))
+                    ((symbol-function 'majutsu-refresh)
+                     (lambda () (setq refreshed (1+ (or refreshed 0)))))
+                    ((symbol-function 'message) (lambda (&rest _) nil)))
+            (setq ids '("before"))
+            (should
+             (eq (majutsu-diff-editor--complete-session
+                  (majutsu-diff-editor-session-create
+                   :origin-buffer origin :repository-root default-directory
+                   :operation-id-before "before"))
+                 'unchanged))
+            (should-not invalidated)
+            (should-not refreshed)
+            (setq ids '("after"))
+            (should
+             (eq (majutsu-diff-editor--complete-session
+                  (majutsu-diff-editor-session-create
+                   :origin-buffer origin :repository-root default-directory
+                   :operation-id-before "before"))
+                 'changed))
+            (should (= invalidated 1))
+            (should (= refreshed 1))
+            (setq ids '(nil))
+            (should
+             (eq (majutsu-diff-editor--complete-session
+                  (majutsu-diff-editor-session-create
+                   :origin-buffer origin :repository-root default-directory
+                   :operation-id-before "before"))
+                 'unknown))
+            (should (= invalidated 2))
+            (should (= refreshed 2))))
+      (when (buffer-live-p origin)
+        (kill-buffer origin)))))
+
+(ert-deftest majutsu-diff-editor-complete-session/quit-releases-and-invalidates ()
+  "C-g during the operation probe leaves no lock or reusable patch selection."
+  (let* ((majutsu-diff-editor--live-sessions (make-hash-table :test 'equal))
+         (session (majutsu-diff-editor-session-create
+                   :repository-root "/repo/" :operation-id-before "before"))
+         invalidated scheduled)
+    (puthash "/repo/" session majutsu-diff-editor--live-sessions)
+    (cl-letf (((symbol-function 'majutsu-diff-editor--operation-id)
+               (lambda (&rest _) (signal 'quit nil)))
+              ((symbol-function 'majutsu-diff-editor--invalidate-origin-selection)
+               (lambda (_session) (setq invalidated t)))
+              ((symbol-function 'run-at-time)
+               (lambda (&rest args) (setq scheduled args))))
+      (let (quit)
+        (condition-case nil
+            (majutsu-diff-editor--complete-session session)
+          (quit (setq quit t)))
+        (should quit))
+      (should invalidated)
+      (should scheduled)
+      (should-not (gethash "/repo/" majutsu-diff-editor--live-sessions)))))
+
+(ert-deftest majutsu-diff-editor-complete-session/releases-before-exit-hook ()
+  "An observer may start another session after the prior slot is released."
+  (let* ((majutsu-diff-editor--live-sessions (make-hash-table :test 'equal))
+         (session (majutsu-diff-editor-session-create
+                   :repository-root "/repo/" :operation-id-before "before"))
+         hook-saw-slot)
+    (puthash "/repo/" session majutsu-diff-editor--live-sessions)
+    (let ((majutsu-diff-editor-session-exit-hook
+           (list (lambda (&rest _)
+                   (setq hook-saw-slot
+                         (gethash "/repo/" majutsu-diff-editor--live-sessions))))))
+      (cl-letf (((symbol-function 'majutsu-diff-editor--operation-id)
+                 (lambda (&rest _) "before"))
+                ((symbol-function 'message) (lambda (&rest _) nil)))
+        (should (eq (majutsu-diff-editor--complete-session session "finished")
+                    'unchanged))
+        (should-not hook-saw-slot)))))
+
+(provide 'majutsu-diff-editor-test)
+;;; majutsu-diff-editor-test.el ends here

--- a/test/majutsu-interactive-test.el
+++ b/test/majutsu-interactive-test.el
@@ -45,8 +45,9 @@
       (insert-file-contents path))
     (buffer-string)))
 
-(defun majutsu-interactive-test--select-replacement (file removed added)
-  "Select the REMOVED/ADDED replacement in FILE's current washed diff."
+(defun majutsu-interactive-test--select-replacement
+    (file removed added command)
+  "Select REMOVED/ADDED in FILE for transient COMMAND."
   (let* ((file-section
           (majutsu-interactive--file-section-for-file file))
          (hunk (and file-section
@@ -65,9 +66,12 @@
     (should hunk)
     (should removed-line)
     (should added-line)
-    (majutsu-interactive--set-selection
-     (majutsu-interactive--hunk-id hunk)
-     (list (cons (nth 2 removed-line) (nth 3 added-line))))))
+    (let ((transient-current-command command)
+          (transient-mark-mode t))
+      (goto-char (nth 2 removed-line))
+      (set-mark (nth 3 added-line))
+      (setq mark-active t)
+      (majutsu-interactive-toggle-region))))
 
 (defun majutsu-interactive-test--toggle-whole-file (file command)
   "Toggle hunkless FILE for transient COMMAND in the current washed diff."
@@ -84,7 +88,9 @@
   (majutsu-jj-integration-with-washed-diff
    repo
    (lambda ()
-     (majutsu-interactive-test--select-replacement file removed added)
+     (majutsu-interactive-test--select-replacement
+      file removed added
+      (if (eq mode 'complement) 'majutsu-restore 'majutsu-split))
      (majutsu-interactive-build-replay-plan-if-selected nil mode))))
 
 (defun majutsu-interactive-test--prepare-mixed-changes (repo)
@@ -117,10 +123,63 @@ COMMAND identifies the transient whose whole-file selections are toggled."
    repo
    (lambda ()
      (majutsu-interactive-test--select-replacement
-      "text.txt" "old one" "new one")
+      "text.txt" "old one" "new one" command)
      (majutsu-interactive-test--toggle-whole-file "selected.bin" command)
      (majutsu-interactive-test--toggle-whole-file "executable.sh" command)
      (majutsu-interactive-build-replay-plan-if-selected nil mode))))
+
+(ert-deftest majutsu-interactive-invalidate/clears-ranges-and-overlays ()
+  "A diff rebuild must not leave position-based selections behind."
+  (with-temp-buffer
+    (insert "old diff\n")
+    (let ((overlay (make-overlay (point-min) (point-max))))
+      (setq-local majutsu-interactive--selections
+                  (let ((table (make-hash-table :test 'equal)))
+                    (puthash 'hunk :all table)
+                    table))
+      (setq-local majutsu-interactive--overlays (list overlay))
+      (setq-local majutsu-interactive--selection-operation 'majutsu-split)
+      (majutsu-interactive-invalidate)
+      (should-not majutsu-interactive--selections)
+      (should-not majutsu-interactive--selection-operation)
+      (should-not majutsu-interactive--overlays)
+      (should-not (overlay-buffer overlay)))))
+
+(ert-deftest majutsu-interactive-selection-context/rejects-a-different-command ()
+  "A patch selection cannot silently change Split/Squash/Restore meaning."
+  (with-temp-buffer
+    (let ((table (make-hash-table :test 'equal)))
+      (puthash 'hunk :all table)
+      (setq-local majutsu-interactive--selections table)
+      (setq-local majutsu-interactive--selection-operation 'majutsu-split)
+      (should-error
+       (majutsu-interactive-build-patch-if-selected
+        nil nil nil 'majutsu-restore)
+       :type 'user-error))))
+
+(ert-deftest majutsu-interactive-complete-patch-operation/retains-cancelled-selection ()
+  "Only a changed or unknown repository operation invalidates a patch selection."
+  (with-temp-buffer
+    (let ((table (make-hash-table :test 'equal))
+          ids refreshed)
+      (puthash 'hunk :all table)
+      (setq-local majutsu-interactive--selections table)
+      (cl-letf (((symbol-function 'majutsu-interactive--operation-id)
+                 (lambda (&rest _)
+                   (pop ids)))
+                ((symbol-function 'majutsu--toplevel-safe)
+                 (lambda (&optional _directory) default-directory))
+                ((symbol-function 'majutsu-refresh)
+                 (lambda () (setq refreshed (1+ (or refreshed 0)))))
+                ((symbol-function 'message) (lambda (&rest _) nil)))
+        (setq ids '("before"))
+        (majutsu-interactive--complete-patch-operation (current-buffer) "before")
+        (should (eq (gethash 'hunk table) :all))
+        (should-not refreshed)
+        (setq ids '("after"))
+        (majutsu-interactive--complete-patch-operation (current-buffer) "before")
+        (should-not majutsu-interactive--selections)
+        (should (= refreshed 1))))))
 
 (ert-deftest majutsu-interactive-run-replay-plan/inserts-tool-before-filesets ()
   "Replay plan should keep jj options before filesets."
@@ -130,17 +189,20 @@ COMMAND identifies the transient whose whole-file selections are toggled."
               ((symbol-function 'majutsu-interactive--build-tool-config)
                (lambda (_patch-file _plan _directory)
                  '("--config" "merge-tools.majutsu-applypatch.program=/tmp/applypatch")))
-              ((symbol-function 'majutsu-run-jj-with-editor)
+              ((symbol-function 'majutsu-start-jj-with-editor)
                (lambda (&rest args)
-                 (setq called (flatten-tree args)))))
+                 (setq called args))))
       (majutsu-interactive-run-replay-plan
        "restore" '("--from=A" "--to=B") '("src/a.el")
        '(:base left :payload-root right :patch "PATCH" :file-ops nil))
-      (should (equal called
+      (should (equal (car called)
                      '("restore" "--from=A" "--to=B"
                        "-i" "--tool" "majutsu-applypatch"
                        "--config" "merge-tools.majutsu-applypatch.program=/tmp/applypatch"
-                       "--" "src/a.el"))))))
+                       "--" "src/a.el")))
+      (should-not (nth 1 called))
+      (should (functionp (nth 2 called)))
+      (should (eq (nth 3 called) t)))))
 
 (ert-deftest majutsu-interactive-run-replay-plan/normalizes-structured-filesets ()
   "Replay plan should also normalize structured filesets."
@@ -150,17 +212,19 @@ COMMAND identifies the transient whose whole-file selections are toggled."
               ((symbol-function 'majutsu-interactive--build-tool-config)
                (lambda (_patch-file _plan _directory)
                  '("--config" "tool=config")))
-              ((symbol-function 'majutsu-run-jj-with-editor)
+              ((symbol-function 'majutsu-start-jj-with-editor)
                (lambda (&rest args)
-                 (setq called (flatten-tree args)))))
+                 (setq called args))))
       (majutsu-interactive-run-replay-plan
        "split" '("--revision=@") '("src/a.el")
        '(:base left :payload-root right :patch "PATCH" :file-ops nil))
-      (should (equal called
+      (should (equal (car called)
                      '("split" "--revision=@"
                        "-i" "--tool" "majutsu-applypatch"
                        "--config" "tool=config"
-                       "--" "src/a.el"))))))
+                       "--" "src/a.el")))
+      (should (functionp (nth 2 called)))
+      (should (eq (nth 3 called) t)))))
 
 (ert-deftest majutsu-interactive--build-tool-config/strips-tramp-prefix ()
   "Tool config should pass local remote paths to jj merge-tool args."
@@ -212,7 +276,7 @@ COMMAND identifies the transient whose whole-file selections are toggled."
                (lambda (_patch _plan _directory)
                  (push _directory configs)
                  nil))
-              ((symbol-function 'majutsu-run-jj-with-editor)
+              ((symbol-function 'majutsu-start-jj-with-editor)
                (lambda (&rest _args) nil))
               ((symbol-function 'majutsu-interactive--delete-operation-temp-dir)
                (lambda (directory) (push directory cleaned))))
@@ -357,6 +421,7 @@ COMMAND identifies the transient whose whole-file selections are toggled."
              (transient-current-command command))
         (goto-char (oref section start))
         (majutsu-interactive-toggle-file)
+        (should (eq majutsu-interactive--selection-operation command))
         (should (equal (majutsu-interactive-build-replay-plan-if-selected)
                        '(:base left :payload-root right
                          :patch nil

--- a/test/majutsu-process-test.el
+++ b/test/majutsu-process-test.el
@@ -175,6 +175,96 @@
       (should (eq (majutsu-start-jj '("status")) 'dummy-process))
       (should (equal seen-root "/repo/")))))
 
+(ert-deftest majutsu-process-test-start-jj-installs-session-state-before-sentinel ()
+  "Session state must reach a child before its sentinel can run."
+  (let ((real-set-process-sentinel (symbol-function 'set-process-sentinel))
+        callback-result
+        observed
+        created
+        process)
+    (unwind-protect
+        (with-temp-buffer
+          (let ((process-buf (current-buffer))
+                (default-directory temporary-file-directory)
+                (callback (lambda (proc exit-code)
+                            (setq callback-result (list proc exit-code))))
+                (majutsu-process--start-created-callback
+                 (lambda (proc) (setq created proc))))
+            (cl-letf (((symbol-function 'majutsu--toplevel-safe)
+                       (lambda (&optional _directory) temporary-file-directory))
+                      ((symbol-function 'majutsu-process-jj-arguments)
+                       (lambda (args) args))
+                      ((symbol-function 'majutsu-process-buffer)
+                       (lambda (&optional _nodisplay) process-buf))
+                      ((symbol-function 'majutsu--process-insert-section)
+                       (lambda (&rest _args)
+                         (insert "\n")
+                         'not-a-section))
+                      ((symbol-function 'start-file-process)
+                       (lambda (name buffer _program &rest _args)
+                         (setq process
+                               (make-process :name (format "%s-session-test" name)
+                                             :buffer buffer
+                                             :command '("cat")
+                                             :noquery t))))
+                      ((symbol-function 'majutsu--process-install-filter) #'ignore)
+                      ((symbol-function 'set-process-sentinel)
+                       (lambda (proc sentinel)
+                         (setq observed
+                               (list (process-get proc 'success-msg)
+                                     (process-get proc 'finish-callback)
+                                     (process-get proc 'inhibit-refresh)
+                                     sentinel))
+                         ;; Keep cleanup silent without changing the point at
+                         ;; which the properties above are observed.
+                         (funcall real-set-process-sentinel proc #'ignore)))
+                      ((symbol-function 'majutsu--process-display-buffer) #'ignore))
+              (should (eq (majutsu-start-jj '("status") "Finished" callback t)
+                          process))
+              (should (eq created process))
+              (should (equal (butlast observed)
+                             (list "Finished" callback t)))
+              (should (eq (car (last observed)) #'majutsu--process-sentinel))
+              ;; Finish callbacks are now installed at that same safe point.
+              (process-put process 'section nil)
+              (cl-letf (((symbol-function 'process-exit-status)
+                         (lambda (_process) 0)))
+                (majutsu-process-finish process))
+              (should (equal callback-result (list process 0)))
+              ;; A session-owned completion path must be able to suppress
+              ;; the generic sentinel refresh.
+              (let (refreshed)
+                (cl-letf (((symbol-function 'process-status)
+                           (lambda (_process) 'exit))
+                          ((symbol-function 'majutsu-process-finish) #'ignore)
+                          ((symbol-function 'majutsu-refresh)
+                           (lambda () (setq refreshed t))))
+                  (majutsu--process-sentinel process "finished\n"))
+                (should-not refreshed)))))
+      (when (and process (process-live-p process))
+        (delete-process process)))))
+
+(ert-deftest majutsu-process-test-start-jj-with-editor-forwards-session-options ()
+  "The session-aware with-editor entry point forwards all completion options."
+  (let ((majutsu-process-popup-time 17)
+        (with-editor-emacsclient-executable nil)
+        callback
+        seen)
+    (setq callback (lambda (&rest _args) nil))
+    (cl-letf (((symbol-function 'majutsu-start-jj)
+               (lambda (&rest args)
+                 (setq seen (list args
+                                  majutsu-process-popup-time
+                                  (getenv majutsu-with-editor-envvar)))
+                 'dummy-process)))
+      (should (eq (majutsu-start-jj-with-editor
+                   '("split" "--interactive") "Finished" callback t)
+                  'dummy-process)))
+    (should (equal (car seen)
+                   (list '("split" "--interactive") "Finished" callback t)))
+    (should (= (nth 1 seen) -1))
+    (should (equal (nth 2 seen) with-editor-sleeping-editor))))
+
 (ert-deftest majutsu-process-test-call-jj-runs-at-root ()
   "`majutsu-call-jj' should execute jj in repo root.
 The process section should use root as command directory."

--- a/test/majutsu-restore-test.el
+++ b/test/majutsu-restore-test.el
@@ -30,7 +30,7 @@
 
 (ert-deftest majutsu-restore-execute/replays-complement-plan ()
   "Restore replays the complement plan after checking the displayed selector."
-  (let (called cleared)
+  (let (called cleared stripped)
     (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
                (lambda (&rest _)
                  '(:base right :payload-root left
@@ -39,6 +39,10 @@
               ((symbol-function 'majutsu-restore--patch-selector)
                (lambda (&rest _)
                  (list :from "@-" :to "@")))
+              ((symbol-function 'majutsu-diff-editor-strip-interactive-arguments)
+               (lambda (args)
+                 (setq stripped args)
+                 args))
               ((symbol-function 'majutsu-interactive-run-replay-plan)
                (lambda (&rest args)
                  (setq called args)))
@@ -53,7 +57,54 @@
                         :payload-root left
                         :patch "PATCH"
                         :file-ops ((:action add :path "keep.bin"))))))
-      (should cleared))))
+      (should (equal stripped '("--from=@-" "--to=@")))
+      (should-not cleared))))
+
+
+(ert-deftest majutsu-restore-execute/routes-jj-editor-flags-to-diff-editor ()
+  "Restore routes every jj diff-editor spelling without rewriting its tool."
+  (let ((origin (current-buffer)))
+    (dolist (editor-args '(("-i")
+                           ("--interactive")
+                           ("--tool" "meld")
+                           ("--tool=meld")))
+      (let (called)
+        (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+                   (lambda (&rest _) nil))
+                  ((symbol-function 'majutsu-diff-editor-start)
+                   (lambda (&rest args)
+                     (setq called args))))
+          (majutsu-restore-execute
+           (append '(("--" "src/a.el") "--from=@-" "--to=@") editor-args))
+          (should (equal (cl-subseq called 0 4)
+                         (list "restore"
+                               (append '("--from=@-" "--to=@") editor-args)
+                               '("src/a.el")
+                               :origin-buffer)))
+          (should (eq (nth 4 called) origin)))))))
+(ert-deftest majutsu-restore-execute/explicit-jj-editor-wins-over-patch-selection ()
+  "An explicit jj editor route must leave a Majutsu patch selection intact."
+  (let ((origin (current-buffer)) called cleared)
+    (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+               (lambda (&rest _) '(:base right :payload-root left :patch "PATCH" :file-ops nil)))
+              ((symbol-function 'majutsu-diff-editor-start)
+               (lambda (&rest args)
+                 (setq called args)))
+              ((symbol-function 'majutsu-interactive-run-replay-plan)
+               (lambda (&rest _)
+                 (ert-fail "Should not replace an explicit jj editor")))
+              ((symbol-function 'majutsu-interactive-clear)
+               (lambda () (setq cleared t))))
+      (majutsu-restore-execute
+       '(("--" "src/a.el") "--from=@-" "--tool" "meld"))
+      (should (equal (cl-subseq called 0 4)
+                     '("restore" ("--from=@-" "--tool" "meld")
+                       ("src/a.el") :origin-buffer)))
+      (should (eq (nth 4 called) origin))
+      (should-not cleared))))
+(ert-deftest majutsu-restore-transient/exposes-tool-infix ()
+  "Restore should expose jj's --tool option."
+  (should (transient-get-suffix 'majutsu-restore "=t")))
 
 (ert-deftest majutsu-restore-execute/rejects-mismatched-selector ()
   "Patch restore refuses when transient selectors leave the displayed diff."

--- a/test/majutsu-split-test.el
+++ b/test/majutsu-split-test.el
@@ -33,25 +33,89 @@
         (should-not (majutsu-split--default-args))
         (should-not (majutsu-split--diff-source-revision))))))
 
+(ert-deftest majutsu-split-transient/exposes-tool-infix-under-equals-prefix ()
+  "The jj tool chooser uses Magit's `=t' convention, not jj's `-t'."
+  (should (transient-get-suffix 'majutsu-split "=t"))
+  (should-not
+   (condition-case nil
+       (transient-get-suffix 'majutsu-split "-t")
+     (error nil))))
+(ert-deftest majutsu-split-execute/routes-jj-editor-flags-to-diff-editor ()
+  "Keep each explicit jj editor flag when routing split to its session."
+  (let ((origin (current-buffer)))
+    (dolist (editor-args '(("-i")
+                           ("--interactive")
+                           ("--tool" "meld")
+                           ("--tool=meld")))
+      (let (called)
+        (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+                   (lambda (&rest _) nil))
+                  ((symbol-function 'majutsu-diff-editor-start)
+                   (lambda (&rest args)
+                     (setq called args))))
+          (majutsu-split-execute
+           (append '(("--" "src/a.el") "--revision=@") editor-args))
+          (should (equal (cl-subseq called 0 4)
+                         (list "split"
+                               (append '("--revision=@") editor-args)
+                               '("src/a.el")
+                               :origin-buffer)))
+          (should (eq (nth 4 called) origin)))))))
+(ert-deftest majutsu-split-execute/routes-no-fileset-to-diff-editor ()
+  "Let jj perform its default interactive split without a fileset."
+  (let ((origin (current-buffer)) called)
+    (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+               (lambda (&rest _) nil))
+              ((symbol-function 'majutsu-diff-editor-start)
+               (lambda (&rest args)
+                 (setq called args))))
+      (majutsu-split-execute '("--revision=@"))
+      (should (equal (cl-subseq called 0 4)
+                     '("split" ("--revision=@") nil :origin-buffer)))
+      (should (eq (nth 4 called) origin)))))
+(ert-deftest majutsu-split-execute/explicit-jj-editor-wins-over-patch-selection ()
+  "An explicit jj editor request must not consume a Majutsu patch selection."
+  (let ((origin (current-buffer)) called cleared)
+    (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+               (lambda (&rest _) '(:base left :payload-root right :patch "PATCH" :file-ops nil)))
+              ((symbol-function 'majutsu-diff-editor-start)
+               (lambda (&rest args)
+                 (setq called args)))
+              ((symbol-function 'majutsu-interactive-run-replay-plan)
+               (lambda (&rest _)
+                 (ert-fail "Should not replace an explicit jj editor")))
+              ((symbol-function 'majutsu-interactive-clear)
+               (lambda () (setq cleared t))))
+      (majutsu-split-execute
+       '(("--" "src/a.el") "--revision=@" "--tool" "meld"))
+      (should (equal (cl-subseq called 0 4)
+                     '("split" ("--revision=@" "--tool" "meld")
+                       ("src/a.el") :origin-buffer)))
+      (should (eq (nth 4 called) origin))
+      (should-not cleared))))
+
 (ert-deftest majutsu-split-execute/places-structured-filesets-after-options ()
-  "Execute split with transient filesets after option arguments."
+  "Run a noninteractive fileset split through the ordinary runner."
   (let (called)
     (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
                (lambda (&rest _) nil))
               ((symbol-function 'majutsu-run-jj-with-editor)
                (lambda (&rest args)
                  (setq called args))))
-      (majutsu-split-execute '(("--" "src/a.el") "--revision=@" "--interactive"))
+      (majutsu-split-execute '(("--" "src/a.el") "--revision=@"))
       (should (equal called
-                     '(("split" "--revision=@" "--interactive"
-                        "--" "src/a.el")))))))
+                     '(("split" "--revision=@" "--" "src/a.el")))))))
 
 (ert-deftest majutsu-split-execute/patch-keeps-filesets-after-options ()
   "Patch split should still pass transient filesets after option arguments."
-  (let (called cleared)
+  (let (called cleared stripped)
     (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
                (lambda (&rest _) '(:base left :payload-root right
                                    :patch "PATCH" :file-ops nil)))
+              ((symbol-function 'majutsu-diff-editor-strip-interactive-arguments)
+               (lambda (args)
+                 (setq stripped args)
+                 args))
               ((symbol-function 'majutsu-interactive-run-replay-plan)
                (lambda (&rest args)
                  (setq called args)))
@@ -59,19 +123,25 @@
                (lambda (&rest _) "@"))
               ((symbol-function 'majutsu-interactive-clear)
                (lambda () (setq cleared t))))
-      (majutsu-split-execute '(("--" "src/a.el") "--revision=@" "--interactive"))
+      (majutsu-split-execute '(("--" "src/a.el") "--revision=@"))
       (should (equal called
                      '("split" ("--revision=@") ("src/a.el")
                        (:base left :payload-root right
                         :patch "PATCH" :file-ops nil))))
-      (should cleared))))
+      (should (equal stripped '("--revision=@")))
+      (should-not cleared))))
 
-(ert-deftest majutsu-split-execute/file-op-only-forwards-filesets-and-strips-tool ()
+
+(ert-deftest majutsu-split-execute/file-op-only-forwards-filesets ()
   "File-op-only splits use the custom tool and preserve current filesets."
-  (let ((ops '((:action delete :path "gone.bin"))) called cleared)
+  (let ((ops '((:action delete :path "gone.bin"))) called cleared stripped)
     (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
                (lambda (&rest _) (list :base 'left :payload-root 'right
                                        :patch nil :file-ops ops)))
+              ((symbol-function 'majutsu-diff-editor-strip-interactive-arguments)
+               (lambda (args)
+                 (setq stripped args)
+                 args))
               ((symbol-function 'majutsu-interactive-run-replay-plan)
                (lambda (&rest args) (setq called args)))
               ((symbol-function 'majutsu-split--diff-source-revision)
@@ -79,13 +149,13 @@
               ((symbol-function 'majutsu-interactive-clear)
                (lambda () (setq cleared t))))
       (majutsu-split-execute
-       '(("--" "bin/gone.bin") "--revision=@" "-i"
-         "--tool" "meld" "--tool=vimdiff"))
+       '(("--" "bin/gone.bin") "--revision=@"))
       (should (equal called
                      (list "split" '("--revision=@") '("bin/gone.bin")
                            (list :base 'left :payload-root 'right
                                  :patch nil :file-ops ops))))
-      (should cleared))))
+      (should (equal stripped '("--revision=@")))
+      (should-not cleared))))
 
 (ert-deftest majutsu-split-execute/patch-rejects-different-source ()
   "Patch mode must not apply the displayed diff to another revision."

--- a/test/majutsu-squash-test.el
+++ b/test/majutsu-squash-test.el
@@ -146,9 +146,63 @@
                      '(("squash" "--from=B" "--into=parents(roots((B)))"
                         "--" "majutsu-squash.el")))))))
 
+(ert-deftest majutsu-squash-execute/routes-jj-editor-flags-to-diff-editor ()
+  "Preserve jj editor flags and canonical squash arguments in the session."
+  (let ((origin (current-buffer)))
+    (dolist (editor-args '(("-i")
+                           ("--interactive")
+                           ("--tool" "meld")
+                           ("--tool=meld")))
+      (let (called)
+        (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+                   (lambda (&rest _) nil))
+                  ((symbol-function 'majutsu-squash--point-revision)
+                   (lambda () nil))
+                  ((symbol-function 'majutsu-diff-editor-start)
+                   (lambda (&rest args)
+                     (setq called args))))
+          (majutsu-squash-execute
+           (append '(("--" "src/a.el") "--from=B") editor-args))
+          (should (equal (cl-subseq called 0 4)
+                         (list "squash"
+                               (append '("--from=B")
+                                       editor-args
+                                       '("--into=parents(roots((B)))"))
+                               '("src/a.el")
+                               :origin-buffer)))
+          (should (eq (nth 4 called) origin)))))))
+(ert-deftest majutsu-squash-execute/explicit-jj-editor-wins-over-patch-selection ()
+  "A requested jj editor bypasses patch-source validation and keeps selection."
+  (let ((origin (current-buffer)) called cleared)
+    (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+               (lambda (&rest _) '(:base left :payload-root right :patch "PATCH" :file-ops nil)))
+              ((symbol-function 'majutsu-squash--patch-source-revset)
+               (lambda (&rest _) nil))
+              ((symbol-function 'majutsu-squash--point-revision)
+               (lambda () nil))
+              ((symbol-function 'majutsu-diff-editor-start)
+               (lambda (&rest args)
+                 (setq called args)))
+              ((symbol-function 'majutsu-interactive-run-replay-plan)
+               (lambda (&rest _)
+                 (ert-fail "Should not replace an explicit jj editor")))
+              ((symbol-function 'majutsu-interactive-clear)
+               (lambda () (setq cleared t))))
+      (majutsu-squash-execute '("--from=B" "--tool" "meld"))
+      (should (equal (cl-subseq called 0 4)
+                     '("squash"
+                       ("--from=B" "--tool" "meld"
+                        "--into=parents(roots((B)))")
+                       nil :origin-buffer)))
+      (should (eq (nth 4 called) origin))
+      (should-not cleared))))
+(ert-deftest majutsu-squash-transient/exposes-tool-infix ()
+  "Squash should expose the jj --tool option without shadowing --into."
+  (should (transient-get-suffix 'majutsu-squash "=t")))
+
 (ert-deftest majutsu-squash-execute/patch-removes-native-interactive-tool-args ()
-  "Patch mode injects Majutsu's tool and strips native tool args."
-  (let (called cleared)
+  "Patch mode calls the shared jj-editor argument stripper."
+  (let (called cleared stripped)
     (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
                (lambda (&rest _)
                  (list :base 'left :payload-root 'right
@@ -157,6 +211,10 @@
                        '((:action modify :path "image.bin")))))
               ((symbol-function 'majutsu-squash--patch-source-revset)
                (lambda (&rest _) "B"))
+              ((symbol-function 'majutsu-diff-editor-strip-interactive-arguments)
+               (lambda (args)
+                 (setq stripped args)
+                 args))
               ((symbol-function 'majutsu-interactive-run-replay-plan)
                (lambda (&rest args)
                  (setq called args)))
@@ -164,7 +222,7 @@
                (lambda () (setq cleared t)))
               ((symbol-function 'majutsu-squash--point-revision)
                (lambda () nil)))
-      (majutsu-squash-execute '("--from=B" "--interactive" "--tool=meld" "--tool" "vimdiff"))
+      (majutsu-squash-execute '("--from=B"))
       (should (equal called
                      '("squash"
                        ("--from=B" "--into=parents(roots((B)))")
@@ -173,7 +231,10 @@
                         :patch "PATCH"
                         :file-ops
                         ((:action modify :path "image.bin"))))))
-      (should cleared))))
+      (should (equal stripped
+                     '("--from=B" "--into=parents(roots((B)))")))
+      (should-not cleared))))
+
 
 (ert-deftest majutsu-squash-execute/patch-rejects-different-source ()
   "Patch mode should not apply the current diff patch to another source."


### PR DESCRIPTION
Route Split, Squash, and Restore through majutsu-diff-editor when users pass
-i/--interactive or --tool.  Keep whole-file replay plans on the Majutsu
patch-selection path, strip native editor flags there, and retain selections
across cancelled editor sessions via operation-id completion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Jujutsu’s configured diff editors in Squash, Split, and Restore.
  * Added `--tool` and interactive editor options, with Ghostel, process, and TRAMP support.
  * Added improved tag, signing, completion, history, Forge, Gerrit, and workspace workflows.
* **Bug Fixes**
  * Preserved patch selections after cancelled or non-mutating operations.
  * Improved diff display, newline handling, folding, file paths, and editor-session recovery.
* **Documentation**
  * Updated guidance for editor configuration, hosting, selection behavior, and requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->