### PR TITLE
Make asynchronous process completion atomic.

### DIFF
--- a/majutsu-process.el
+++ b/majutsu-process.el
@@ -120,6 +120,19 @@ This dynamic hook is for a caller that must retain ownership of a child even
 if a non-local exit interrupts setup before `majutsu-start-process' returns.
 It runs before Majutsu installs the process sentinel.")
 
+(defconst majutsu-process--control-fragment-max-bytes 1000
+  "Maximum size of an incomplete process control packet.")
+
+(defun majutsu-process-completion-owned-p (process)
+  "Return non-nil when PROCESS has a complete Majutsu completion path.
+
+This becomes non-nil only after both the Majutsu filter and sentinel have
+been installed successfully.  Callers which receive a child through
+`majutsu-process--start-created-callback' can use this to distinguish a child
+whose completion is owned by Majutsu from one still in startup setup."
+  (and (processp process)
+       (process-get process 'majutsu-completion-owned)))
+
 (defun majutsu-process--with-editor-open-file (process line)
   "Return the file opened by with-editor control LINE from PROCESS."
   (save-match-data
@@ -446,6 +459,15 @@ is not a `magit-section', in which case the section slots are left unset."
     (set-marker (process-mark process) (point)))
   (majutsu--process-install-filter process)
   (set-process-sentinel process sentinel)
+  ;; Do not publish completion ownership until both installation calls have
+  ;; returned.  In particular, a wrapper can install one of them and then
+  ;; signal; startup cleanup must still reclaim that child.
+  (process-put process 'majutsu-completion-owned t)
+  ;; Emacs does not replay an exit event which was delivered before the
+  ;; sentinel was installed.  The Majutsu sentinel is idempotent, so this
+  ;; explicit dispatch also closes the exit-at-installation boundary race.
+  (when (memq (process-status process) '(exit signal))
+    (funcall sentinel process "finished\n"))
   process)
 
 (defun majutsu-start-process (program &optional input &rest args)
@@ -464,8 +486,7 @@ repository's log buffer (see `majutsu-refresh')."
          (section (with-current-buffer process-buf
                     (prog1 (majutsu--process-insert-section pwd program args nil nil)
                       (backward-char 1))))
-         process
-         (setup-complete nil))
+         process)
     ;; A quit while configuring a just-created child must not leave an
     ;; unowned process behind.  The creation callback lets session owners see
     ;; the child early enough to make their own cleanup decision.
@@ -479,14 +500,13 @@ repository's log buffer (see `majutsu-refresh')."
           (when majutsu-process--start-created-callback
             (funcall majutsu-process--start-created-callback process))
           (majutsu--process-setup process section root #'majutsu--process-sentinel)
-          (setq setup-complete t)
           (when input
             (with-current-buffer input
               (process-send-region process (point-min) (point-max))
               (process-send-eof process)))
           (majutsu--process-display-buffer process)
           process)
-      (unless setup-complete
+      (unless (majutsu-process-completion-owned-p process)
         (when (and (processp process) (process-live-p process))
           (ignore-errors (delete-process process)))))))
 
@@ -510,6 +530,14 @@ repository's log buffer (see `majutsu-refresh')."
        (or (string-prefix-p "MAJUTSU-EDIFF:" fragment)
            (string-prefix-p fragment "MAJUTSU-EDIFF:"))))
 
