### PR TITLE
Preserve multi-revision Squash context.

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -199,8 +199,9 @@
 ** Fixed
 
 - Split, Squash, and Restore defaults ::
-  Split inherits a displayed change only when the diff resolves to one revision;
-  multi-change ranges are no longer forwarded as invalid Split arguments.
+  Split inherits only single-change diff sources.  Squash keeps every
+  =--revisions= source from the displayed diff when given an explicit
+  destination; arbitrary =--from= / =--to= comparisons do not imply a Squash source.
 
 - Transient command context ::
   Revision and file prompts, selection toggles, and point-sensitive actions

--- a/majutsu-jj.el
+++ b/majutsu-jj.el
@@ -677,6 +677,33 @@ to do the following.
 * Prepend `majutsu-jj-global-arguments' to ARGS."
   (append majutsu-jj-global-arguments (flatten-tree args)))
 
+(defun majutsu-jj-option-values (args option &optional short)
+  "Return values supplied for OPTION in ARGS, also accepting SHORT.
+
+Both `--option=VALUE' and separate-value spellings are recognized.  Stop at
+`--', so filesets cannot be mistaken for options.  An option without a value
+contributes an empty string; callers can distinguish it from an absent option."
+  (let (values)
+    (while args
+      (let ((arg (pop args)))
+        (cond
+         ((equal arg "--")
+          (setq args nil))
+         ((or (equal arg option) (and short (equal arg short)))
+          (if (and args
+                   (stringp (car args))
+                   (not (string-prefix-p "-" (car args))))
+              (push (pop args) values)
+            (push "" values)))
+         ((and (stringp arg)
+               (string-prefix-p (concat option "=") arg))
+          (push (substring arg (1+ (length option))) values))
+         ((and short (stringp arg)
+               (string-prefix-p short arg)
+               (> (length arg) (length short)))
+          (push (substring arg (length short)) values)))))
+    (nreverse values)))
+
 (defun majutsu--jj-insert (return-error &rest args)
   "Run jj with ARGS and insert output at point.
 
@@ -795,6 +822,21 @@ newline, return an empty string.  This function aligns with
       (unless (bobp)
         (goto-char (point-min))
         (buffer-substring-no-properties (point) (line-end-position))))))
+
+(defun majutsu-jj-resolve-single-commit (revset)
+  "Return REVSET's only commit ID, or nil unless it resolves exactly once.
+
+Unlike helpers that use `latest', this preserves cardinality: a range is not
+silently reduced to one of its commits."
+  (condition-case nil
+      (when-let* ((commit-id
+                   (majutsu-jj-string
+                    "--ignore-working-copy" "log" "-r"
+                    (format "exactly((%s), 1)" revset)
+                    "--no-graph" "--limit" "1" "-T" "commit_id")))
+        (unless (string-empty-p commit-id)
+          commit-id))
+    (error nil)))
 
 (defun majutsu-jj--escape-fileset-string (s)
   "Escape S for a jj fileset string literal."

--- a/majutsu-squash.el
+++ b/majutsu-squash.el
@@ -26,8 +26,7 @@
 
 (defun majutsu-squash--source-values (args)
   "Return --from values in ARGS."
-  (seq-keep (lambda (arg) (transient-arg-value "--from=" (list arg)))
-            args))
+  (majutsu-jj-option-values args "--from"))
 
 (defun majutsu-squash--remove-interactive-tool-args (args)
   "Remove native interactive/tool arguments from ARGS."
@@ -67,11 +66,10 @@ The resulting revset is intentionally left for jj to resolve."
 (defun majutsu-squash--diff-default-args ()
   "Return default squash args from a diff buffer context."
   (let* ((range majutsu-buffer-diff-range)
-         (from (transient-arg-value "--from=" range))
-         (to (transient-arg-value "--to=" range))
-         (revisions (seq-keep (lambda (arg)
-                                (transient-arg-value "--revisions=" (list arg)))
-                              range)))
+         (from (majutsu-jj-option-values range "--from"))
+         (to (majutsu-jj-option-values range "--to"))
+         (revisions
+          (majutsu-jj-option-values range "--revisions" "-r")))
     (cond
      ;; Arbitrary --from/--to diff buffers do not describe a squash source.
      ((or from to) nil)
@@ -99,20 +97,37 @@ return the same context defaults that execution would use."
 
 ;;; Patch selection safety
 
+(defvar-local majutsu-squash--patch-source-cache-key :uncomputed
+  "Diff range and rendered-text tick for the cached patch source.")
+
+(defvar-local majutsu-squash--patch-source-cache-value nil
+  "Cached safe source revset for the current diff range.")
+
 (defun majutsu-squash--patch-source-revset (&optional buffer)
   "Return a source revset when BUFFER is a safe squash patch-selection buffer."
   (with-current-buffer (or buffer (current-buffer))
     (when (derived-mode-p 'majutsu-diff-mode)
-      (let* ((range majutsu-buffer-diff-range)
-             (from (transient-arg-value "--from=" range))
-             (to (transient-arg-value "--to=" range))
-             (revisions (seq-keep (lambda (arg)
-                                    (transient-arg-value "--revisions=" (list arg)))
-                                  range)))
-        (cond
-         ((or from to) nil)
-         ((null range) "@")
-         ((= (length revisions) 1) (car revisions)))))))
+      (let* ((range (copy-tree majutsu-buffer-diff-range))
+             (cache-key (list range (buffer-chars-modified-tick))))
+        ;; Transient predicates are evaluated repeatedly while rendering.  A
+        ;; range cardinality probe is synchronous, so cache it for this
+        ;; rendered diff.  A refresh changes the text tick even when a dynamic
+        ;; revset expression itself remains unchanged.
+        (unless (equal cache-key majutsu-squash--patch-source-cache-key)
+          (setq-local majutsu-squash--patch-source-cache-key cache-key)
+          (setq-local majutsu-squash--patch-source-cache-value
+                      (let* ((from (majutsu-jj-option-values range "--from"))
+                             (to (majutsu-jj-option-values range "--to"))
+                             (revisions (majutsu-jj-option-values
+                                         range "--revisions" "-r")))
+                        (cond
+                         ((or from to) nil)
+                         ((null range) "@")
+                         ((and (= (length revisions) 1)
+                               (majutsu-jj-resolve-single-commit
+                                (car revisions)))
+                          (car revisions))))))
+        majutsu-squash--patch-source-cache-value))))
 
 (defun majutsu-squash-interactive-selection-available-p ()
   "Return non-nil when squash patch selection is available."
@@ -123,7 +138,7 @@ return the same context defaults that execution would use."
   "Signal if ARGS select a source incompatible with PATCH-SOURCE."
   (let ((sources (majutsu-squash--source-values args)))
     (unless patch-source
-      (user-error "Patch selection for squash requires a revision diff"))
+      (user-error "Patch selection for squash requires a diff for exactly one commit"))
     (unless (or (null sources)
                 (and (= (length sources) 1)
                      (equal (car sources) patch-source)))
@@ -153,9 +168,7 @@ return the same context defaults that execution would use."
                         '("--into=" "--to=" "--onto=" "--destination="
                           "--insert-after=" "--after="
                           "--insert-before=" "--before=")))
