### PR TITLE
Support Ghostel diff-editor sessions over TRAMP.

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -97,9 +97,9 @@
   selection nor a fileset is supplied.
 
 - Terminal diff editors through Ghostel ::
-  Optional Ghostel integration hosts jj's built-in terminal diff editor.
-  ~majutsu-diff-editor-host~ selects the host; external non-terminal tools
-  can also run without Ghostel.
+  Optional Ghostel integration hosts jj's built-in terminal diff editor,
+  locally and over supported POSIX TRAMP connections.  ~majutsu-diff-editor-host~
+  selects the host; external non-terminal tools can also run without Ghostel.
 
 - Revision information in diff buffers ::
   Single-revision change diffs show collapsible commit metadata and the full

--- a/docs/majutsu.org
+++ b/docs/majutsu.org
@@ -1141,20 +1141,27 @@ a different diff.
 The default jj editor, =:builtin=, is a terminal TUI.  Customize
 =majutsu-diff-editor-host= to choose how Majutsu hosts it:
 
-- =auto= (the default) uses Ghostel when available with a local
-  =emacsclient=.  Otherwise it only falls back to a normal process for a known
-  external editor such as Meld.
+- =auto= (the default) uses Ghostel when available.  Local sessions also need
+  a working =emacsclient=; Ghostel-supported TRAMP sessions use with-editor's
+  remote sleeping-editor bridge instead.
 - =ghostel= requires Ghostel and supports jj's built-in TUI and external
   terminal editors.
 - =process= is for external non-terminal tools only; Majutsu rejects
   =:builtin= rather than trying to render it in a process buffer.
 
-Ghostel is optional.  Ghostel-hosted sessions require a local working
-=emacsclient= for jj's later description-editor invocation.  On TRAMP,
-=auto= routes a configured external editor through Majutsu's ordinary process
-path; the built-in =:builtin= recorder is rejected because Ghostel cannot
-bridge the later description editor there.  The same external-editor fallback
-is used locally when no usable =emacsclient= is configured.
+Ghostel is optional.  A local Ghostel session requires a working
+=emacsclient= for jj's later description-editor invocation.  On a
+Ghostel-supported POSIX TRAMP remote, Ghostel starts a remote PTY and
+with-editor uses its sleeping-editor protocol, so no local =emacsclient= is
+needed.  Majutsu associates jj's remote temporary description file with its
+repository before it is visited, keeping description-buffer commands in the
+right repository.  A =WITH-EDITOR= control line may remain visible in the
+Ghostel transcript.
+
+Ghostel's remote PTY path needs a POSIX remote reachable by a supported TRAMP
+method; Windows remotes are not supported.  The ordinary external-editor
+fallback is used when Ghostel is unavailable, or locally when no usable
+=emacsclient= is configured.
 
 *** Selection Semantics
 The meaning of "selected" differs by operation:

--- a/docs/majutsu.texi
+++ b/docs/majutsu.texi
@@ -2090,9 +2090,9 @@ The default jj editor@comma{} @samp{:builtin}@comma{} is a terminal TUI@.  Custo
 
 @itemize
 @item
-@samp{auto} (the default) uses Ghostel when available with a local
-@samp{emacsclient}.  Otherwise it only falls back to a normal process for a known
-external editor such as Meld.
+@samp{auto} (the default) uses Ghostel when available.  Local sessions also need
+a working @samp{emacsclient}; Ghostel-supported TRAMP sessions use with-editor's
+remote sleeping-editor bridge instead.
 @item
 @samp{ghostel} requires Ghostel and supports jj's built-in TUI and external
 terminal editors.
@@ -2101,12 +2101,19 @@ terminal editors.
 @samp{:builtin} rather than trying to render it in a process buffer.
 @end itemize
 