+(defun majutsu--process-bounded-control-fragment (fragment)
+  "Return control FRAGMENT when it fits the pending-packet bound.
+Return the empty string when FRAGMENT exceeds that bound."
+  (if (<= (string-bytes fragment)
+          majutsu-process--control-fragment-max-bytes)
+      fragment
+    ""))
+
 (defun majutsu-process-track-with-editor-output (process output)
   "Record roots for with-editor OPEN packets in raw PROCESS OUTPUT.
 
@@ -532,7 +560,7 @@ process-buffer filter."
     (let ((trailing (substring input start)))
       (process-put process 'majutsu--with-editor-root-pending
                    (if (majutsu--with-editor-control-fragment-p trailing)
-                       trailing
+                       (majutsu--process-bounded-control-fragment trailing)
                      "")))))
 
 (defun majutsu--process-handle-control-line (proc line)
@@ -567,7 +595,8 @@ Return non-nil when LINE is consumed as a control packet."
       (cond
        ((or (majutsu--with-editor-control-fragment-p trailing)
             (majutsu--ediff-control-fragment-p trailing))
-        (process-put proc 'majutsu--with-editor-filter-pending trailing))
+        (process-put proc 'majutsu--with-editor-filter-pending
+                     (majutsu--process-bounded-control-fragment trailing)))
        ((string-empty-p trailing)
         (process-put proc 'majutsu--with-editor-filter-pending ""))
        (t
@@ -575,23 +604,37 @@ Return non-nil when LINE is consumed as a control packet."
         (push trailing visible)))
       (apply #'concat (nreverse visible)))))
 
+(defun majutsu--process-last-bare-carriage-return (string)
+  "Return the last carriage return in STRING that is not part of CRLF."
+  (let ((position (1- (length string)))
+        found)
+    (while (and (>= position 0) (not found))
+      (when (and (eq (aref string position) ?\r)
+                 (or (= position (1- (length string)))
+                     (not (eq (aref string (1+ position)) ?\n))))
+        (setq found position))
+      (setq position (1- position)))
+    found))
+
 (defun majutsu--process-filter (proc string)
   "Default filter used by `majutsu-start-process'."
   (with-current-buffer (process-buffer proc)
     (let ((inhibit-read-only t))
       (goto-char (process-mark proc))
-      ;; Find last ^M in STRING.  If one was found, ignore everything
-      ;; before it and delete the current line.
-      (when-let* ((ret-pos (cl-position ?\r string :from-end t)))
-        (setq string (substring string (1+ ret-pos)))
-        (delete-region (line-beginning-position) (point)))
       ;; Control packets (with-editor and Majutsu Ediff) are not user-facing
-      ;; process output and should be consumed before insertion.
+      ;; process output and should be consumed before insertion.  Do this
+      ;; before handling bare carriage returns so packet CRLF, including a
+      ;; CR/LF chunk boundary, remains available to the packet parser.
       (setq string
             (majutsu--process-strip-with-editor-control-packets
              proc
              (concat (or (process-get proc 'majutsu--with-editor-filter-pending) "")
                      string)))
+      ;; A bare ^M is progress-style line replacement.  CRLF is an ordinary
+      ;; line ending and must not discard a preceding control packet or text.
+      (when-let* ((ret-pos (majutsu--process-last-bare-carriage-return string)))
+        (setq string (substring string (1+ ret-pos)))
+        (delete-region (line-beginning-position) (point)))
       (unless (string-empty-p string)
         (insert (propertize string 'magit-section
                             (process-get proc 'section)))
@@ -610,7 +653,12 @@ Return non-nil when LINE is consumed as a control packet."
 
 (defun majutsu--process-sentinel (process _event)
   "Default sentinel used by `majutsu-start-process'."
-  (when (memq (process-status process) '(exit signal))
+  (when (and (memq (process-status process) '(exit signal))
+             (not (process-get process 'majutsu-completion-finished)))
+    ;; Mark completion before any callback or refresh.  Setup may dispatch an
+    ;; already-finished child explicitly while an ordinary exit event is also
+    ;; pending, and both paths must converge here exactly once.
+    (process-put process 'majutsu-completion-finished t)
     (majutsu-process-finish process)
     (unless (process-get process 'inhibit-refresh)
       (let ((command-buf (process-get process 'command-buf))

--- a/test/majutsu-process-test.el
+++ b/test/majutsu-process-test.el
@@ -12,6 +12,66 @@
 (require 'cl-lib)
 (require 'majutsu-process)
 
+(defun majutsu-process-test--setup-failure-result (phase condition)
+  "Return startup state after PHASE signals CONDITION.
+PHASE is either `filter' or `sentinel'."
+  (let ((real-set-process-filter (symbol-function 'set-process-filter))
+        (real-set-process-sentinel (symbol-function 'set-process-sentinel))
+        process
+        caught
+        phase-owned
+        final-owned
+        live)
+    (unwind-protect
+        (with-temp-buffer
+          (let ((process-buf (current-buffer))
+                (default-directory temporary-file-directory))
+            (cl-letf (((symbol-function 'majutsu-process-buffer)
+                       (lambda (&optional _nodisplay) process-buf))
+                      ((symbol-function 'majutsu--process-insert-section)
+                       (lambda (&rest _args)
+                         (insert "\n")
+                         'not-a-section))
+                      ((symbol-function 'majutsu-process-environment)
+                       (lambda (_args) process-environment))
+                      ((symbol-function 'start-file-process)
+                       (lambda (name buffer _program &rest _args)
+                         (setq process
+                               (make-process
+                                :name (format "%s-setup-failure-test" name)
+                                :buffer buffer
+                                :command '("cat")
+                                :noquery t))))
+                      ((symbol-function 'majutsu--process-install-filter)
+                       (lambda (child)
+                         (if (eq phase 'filter)
+                             (progn
+                               (setq phase-owned
+                                     (majutsu-process-completion-owned-p child))
+                               (signal condition
+                                       (and (eq condition 'error)
+                                            '("filter setup failed"))))
+                           (funcall real-set-process-filter child #'ignore))))
+                      ((symbol-function 'set-process-sentinel)
+                       (lambda (child sentinel)
+                         (if (eq phase 'sentinel)
+                             (progn
+                               (setq phase-owned
+                                     (majutsu-process-completion-owned-p child))
+                               (signal condition
+                                       (and (eq condition 'error)
+                                            '("sentinel setup failed"))))
+                           (funcall real-set-process-sentinel child sentinel)))))
+              (condition-case err
+                  (majutsu-start-process "jj")
+                ((error quit) (setq caught err)))
+              (setq final-owned
+                    (majutsu-process-completion-owned-p process))
+              (setq live (and (processp process) (process-live-p process))))))
+      (when (and (processp process) (process-live-p process))
+        (delete-process process)))
+    (list (car-safe caught) phase-owned final-owned live)))
+
 (ert-deftest test-majutsu-process-error-summary-from-string/error ()
   (should (equal (majutsu--process-error-summary-from-string "Error: something went wrong\n")
                  "something went wrong")))
@@ -82,6 +142,33 @@
         (should (string-match-p (regexp-quote "normal\ntail\n") out))
         (should-not (string-match-p "WITH-EDITOR:" out))))))
 
+(ert-deftest test-majutsu-process-filter/handles-real-packet-across-crlf-chunks ()
+  "A real two-US packet records a relative file and stays invisible."
+  (let ((majutsu-process--with-editor-file-roots (make-hash-table :test #'equal)))
+    (with-temp-buffer
+      (let* ((us (char-to-string ?\x1f))
+             (parts (list "normal\nWITH-ED"
+                          (concat "ITOR: 123 OPEN +12:3" us "descriptions/edit.jj")
+                          (concat us " IN /tmp/majutsu-editor\r")
+                          "\ntail\n"))
+             (file "/tmp/majutsu-editor/descriptions/edit.jj")
+             (proc (make-process :name "majutsu-test"
+                                 :buffer (current-buffer)
+                                 :command (list "cat"))))
+        (unwind-protect
+            (progn
+              (process-put proc 'default-dir "/repo/")
+              (set-marker (process-mark proc) (point))
+              (dolist (part parts)
+                (majutsu--process-filter proc part))
+              (should (equal (buffer-string) "normal\ntail\n"))
+              (should (equal (majutsu-process-with-editor-file-root file)
+                             "/repo/"))
+              (should (equal
+                       (process-get proc 'majutsu--with-editor-filter-pending)
+                       "")))
+          (delete-process proc))))))
+
 (ert-deftest test-majutsu-process-filter/remembers-with-editor-file-root ()
   (let ((majutsu-process--with-editor-file-roots (make-hash-table :test #'equal)))
     (with-temp-buffer
@@ -98,11 +185,13 @@
                        "/repo/"))))))
 
 (ert-deftest test-majutsu-process-track-with-editor-output/remembers-remote-root ()
-  "Raw terminal output records a split sleeping-editor packet before display."
+  "Raw output records a real split packet with relative file and CRLF."
   (let ((majutsu-process--with-editor-file-roots (make-hash-table :test #'equal)))
     (with-temp-buffer
-      (let* ((part1 "WITH-EDITOR: 123 OPEN /tmp/editor-")
-             (part2 (format "abc.jjdescription%c IN /repo\n" ?\x1f))
+      (let* ((part1 (format "WITH-EDITOR: 123 OPEN +1%cdesc/editor-"
+                            ?\x1f))
+             (part2 (format "abc.jjdescription%c IN /tmp/editor\r" ?\x1f))
+             (part3 "\n")
              (proc (make-process :name "majutsu-test"
                                  :buffer (current-buffer)
                                  :command (list "cat"))))
@@ -112,14 +201,54 @@
               (majutsu-process-track-with-editor-output proc part1)
               (should-not
                (majutsu-process-with-editor-file-root
-                "/ssh:example:/tmp/editor-abc.jjdescription"))
+                "/ssh:example:/tmp/editor/desc/editor-abc.jjdescription"))
               (majutsu-process-track-with-editor-output proc part2)
+              (should-not
+               (majutsu-process-with-editor-file-root
+                "/ssh:example:/tmp/editor/desc/editor-abc.jjdescription"))
+              (majutsu-process-track-with-editor-output proc part3)
               (should
                (equal
                 (majutsu-process-with-editor-file-root
-                 "/ssh:example:/tmp/editor-abc.jjdescription")
+                 "/ssh:example:/tmp/editor/desc/editor-abc.jjdescription")
                 "/ssh:example:/repo/")))
           (delete-process proc))))))
+
+(ert-deftest test-majutsu-process-filter/discards-oversized-control-fragment ()
+  "The ordinary filter must not retain or display an oversized fragment."
+  (with-temp-buffer
+    (let* ((fragment (concat "WITH-EDITOR: " (make-string 400 ?界)))
+           (proc (make-process :name "majutsu-test"
+                               :buffer (current-buffer)
+                               :command (list "cat"))))
+      (unwind-protect
+          (progn
+            (should (> (string-bytes fragment)
+                       majutsu-process--control-fragment-max-bytes))
+            (set-marker (process-mark proc) (point))
+            (majutsu--process-filter proc fragment)
+            (should (equal (buffer-string) ""))
+            (should (equal
+                     (process-get proc 'majutsu--with-editor-filter-pending)
+                     ""))
+            (majutsu--process-filter proc "tail\n")
+            (should (equal (buffer-string) "tail\n")))
+        (delete-process proc)))))
+
+(ert-deftest test-majutsu-process-track-with-editor-output/discards-oversized-fragment ()
+  "The raw tracker uses the same byte bound as the ordinary filter."
+  (with-temp-buffer
+    (let* ((fragment (concat "WITH-EDITOR: " (make-string 400 ?界)))
+           (proc (make-process :name "majutsu-test"
+                               :buffer (current-buffer)
+                               :command (list "cat"))))
+      (unwind-protect
+          (progn
+            (majutsu-process-track-with-editor-output proc fragment)
+            (should (equal
+                     (process-get proc 'majutsu--with-editor-root-pending)
+                     "")))
+        (delete-process proc)))))
 
 (ert-deftest test-majutsu-process-filter/dispatches-majutsu-ediff-control-packets ()
   (with-temp-buffer
@@ -205,6 +334,7 @@
         callback-result
         observed
         created
+        created-owned
         process)
     (unwind-protect
         (with-temp-buffer
@@ -213,7 +343,10 @@
                 (callback (lambda (proc exit-code)
                             (setq callback-result (list proc exit-code))))
                 (majutsu-process--start-created-callback
-                 (lambda (proc) (setq created proc))))
+                 (lambda (proc)
+                   (setq created proc)
+                   (setq created-owned
+                         (majutsu-process-completion-owned-p proc)))))
             (cl-letf (((symbol-function 'majutsu--toplevel-safe)
                        (lambda (&optional _directory) temporary-file-directory))
                       ((symbol-function 'majutsu-process-jj-arguments)
@@ -238,6 +371,7 @@
                                (list (process-get proc 'success-msg)
                                      (process-get proc 'finish-callback)
                                      (process-get proc 'inhibit-refresh)
+                                     (majutsu-process-completion-owned-p proc)
                                      sentinel))
                          ;; Keep cleanup silent without changing the point at
                          ;; which the properties above are observed.
@@ -246,9 +380,11 @@
               (should (eq (majutsu-start-jj '("status") "Finished" callback t)
                           process))
               (should (eq created process))
+              (should-not created-owned)
               (should (equal (butlast observed)
-                             (list "Finished" callback t)))
+                             (list "Finished" callback t nil)))
               (should (eq (car (last observed)) #'majutsu--process-sentinel))
+              (should (majutsu-process-completion-owned-p process))
               ;; Finish callbacks are now installed at that same safe point.
               (process-put process 'section nil)
               (cl-letf (((symbol-function 'process-exit-status)
@@ -267,6 +403,53 @@
                 (should-not refreshed)))))
       (when (and process (process-live-p process))
         (delete-process process)))))
+
+(ert-deftest majutsu-process-test-start-process-filter-error-stops-unowned-child ()
+  "A filter installation error must stop the child before ownership."
+  (should (equal (majutsu-process-test--setup-failure-result 'filter 'error)
+                 '(error nil nil nil))))
+
+(ert-deftest majutsu-process-test-start-process-filter-quit-stops-unowned-child ()
+  "A quit during filter installation must stop the child before ownership."
+  (should (equal (majutsu-process-test--setup-failure-result 'filter 'quit)
+                 '(quit nil nil nil))))
+
+(ert-deftest majutsu-process-test-start-process-sentinel-error-stops-unowned-child ()
+  "A sentinel installation error must stop the child before ownership."
+  (should (equal (majutsu-process-test--setup-failure-result 'sentinel 'error)
+                 '(error nil nil nil))))
+
+(ert-deftest majutsu-process-test-start-process-sentinel-quit-stops-unowned-child ()
+  "A quit during sentinel installation must stop the child before ownership."
+  (should (equal (majutsu-process-test--setup-failure-result 'sentinel 'quit)
+                 '(quit nil nil nil))))
+
+(ert-deftest majutsu-process-test-setup-finalizes-an-already-exited-child-once ()
+  "Installing a sentinel after exit must still run completion exactly once."
+  (with-temp-buffer
+    (let* ((process (make-process :name "majutsu-already-exited-test"
+                                  :buffer (current-buffer)
+                                  :command '("sh" "-c" "exit 0")
+                                  :noquery t))
+           (calls 0)
+           (majutsu-process--start-finish-callback
+            (lambda (_process exit-code)
+              (should (= exit-code 0))
+              (setq calls (1+ calls))))
+           (majutsu-process--inhibit-refresh t))
+      (while (process-live-p process)
+        (accept-process-output process 0.05))
+      ;; Drain the original exit notification before Majutsu owns the child.
+      (accept-process-output process 0.01)
+      (cl-letf (((symbol-function 'message) #'ignore))
+        (majutsu--process-setup
+         process nil temporary-file-directory
+         #'majutsu--process-sentinel)
+        (should (majutsu-process-completion-owned-p process))
+        (should (= calls 1))
+        ;; A late duplicate notification must be harmless.
+        (majutsu--process-sentinel process "finished\n")
+        (should (= calls 1))))))
 
 (ert-deftest majutsu-process-test-start-jj-with-editor-forwards-session-options ()
   "The session-aware with-editor entry point forwards all completion options."


### PR DESCRIPTION
* majutsu-process.el (majutsu-process-completion-owned-p,
majutsu--process-setup, majutsu-start-process): Publish completion
ownership only after installing both the process filter and sentinel.
Reclaim unowned children after setup errors or quits, and finalize a
child that exited before sentinel installation.
(majutsu--process-sentinel): Make process finalization idempotent.
(majutsu-process--control-fragment-max-bytes,
majutsu--process-bounded-control-fragment,
majutsu-process-track-with-editor-output,
majutsu--process-strip-with-editor-control-packets): Bound retained
incomplete control packets.
(majutsu--process-last-bare-carriage-return,
majutsu--process-filter): Parse control packets before interpreting bare
carriage returns, preserving CRLF framing across output chunks.
* test/majutsu-process-test.el
(majutsu-process-test--setup-failure-result): Add a common setup-failure
harness.
(majutsu-process-test-start-process-filter-error-stops-unowned-child,
majutsu-process-test-start-process-filter-quit-stops-unowned-child,
majutsu-process-test-start-process-sentinel-error-stops-unowned-child,
majutsu-process-test-start-process-sentinel-quit-stops-unowned-child,
majutsu-process-test-setup-finalizes-an-already-exited-child-once):
Test startup cleanup and exactly-once completion.
(test-majutsu-process-filter/handles-real-packet-across-crlf-chunks,
test-majutsu-process-filter/discards-oversized-control-fragment,
test-majutsu-process-track-with-editor-output/discards-oversized-fragment):
Test sleeping-editor framing and fragment bounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process completion handling to prevent missed or duplicate finalization during startup and shutdown.
  * Improved cleanup when processes fail to start or exit before initialization completes.
  * Fixed handling of split control packets and CRLF line endings.
  * Limited retained control-packet fragments to prevent excessive buffering.
  * Improved cleanup of identifiable child processes and session-state handling for relative paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->