-             (source-default (if explicit-destination
-                                 '("--from=@")
-                               (or (majutsu-squash--default-args) '("--from=@")))))
+             (source-default (or (majutsu-squash--default-args) '("--from=@"))))
         (unless explicit-sources
           (setq args (append args source-default)))
         (let ((sources (majutsu-squash--source-values args)))

--- a/test/majutsu-jj-test.el
+++ b/test/majutsu-jj-test.el
@@ -51,6 +51,26 @@
                (insert "\nsecond line") 0)))
     (should (equal (majutsu-jj-string "log" "-r" "@") ""))))
 
+(ert-deftest majutsu-jj-option-values/accepts-all-option-spellings ()
+  "Parse long, separate, and short option values before a fileset separator."
+  (should (equal (majutsu-jj-option-values
+                  '("--revisions=A" "-r" "B" "-rC" "--" "--revisions=D")
+                  "--revisions" "-r")
+                 '("A" "B" "C"))))
+
+(ert-deftest majutsu-jj-resolve-single-commit/requires-exact-cardinality ()
+  "A singleton probe must not use `latest' or otherwise reduce a range."
+  (let (called)
+    (cl-letf (((symbol-function 'majutsu-jj-string)
+               (lambda (&rest args)
+                 (setq called args)
+                 "deadbeef")))
+      (should (equal (majutsu-jj-resolve-single-commit "B::C") "deadbeef"))
+      (should (equal called
+                     '("--ignore-working-copy" "log" "-r"
+                       "exactly((B::C), 1)"
+                       "--no-graph" "--limit" "1" "-T" "commit_id"))))))
+
 
 
 ;; Tests for majutsu-jj-lines

--- a/test/majutsu-squash-test.el
+++ b/test/majutsu-squash-test.el
@@ -21,6 +21,12 @@
                (lambda () '("--from=point"))))
       (should-not (majutsu-squash-arguments)))))
 
+(ert-deftest majutsu-squash-source-values/accepts-separate-arguments ()
+  "Parse repeated --from options without consuming fileset values."
+  (should (equal (majutsu-squash--source-values
+                  '("--from" "B" "--from=C" "--" "--from=D"))
+                 '("B" "C"))))
+
 (ert-deftest majutsu-squash-default-args/from-diff-revisions ()
   "Use diff --revisions context as default squash source."
   (with-temp-buffer
@@ -28,6 +34,17 @@
     (setq-local majutsu-buffer-diff-range '("--revisions=B::D"))
     (should (equal (majutsu-squash--default-args)
                    '("--from=B::D")))))
+
+(ert-deftest majutsu-squash-default-args/from-legacy-diff-revisions ()
+  "Keep all accepted diff revision spellings when seeding squash."
+  (dolist (range '(("-r" "B::D")
+                   ("--revisions" "B::D")
+                   ("-rB::D")))
+    (with-temp-buffer
+      (majutsu-diff-mode)
+      (setq-local majutsu-buffer-diff-range range)
+      (should (equal (majutsu-squash--default-args)
+                     '("--from=B::D"))))))
 
 (ert-deftest majutsu-squash-default-args/does-not-inherit-diff-from-to ()
   "Do not inherit arbitrary diff --from/--to range for squash."
@@ -52,10 +69,228 @@
 
 (ert-deftest majutsu-squash-patch-source/rejects-arbitrary-from-to-diff ()
   "Squash patch selection is unavailable for arbitrary from/to diff buffers."
+  (dolist (range '(("--from=A" "--to=B")
+                   ("--from" "A" "--to" "B")))
+    (with-temp-buffer
+      (majutsu-diff-mode)
+      (setq-local majutsu-buffer-diff-range range)
+      (should-not (majutsu-squash--patch-source-revset (current-buffer))))))
+
+(ert-deftest majutsu-squash-patch-source/requires-exactly-one-commit ()
+  "A range revset must not be mistaken for one patch-selection source."
   (with-temp-buffer
     (majutsu-diff-mode)
-    (setq-local majutsu-buffer-diff-range '("--from=A" "--to=B"))
-    (should-not (majutsu-squash--patch-source-revset (current-buffer)))))
+    (setq-local majutsu-buffer-diff-range '("--revisions=B::C"))
+    (let (calls)
+      (cl-letf (((symbol-function 'majutsu-jj-string)
+                 (lambda (&rest args)
+                   (push args calls)
+                   nil)))
+        (should-not (majutsu-squash--patch-source-revset (current-buffer)))
+        ;; Rendering the transient asks this predicate more than once; it must
+        ;; not synchronously query jj for each entry.
+        (should-not (majutsu-squash--patch-source-revset (current-buffer))))
+      (should (equal calls
+                     '(("--ignore-working-copy" "log" "-r"
+                        "exactly((B::C), 1)"
+                        "--no-graph" "--limit" "1" "-T" "commit_id")))))))
+
+(ert-deftest majutsu-squash-patch-source/accepts-one-commit-revset ()
+  "A one-commit revset remains valid in every supported diff spelling."
+  (dolist (range '(("--revisions=B")
+                   ("--revisions" "B")
+                   ("-r" "B")
+                   ("-rB")))
+    (with-temp-buffer
+      (majutsu-diff-mode)
+      (setq-local majutsu-buffer-diff-range range)
+      (cl-letf (((symbol-function 'majutsu-jj-string)
+                 (lambda (&rest _) "commit-id")))
+        (should (equal (majutsu-squash--patch-source-revset (current-buffer))
+                       "B"))))))
+
+(ert-deftest majutsu-squash-patch-source/invalidates-after-diff-refresh ()
+  "A dynamic revset is checked again after the rendered diff changes."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-range '("--revisions=mine()"))
+    (let ((result "commit-id") calls)
+      (cl-letf (((symbol-function 'majutsu-jj-string)
+                 (lambda (&rest _)
+                   (setq calls (1+ (or calls 0)))
+                   result)))
+        (should (equal (majutsu-squash--patch-source-revset (current-buffer))
+                       "mine()"))
+        (let ((inhibit-read-only t))
+          (insert "refreshed"))
+        (setq result nil)
+        (should-not (majutsu-squash--patch-source-revset (current-buffer)))
+        (should (= calls 2))))))
+
+(ert-deftest majutsu-squash-execute/rejects-range-patch-selection ()
+  "Never replay one aggregate patch for each commit in a squash range."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-range '("--revisions=B::C"))
+    (let (applied)
+      (cl-letf (((symbol-function 'majutsu-jj-string)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'majutsu-interactive-build-patch-if-selected)
+                 (lambda (&rest _) "PATCH"))
+                ((symbol-function 'majutsu-interactive-run-with-patch)
+                 (lambda (&rest _)
+                   (setq applied t))))
+        (should-error (majutsu-squash-execute nil) :type 'user-error)
+        (should-not applied)))))
+
+(defun majutsu-squash-test--jj-call (program directory &rest args)
+  "Run PROGRAM with ARGS in DIRECTORY, returning its standard output.
+Signal an ERT failure if the command exits unsuccessfully."
+  (with-temp-buffer
+    (let* ((default-directory (file-name-as-directory directory))
+           (exit (apply #'call-process
+                        program nil t nil
+                        (append '("--no-pager" "--color=never"
+                                  "--config" "user.name=\"Majutsu Test\""
+                                  "--config" "user.email=\"majutsu@example.invalid\"")
+                                args))))
+      (unless (zerop exit)
+        (ert-fail (format "jj failed (%d): %s\n%s"
+                          exit (string-join args " ") (buffer-string))))
+      (buffer-string))))
+
+(ert-deftest majutsu-squash/integration-configured-editor-runs-on-each-range-source ()
+  "A configured native jj editor must run once for every range source."
+  (let ((jj (or (let ((configured (getenv "MAJUTSU_TEST_JJ")))
+                  (and configured (file-executable-p configured) configured))
+                (executable-find "jj"))))
+    (skip-unless jj)
+    (let* ((parent (make-temp-file "majutsu-squash-integration-" t))
+           (repo (expand-file-name "repo" parent))
+           (tool (expand-file-name "count-tool" parent))
+           (calls (expand-file-name "tool-calls" parent))
+           (destination nil)
+           (session nil)
+           (process nil)
+           (majutsu-diff-editor--live-sessions (make-hash-table :test 'equal)))
+      (unwind-protect
+          (progn
+            (majutsu-squash-test--jj-call jj parent "git" "init" repo)
+            (with-temp-file tool
+              (insert "#!/bin/sh\n"
+                      "if test -e \"$2/c.txt\"; then\n"
+                      "  printf 'C\\n'\n"
+                      "else\n"
+                      "  printf 'B\\n'\n"
+                      "fi >> "
+                      (shell-quote-argument calls)
+                      "\nexit 0\n"))
+            (set-file-modes tool #o755)
+            (let ((default-directory (file-name-as-directory repo)))
+              (with-temp-file (expand-file-name "base.txt" repo)
+                (insert "base\n"))
+              (majutsu-squash-test--jj-call jj repo "describe" "-m" "A")
+              (setq destination
+                    (string-trim
+                     (majutsu-squash-test--jj-call
+                      jj repo "log" "-r" "@" "--no-graph" "-T" "change_id")))
+              (majutsu-squash-test--jj-call jj repo "new" "-m" "B")
+              (with-temp-file (expand-file-name "b.txt" repo)
+                (insert "B\n"))
+              (majutsu-squash-test--jj-call jj repo "new" "-m" "C")
+              (let ((source-b (string-trim
+                               (majutsu-squash-test--jj-call
+                                jj repo "log" "-r" "@-" "--no-graph"
+                                "-T" "change_id"))))
+                (with-temp-file (expand-file-name "c.txt" repo)
+                  (insert "C\n"))
+                (majutsu-squash-test--jj-call jj repo "new" "-m" "D")
+                (let ((source-c (string-trim
+                                 (majutsu-squash-test--jj-call
+                                  jj repo "log" "-r" "@-" "--no-graph"
+                                  "-T" "change_id"))))
+                  (with-temp-buffer
+                    (setq-local default-directory (file-name-as-directory repo))
+                    (majutsu-diff-mode)
+                    (setq-local majutsu-buffer-diff-range
+                                (list "-r" (format "%s::%s"
+                                                   source-b source-c)))
+                    (let* ((majutsu-jj-executable jj)
+                           (majutsu-jj-global-arguments
+                            (list "--no-pager" "--color=never"
+                                  "--config" "user.name=\"Majutsu Test\""
+                                  "--config" "user.email=\"majutsu@example.invalid\""
+                                  "--config"
+                                  (format "ui.diff-editor=%S" "count")
+                                  "--config"
+                                  (format "merge-tools.count.program=%S" tool)
+                                  "--config"
+                                  "merge-tools.count.edit-args=[\"$left\", \"$right\"]"
+                                  "--config"
+                                  "merge-tools.count.edit-invocation-mode=\"dir\""))
+                           (majutsu-diff-editor-host 'process)
+                           (majutsu-process-popup-time -1))
+                      (should-not
+                       (majutsu-squash-interactive-selection-available-p))
+                      (cl-letf
+                          (((symbol-function
+                             'majutsu-interactive-build-patch-if-selected)
+                            (lambda (&rest _) nil))
+                           ((symbol-function 'majutsu--process-display-buffer)
+                            (lambda (&rest _) nil))
+                           ((symbol-function 'majutsu-refresh)
+                            (lambda (&rest _) nil)))
+                        (let ((deadline (+ (float-time) 10)))
+                          (setq session
+                                (majutsu-squash-execute
+                                 (list "-i" "--message" "range"
+                                       (concat "--into=" destination))))
+                          (setq process
+                                (majutsu-diff-editor-session-process session))
+                          (let ((root
+                                 (majutsu-diff-editor-session-repository-root
+                                  session)))
+                            (should (equal root (file-name-as-directory repo)))
+                            (should (processp process))
+                            (while (and (process-live-p process)
+                                        (< (float-time) deadline))
+                              (accept-process-output process 0.05))
+                            (when (process-live-p process)
+                              (ignore-errors (delete-process process))
+                              (ert-fail "Timed out waiting for range squash"))
+                            (should (zerop (process-exit-status process)))
+                            ;; Session completion is deferred out of the process
+                            ;; sentinel; keep the UI stubs active until it frees
+                            ;; the per-repository slot.
+                            (while (and (gethash root majutsu-diff-editor--live-sessions)
+                                        (< (float-time) deadline))
+                              (sit-for 0.01))
+                            (should-not (gethash root
+                                                 majutsu-diff-editor--live-sessions))))))))
+            (should (file-exists-p calls))
+            (with-temp-buffer
+              (insert-file-contents calls)
+              (should (equal (sort (split-string (buffer-string) "\n" t)
+                                   #'string<)
+                             '("B" "C"))))
+            (should (equal (majutsu-squash-test--jj-call
+                            jj repo "file" "show" "-r" "@" "b.txt")
+                           "B\n"))
+            (should (equal (majutsu-squash-test--jj-call
+                            jj repo "file" "show" "-r" "@" "c.txt")
+                           "C\n"))
+            (should (equal
+                     (string-trim
+                      (majutsu-squash-test--jj-call
+                       jj repo "log" "-r" destination "--no-graph"
+                       "-T" "description"))
+                     "range")))
+        (when (and (processp process) (process-live-p process))
+          (ignore-errors (delete-process process)))
+        (when session
+          (ignore-errors (majutsu-diff-editor--unregister-session session)))
+        (when (file-directory-p parent)
+          (delete-directory parent t))))))))
 
 (ert-deftest majutsu-squash-execute/runs-jj-squash-with-inferred-destination ()
   "Execute non-patch squash through `majutsu-run-jj-with-editor'."
@@ -103,6 +338,23 @@
       (should (equal called
                      '(("squash" "--from=B" "--into=parents(roots((B)))")))))))
 
+(ert-deftest majutsu-squash-execute/keeps-diff-range-with-explicit-destination ()
+  "An explicit destination must not replace a diff range source with @."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-range '("--revisions=B::C"))
+    (let ((origin (current-buffer)) called)
+      (cl-letf (((symbol-function 'majutsu-interactive-build-patch-if-selected)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'majutsu-diff-editor-start)
+                 (lambda (&rest args)
+                   (setq called args))))
+        (majutsu-squash-execute '("--into=A" "--tool=count"))
+        (should (equal called
+                       (list "squash"
+                             '("--into=A" "--tool=count" "--from=B::C")
+                             nil :origin-buffer origin)))))))
+
 (ert-deftest majutsu-squash-execute/keeps-explicit-destination ()
   "Do not infer destination when user selected one."
   (let (called)
@@ -116,6 +368,23 @@
       (majutsu-squash-execute '("--from=C" "--into=A"))
       (should (equal called
                      '(("squash" "--from=C" "--into=A")))))))
+
+(ert-deftest majutsu-squash-execute/log-explicit-destination-uses-commit-at-point ()
+  "In a log buffer an explicit destination squashes from the commit at point."
+  (with-temp-buffer
+    (let (called)
+      (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'majutsu-run-jj-with-editor)
+                 (lambda (&rest args)
+                   (setq called args)))
+                ((symbol-function 'magit-region-values)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'magit-section-value-if)
+                 (lambda (_) "Y")))
+        (majutsu-squash-execute '("--into=X"))
+        (should (equal called
+                       '(("squash" "--into=X" "--from=Y"))))))))
 
 (ert-deftest majutsu-squash-execute/keeps-literal-none-source-for-jj-noop ()
   "Do not add --into for literal --from=none(); let jj keep no-op behavior."


### PR DESCRIPTION
* majutsu-jj.el (majutsu-jj-option-values): Parse attached and separate
long and short option values.
(majutsu-jj-resolve-single-commit): Check revset cardinality without
reducing ranges.
* majutsu-squash.el (majutsu-squash--source-values,
majutsu-squash--diff-default-args): Preserve every supported diff
revision spelling when deriving Squash sources.
(majutsu-squash--patch-source-cache-key,
majutsu-squash--patch-source-cache-value,
majutsu-squash--patch-source-revset): Permit patch selection only for a
revset that resolves to exactly one commit, and cache the result for the
rendered diff.
(majutsu-squash--assert-patch-compatible): Clarify the invalid patch
source error.
(majutsu-squash-execute): Retain the diff-derived source when an
explicit destination is supplied.
* test/majutsu-jj-test.el: Test option-value parsing and exact revset
cardinality.
* test/majutsu-squash-test.el: Test source parsing, patch-source safety,
cache invalidation, and explicit destinations.
(majutsu-squash-test--jj-call,
majutsu-squash/integration-configured-editor-runs-on-each-range-source):
Exercise the configured diff editor once for each source in a real jj
range Squash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved recognition of squash command options across long, short, separate-value, and `--option=value` formats.
  * Added reliable resolution of revision selections when they identify exactly one commit.

* **Bug Fixes**
  * Squash now rejects ambiguous or unresolved patch sources instead of proceeding incorrectly.
  * Explicit destinations preserve context-derived source ranges.
  * Improved handling of legacy diff-range syntax and editor-based squash workflows.
  * Cached patch-source checks are refreshed when the working buffer changes.

* **Documentation**
  * Clarified Split and Squash behavior for single-commit and multi-commit diff sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->