-Ghostel is optional.  Ghostel-hosted sessions require a local working
-@samp{emacsclient} for jj's later description-editor invocation.  On TRAMP@comma{}
-@samp{auto} routes a configured external editor through Majutsu's ordinary process
-path; the built-in @samp{:builtin} recorder is rejected because Ghostel cannot
-bridge the later description editor there.  The same external-editor fallback
-is used locally when no usable @samp{emacsclient} is configured.
+Ghostel is optional.  A local Ghostel session requires a working
+@samp{emacsclient} for jj's later description-editor invocation.  On a
+Ghostel-supported POSIX TRAMP remote@comma{} Ghostel starts a remote PTY and
+with-editor uses its sleeping-editor protocol@comma{} so no local @samp{emacsclient} is
+needed.  Majutsu associates jj's remote temporary description file with its
+repository before it is visited@comma{} keeping description-buffer commands in the
+right repository.  A @samp{WITH-EDITOR} control line may remain visible in the
+Ghostel transcript.
+
+Ghostel's remote PTY path needs a POSIX remote reachable by a supported TRAMP
+method; Windows remotes are not supported.  The ordinary external-editor
+fallback is used when Ghostel is unavailable@comma{} or locally when no usable
+@samp{emacsclient} is configured.
 
 @node Selection Semantics
 @subsection Selection Semantics

--- a/majutsu-diff-editor.el
+++ b/majutsu-diff-editor.el
@@ -24,6 +24,8 @@
 (declare-function ghostel-mode "ghostel" ())
 (declare-function majutsu-start-jj-with-editor "majutsu-process"
                   (args &optional success-msg finish-callback inhibit-refresh))
+(declare-function majutsu-process-track-with-editor-output "majutsu-process"
+                  (process output))
 
 (defvar ghostel-exit-functions)
 (defvar ghostel-kill-buffer-on-exit)
@@ -38,10 +40,12 @@
 (defcustom majutsu-diff-editor-host 'auto
   "How Majutsu hosts jj diff-editor sessions.
 
-`auto' uses Ghostel when it is available, otherwise it permits an
-ordinary process only for a known external editor.  `ghostel' requires
-Ghostel.  `process' always uses an ordinary process, which cannot host
-jj's built-in terminal editor."
+`auto' uses Ghostel when it is available.  Local sessions also need a
+working `emacsclient' for jj's later description-editor invocation;
+remote Ghostel sessions use with-editor's TRAMP sleeping-editor bridge.
+Without a suitable terminal host, `auto' permits an ordinary process only
+for a known external editor.  `ghostel' requires Ghostel.  `process' always
+uses an ordinary process, which cannot host jj's built-in terminal editor."
   :type '(choice (const :tag "Automatic" auto)
                  (const :tag "Ghostel terminal" ghostel)
                  (const :tag "Ordinary process (external editor only)" process))
@@ -216,25 +220,25 @@ The return value is either `ghostel' or `process'."
          'ghostel
        (user-error "Ghostel is required for the selected diff-editor host")))
     ('auto
-     (let ((tool (majutsu-diff-editor--effective-tool args)))
+     (let ((tool (majutsu-diff-editor--effective-tool args))
+           (remote-p (file-remote-p default-directory))
+           (ghostel-p (majutsu-diff-editor-ghostel-available-p)))
        (cond
-        ;; Ghostel cannot bridge with-editor's sleeping-editor protocol over
-        ;; TRAMP.  An external tool can still use Majutsu's ordinary remote
-        ;; process path; the built-in recorder cannot.
-        ((file-remote-p default-directory)
-         (if (majutsu-diff-editor--builtin-tool-p tool)
-             (user-error (concat "jj's :builtin diff editor needs a terminal host; "
-                                 "Ghostel sessions over TRAMP are unsupported, so "
-                                 "configure an external editor"))
-           (majutsu-diff-editor--note-process-fallback)
-           'process))
-        ((and (majutsu-diff-editor-ghostel-available-p)
-              with-editor-emacsclient-executable)
+        ;; Remote Ghostel runs through Emacs `make-process' with a TRAMP file
+        ;; handler.  with-editor observes that path and installs its sleeping
+        ;; editor filter, so unlike the local native PTY path it needs no
+        ;; emacsclient.
+        ((and ghostel-p (or remote-p with-editor-emacsclient-executable))
          'ghostel)
         ((majutsu-diff-editor--builtin-tool-p tool)
-         (user-error (concat "jj's :builtin diff editor requires Ghostel and a "
-                             "working emacsclient; configure an external editor "
-                             "or set `with-editor-emacsclient-executable'")))
+         (user-error
+          (if remote-p
+              (concat "jj's :builtin diff editor requires Ghostel for this "
+                      "TRAMP repository; install Ghostel or configure an "
+                      "external editor")
+            (concat "jj's :builtin diff editor requires Ghostel and a working "
+                    "emacsclient; configure an external editor or set "
+                    "`with-editor-emacsclient-executable'"))))
         (t
          (majutsu-diff-editor--note-process-fallback)
          'process))))
@@ -500,15 +504,55 @@ not compare operation ids until that lifecycle process has exited."
 (defun majutsu-diff-editor--assert-ghostel-editor-support (root)
   "Signal unless Ghostel can support jj's later `JJ_EDITOR' invocation.
 
-Ghostel's public execution API has no with-editor sleeping-editor filter.  A
-remote session, or a local Emacs without emacsclient, would render the control
-packet but leave jj waiting forever."
-  (when (file-remote-p root)
-    (user-error (concat "Ghostel jj diff-editor sessions over TRAMP are not yet "
-                        "supported; use an external terminal instead")))
-  (unless with-editor-emacsclient-executable
+Remote Ghostel sessions use Emacs `make-process' with a TRAMP file handler.
+with-editor observes that path and supplies its sleeping-editor protocol.
+Local native Ghostel PTYs do not pass through that path, so they require
+emacsclient."
+  (unless (or (file-remote-p root) with-editor-emacsclient-executable)
     (user-error (concat "Ghostel jj diff-editor sessions require emacsclient for "
                         "JJ_EDITOR; configure `with-editor-emacsclient-executable'"))))
+
+(defun majutsu-diff-editor--install-remote-with-editor-tracker (process root)
+  "Track remote with-editor packets from PROCESS for repository ROOT.
+
+Ghostel's filter must continue to receive every byte.  The wrapper records a
+sleeping-editor OPEN packet before with-editor visits jj's temporary
+description file, then delegates unchanged to Ghostel's existing composite
+filter."
+  (when (processp process)
+    ;; with-editor sets this itself for a remote `make-process', but it is the
+    ;; protocol's authoritative repository context, so retain it explicitly.
+    (process-put process 'default-dir root)
+    (when-let* ((filter (process-filter process)))
+      (set-process-filter
+       process
+       (lambda (proc output)
+         (majutsu-process-track-with-editor-output proc output)
+         (funcall filter proc output))))))
+
+(defun majutsu-diff-editor--ghostel-exec (session buffer program args)
+  "Run Ghostel for SESSION and install its remote editor tracker atomically.
+
+The tracker has to be installed before `make-process' returns: a later wrapper
+could miss a fast `WITH-EDITOR' OPEN packet and leave the description buffer
+without its repository association."
+  (let ((root (majutsu-diff-editor-session-repository-root session)))
+    (if (not (file-remote-p root))
+        (ghostel-exec buffer program args)
+      (let ((make-process-function (symbol-function 'make-process))
+            (installed nil))
+        (cl-letf
+            (((symbol-function 'make-process)
+              (lambda (&rest keys)
+                (let ((process (apply make-process-function keys)))
+                  (when (and (not installed)
+                             (eq (plist-get keys :buffer) buffer)
+                             (plist-get keys :file-handler))
+                    (setq installed t)
+                    (majutsu-diff-editor--install-remote-with-editor-tracker
+                     process root))
+                  process))))
+          (ghostel-exec buffer program args))))))
 
 (defun majutsu-diff-editor--start-ghostel (session)
   "Start SESSION through Ghostel's public API and return SESSION."
@@ -551,7 +595,8 @@ packet but leave jj waiting forever."
                   ;; that, so Ghostel inherits both JJ_EDITOR and user overrides.
                   (let ((process-environment (majutsu-process-environment args)))
                     (setf (majutsu-diff-editor-session-process session)
-                          (ghostel-exec buffer program args))))
+                          (majutsu-diff-editor--ghostel-exec
+                           session buffer program args))))
                 (setq started t)
                 session))
           (unless started

--- a/majutsu-process.el
+++ b/majutsu-process.el
@@ -510,6 +510,31 @@ repository's log buffer (see `majutsu-refresh')."
        (or (string-prefix-p "MAJUTSU-EDIFF:" fragment)
            (string-prefix-p fragment "MAJUTSU-EDIFF:"))))
 
+(defun majutsu-process-track-with-editor-output (process output)
+  "Record roots for with-editor OPEN packets in raw PROCESS OUTPUT.
+
+Do not consume OUTPUT or alter PROCESS's visible filter.  This is for a
+terminal host which must preserve its own rendering filter but needs the
+repository association before with-editor visits jj's temporary description
+file.  Partial packets are retained independently of Majutsu's ordinary
+process-buffer filter."
+  (let ((input (concat (or (process-get process
+                                        'majutsu--with-editor-root-pending)
+                           "")
+                       output))
+        (start 0))
+    (while (string-match "\n" input start)
+      (let* ((end (match-beginning 0))
+             (line (substring input start end)))
+        (when (majutsu--with-editor-control-line-p line)
+          (majutsu-process--remember-with-editor-file-root process line))
+        (setq start (1+ end))))
+    (let ((trailing (substring input start)))
+      (process-put process 'majutsu--with-editor-root-pending
+                   (if (majutsu--with-editor-control-fragment-p trailing)
+                       trailing
+                     "")))))
+
 (defun majutsu--process-handle-control-line (proc line)
   "Handle known control LINE values for PROC.
 Return non-nil when LINE is consumed as a control packet."

--- a/test/majutsu-diff-editor-test.el
+++ b/test/majutsu-diff-editor-test.el
@@ -111,29 +111,42 @@
       (should (eq (majutsu-diff-editor-select-host '("--tool" "meld"))
                   'process)))))
 
-(ert-deftest majutsu-diff-editor-select-host/auto-remote-external-uses-process ()
-  "TRAMP external editors use the ordinary process path, even with Ghostel."
-  (let ((majutsu-diff-editor-host 'auto))
+(ert-deftest majutsu-diff-editor-select-host/auto-remote-prefers-ghostel ()
+  "TRAMP sessions use Ghostel without requiring a local emacsclient."
+  (let ((majutsu-diff-editor-host 'auto)
+        (with-editor-emacsclient-executable nil))
     (cl-letf (((symbol-function 'file-remote-p) (lambda (&rest _) t))
               ((symbol-function 'majutsu-diff-editor-ghostel-available-p)
                (lambda () t))
               ((symbol-function 'majutsu-diff-editor--effective-tool)
-               (lambda (_args) "meld"))
-              ((symbol-function 'message) (lambda (&rest _) nil)))
+               (lambda (_args) "meld")))
       (should (eq (majutsu-diff-editor-select-host '("--tool" "meld"))
-                  'process)))))
+                  'ghostel)))))
 
-(ert-deftest majutsu-diff-editor-select-host/auto-remote-rejects-builtin ()
-  "TRAMP cannot host jj's built-in recorder through Ghostel."
-  (let ((majutsu-diff-editor-host 'auto))
+(ert-deftest majutsu-diff-editor-select-host/auto-remote-hosts-builtin ()
+  "TRAMP Ghostel sessions support jj's built-in recorder."
+  (let ((majutsu-diff-editor-host 'auto)
+        (with-editor-emacsclient-executable nil))
     (cl-letf (((symbol-function 'file-remote-p) (lambda (&rest _) t))
               ((symbol-function 'majutsu-diff-editor-ghostel-available-p)
                (lambda () t))
               ((symbol-function 'majutsu-diff-editor--effective-tool)
                (lambda (_args) ":builtin")))
-      (should-error
-       (majutsu-diff-editor-select-host '("--interactive"))
-       :type 'user-error))))
+      (should (eq (majutsu-diff-editor-select-host '("--interactive"))
+                  'ghostel)))))
+
+(ert-deftest majutsu-diff-editor-select-host/auto-remote-falls-back-without-ghostel ()
+  "A remote external editor still has a process fallback without Ghostel."
+  (let ((majutsu-diff-editor-host 'auto)
+        (with-editor-emacsclient-executable nil))
+    (cl-letf (((symbol-function 'file-remote-p) (lambda (&rest _) t))
+              ((symbol-function 'majutsu-diff-editor-ghostel-available-p)
+               (lambda () nil))
+              ((symbol-function 'majutsu-diff-editor--effective-tool)
+               (lambda (_args) "meld"))
+              ((symbol-function 'message) (lambda (&rest _) nil)))
+      (should (eq (majutsu-diff-editor-select-host '("--tool" "meld"))
+                  'process)))))
 
 (ert-deftest majutsu-diff-editor-configured-tool/preserves-global-then-local-order ()
   "The config probe must match jj's global-then-invocation argv order."
@@ -196,6 +209,97 @@
                    (and (not (memq buffer before))
                         (string-prefix-p "*majutsu split diff editor:" (buffer-name buffer))))
                  (buffer-list))))))
+
+(ert-deftest majutsu-diff-editor-assert-ghostel-editor-support/remote-needs-no-emacsclient ()
+  "The remote with-editor bridge uses its sleeping editor."
+  (let ((with-editor-emacsclient-executable nil))
+    (cl-letf (((symbol-function 'file-remote-p) (lambda (&rest _) t)))
+      (should-not
+       (majutsu-diff-editor--assert-ghostel-editor-support "/ssh:example:/repo/")))))
+
+(ert-deftest majutsu-diff-editor-ghostel-exec/installs-tracker-before-delegating-output ()
+  "The remote tracker precedes Ghostel's already-installed output filter."
+  (let ((majutsu-process--with-editor-file-roots (make-hash-table :test #'equal))
+        (root "/ssh:example:/repo/")
+        called)
+    (with-temp-buffer
+      (let* ((buffer (current-buffer))
+             (session (majutsu-diff-editor-session-create :repository-root root))
+             (proc (make-process :name "majutsu-test"
+                                 :buffer buffer
+                                 :command (list "cat"))))
+        (unwind-protect
+            (progn
+              (set-process-filter proc (lambda (&rest _) (setq called t)))
+              (cl-letf (((symbol-function 'file-remote-p)
+                         (lambda (&rest _) "/ssh:example:"))
+                        ;; The outer binding is the pre-existing advised
+                        ;; `make-process' implementation seen by the helper.
+                        ((symbol-function 'make-process)
+                         (lambda (&rest _) proc))
+                        ((symbol-function 'ghostel-exec)
+                         (lambda (target-buffer _program _args)
+                           (make-process :name "ghostel"
+                                         :buffer target-buffer
+                                         :file-handler "/ssh:example:"))))
+                (should (eq (majutsu-diff-editor--ghostel-exec
+                             session buffer "jj" '("split"))
+                            proc)))
+              (funcall (process-filter proc) proc
+                       (format "WITH-EDITOR: 123 OPEN /tmp/editor.jjdescription%c IN /repo\n"
+                               ?\x1f))
+              (should called)
+              (should
+               (equal
+                (majutsu-process-with-editor-file-root
+                 "/ssh:example:/tmp/editor.jjdescription")
+                root)))
+          (delete-process proc))))))
+
+(ert-deftest majutsu-diff-editor-remote-with-editor-advice/composes-the-tracker ()
+  "The real with-editor advice preserves Ghostel after Majutsu tracks output."
+  (let ((majutsu-process--with-editor-file-roots (make-hash-table :test #'equal))
+        (root "/ssh:example:/repo/")
+        command order seen-root)
+    (with-temp-buffer
+      (let ((terminal (current-buffer))
+            (proc (let ((default-directory temporary-file-directory))
+                    (make-process :name "majutsu-test"
+                                  :buffer (current-buffer)
+                                  :command (list "cat")))))
+        (unwind-protect
+            (let ((default-directory root)
+                  (with-editor-emacsclient-executable nil))
+              (cl-letf (((symbol-function 'with-editor-process-filter)
+                         (lambda (_process _output &optional no-default-filter)
+                           (push (if no-default-filter 'with-editor :unexpected)
+                                 order)
+                           (setq seen-root
+                                 (majutsu-process-with-editor-file-root
+                                  "/ssh:example:/tmp/editor.jjdescription")))))
+                (majutsu-with-editor
+                  (let ((process
+                         (make-process@with-editor-process-filter
+                          (lambda (&rest keys)
+                            (setq command (plist-get keys :command))
+                            (set-process-filter proc (plist-get keys :filter))
+                            proc)
+                          :name "ghostel"
+                          :buffer terminal
+                          :command '("/bin/sh" "-c" "exec jj split -i")
+                          :connection-type 'pty
+                          :filter (lambda (&rest _) (push 'ghostel order))
+                          :file-handler "/ssh:example:")))
+                    (majutsu-diff-editor--install-remote-with-editor-tracker
+                     process root)
+                    (funcall (process-filter process) process
+                             (format "WITH-EDITOR: 123 OPEN /tmp/editor.jjdescription%c IN /repo\n"
+                                     ?\x1f)))))
+              (should (equal (car command) "env"))
+              (should (string-prefix-p "JJ_EDITOR=" (cadr command)))
+              (should (equal (nreverse order) '(ghostel with-editor)))
+              (should (equal seen-root root)))
+          (delete-process proc))))))
 
 (ert-deftest majutsu-diff-editor-start/ghostel-displays-and-prepares-buffer ()
   "Ghostel starts only after its session buffer is displayed and prepared."

--- a/test/majutsu-process-test.el
+++ b/test/majutsu-process-test.el
@@ -97,6 +97,30 @@
         (should (equal (majutsu-process-with-editor-file-root "/tmp/manifest")
                        "/repo/"))))))
 
+(ert-deftest test-majutsu-process-track-with-editor-output/remembers-remote-root ()
+  "Raw terminal output records a split sleeping-editor packet before display."
+  (let ((majutsu-process--with-editor-file-roots (make-hash-table :test #'equal)))
+    (with-temp-buffer
+      (let* ((part1 "WITH-EDITOR: 123 OPEN /tmp/editor-")
+             (part2 (format "abc.jjdescription%c IN /repo\n" ?\x1f))
+             (proc (make-process :name "majutsu-test"
+                                 :buffer (current-buffer)
+                                 :command (list "cat"))))
+        (unwind-protect
+            (progn
+              (process-put proc 'default-dir "/ssh:example:/repo/")
+              (majutsu-process-track-with-editor-output proc part1)
+              (should-not
+               (majutsu-process-with-editor-file-root
+                "/ssh:example:/tmp/editor-abc.jjdescription"))
+              (majutsu-process-track-with-editor-output proc part2)
+              (should
+               (equal
+                (majutsu-process-with-editor-file-root
+                 "/ssh:example:/tmp/editor-abc.jjdescription")
+                "/ssh:example:/repo/")))
+          (delete-process proc))))))
+
 (ert-deftest test-majutsu-process-filter/dispatches-majutsu-ediff-control-packets ()
   (with-temp-buffer
     (let* ((packet (format "MAJUTSU-EDIFF: 123 DIFF /tmp/left%c/tmp/right%cfoo.txt\n"


### PR DESCRIPTION
* majutsu-diff-editor.el (majutsu-diff-editor-host): Document remote
Ghostel editor integration.
(majutsu-diff-editor-select-host): Prefer Ghostel for supported remote
sessions without requiring a local emacsclient.
(majutsu-diff-editor--assert-ghostel-editor-support): Accept the TRAMP
sleeping-editor bridge.
(majutsu-diff-editor--install-remote-with-editor-tracker): New
function.
(majutsu-diff-editor--ghostel-exec): Install remote packet tracking
before Ghostel can produce output.
(majutsu-diff-editor--start-ghostel): Use the remote-aware execution
wrapper.
* majutsu-process.el (majutsu-process-track-with-editor-output): Record
repository roots from raw sleeping-editor packets without consuming
terminal output.
* test/majutsu-diff-editor-test.el: Test remote host selection,
emacsclient requirements, and atomic sleeping-editor tracking.
* test/majutsu-process-test.el
(test-majutsu-process-track-with-editor-output/remembers-remote-root):
Test fragmented remote sleeping-editor packets.
* NEWS.org: Announce remote Ghostel diff-editor support.
* docs/majutsu.org: Document the TRAMP sleeping-editor bridge and remote
terminal requirements.
* docs/majutsu.texi: Regenerate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for hosting jj diff-editor sessions remotely through Ghostel.
  * Improved editor selection for local and remote sessions, including TRAMP connections.
  * Added repository-aware handling for remote temporary description files.
  * Added clear fallbacks to external editor processes when Ghostel is unavailable.

* **Documentation**
  * Documented local, remote, Windows, and fallback requirements for Ghostel sessions.

* **Bug Fixes**
  * Improved tracking of remote editor sessions and split control messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->