### PR TITLE
Bind patch selections to rendered repository context.

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -210,6 +210,9 @@
 
 - Patch selection safety ::
   Concurrent patch operations no longer overwrite each other's patch input.
+  Patch operations reject stale selections or a source different from the
+  displayed diff, and pin execution to the validated revisions.  Restore
+  requires an explicit operation for ambiguous multi-revision diffs.
 
 - Cancelled editor sessions preserve selections ::
   When a jj editor exits without changing the repository, the Emacs patch
@@ -219,6 +222,10 @@
 - Files without a final newline ::
   Partial patch selections no longer join added text onto an unselected final
   line when the file lacks a trailing newline.
+
+- Restore selections spanning multiple files ::
+  Restore reuses the displayed fileset when applying a partial patch, preserving
+  unselected changes in other files.
 
 - Ediff conflict results ::
   Quitting Ediff without edits keeps a conflict unresolved.  Saving edited

--- a/majutsu-interactive.el
+++ b/majutsu-interactive.el
@@ -26,6 +26,10 @@
 (require 'magit-section)
 (require 'transient)
 
+(declare-function majutsu-jj-operation-id "majutsu-jj"
+                  (&optional directory snapshot))
+(declare-function majutsu-process-completion-owned-p "majutsu-process" (process))
+
 ;;; Options
 
 (defgroup majutsu-interactive nil
@@ -64,6 +68,18 @@ region within a hunk.")
 (defvar-local majutsu-interactive--selection-operation nil
   "Transient operation that owns the current patch selection.")
 
+(cl-defstruct (majutsu-interactive-context
+               (:constructor majutsu-interactive-context-create))
+  "Repository and buffer generation that a patch selection belongs to."
+  operation root operation-id buffer-tick diff-range diff-filesets)
+
+(defvar-local majutsu-interactive--render-context nil
+  "Repository state represented by the current rendered diff.
+Nil means no context has been recorded; `stale' requires a fresh render.")
+
+(defvar-local majutsu-interactive--selection-context nil
+  "Rendered repository state copied when the first change is selected.")
+
 (defun majutsu-interactive--current-operation ()
   "Return the patch-selection operation active in the current transient."
   (and (boundp 'transient-current-command)
@@ -71,12 +87,76 @@ region within a hunk.")
              '(majutsu-split majutsu-squash majutsu-restore))
        transient-current-command))
 
+(defun majutsu-interactive--repository-root ()
+  "Return the current buffer's repository root without signaling."
+  (condition-case nil
+      (when-let* ((root (or (majutsu--buffer-root)
+                            (majutsu--toplevel-safe default-directory))))
+        (file-name-as-directory root))
+    (error nil)))
+
+(defun majutsu-interactive--current-repository-operation (root &optional snapshot)
+  "Return ROOT's current jj operation id without signaling.
+When SNAPSHOT is non-nil, snapshot working-copy filesystem changes first."
+  (and root
+       (fboundp 'majutsu-jj-operation-id)
+       (majutsu-jj-operation-id root snapshot)))
+
+(defun majutsu-interactive-record-render-context ()
+  "Record the repository state represented by the current diff buffer."
+  (when (derived-mode-p 'majutsu-diff-mode)
+    (let ((root (majutsu-interactive--repository-root)))
+      (setq-local
+       majutsu-interactive--render-context
+       (majutsu-interactive-context-create
+        :root root
+        :operation-id
+        ;; The refresh command has already produced the rendered tree.  Merely
+        ;; read that operation here; freshness checks snapshot later changes.
+        (majutsu-interactive--current-repository-operation root)
+        :buffer-tick (buffer-chars-modified-tick)
+        :diff-range (copy-tree majutsu-buffer-diff-range)
+        :diff-filesets (copy-tree majutsu-buffer-diff-filesets))))))
+
+(defun majutsu-interactive--context-current-p (context &optional check-operation)
+  "Return non-nil when CONTEXT still describes the current buffer.
+When CHECK-OPERATION is non-nil, also require the same readable jj operation."
+  (and context
+       (equal (majutsu-interactive-context-root context)
+              (majutsu-interactive--repository-root))
+       (equal (majutsu-interactive-context-buffer-tick context)
+              (buffer-chars-modified-tick))
+       (equal (majutsu-interactive-context-diff-range context)
+              majutsu-buffer-diff-range)
+       (equal (majutsu-interactive-context-diff-filesets context)
+              majutsu-buffer-diff-filesets)
+       (or (not check-operation)
+           (let ((before (majutsu-interactive-context-operation-id context))
+                 (after
+                  (majutsu-interactive--current-repository-operation
+                   (majutsu-interactive-context-root context) t)))
+             ;; Hand-built test/extension buffers may not have a render-time
+             ;; token.  Real refreshed diff buffers are rejected below when
+             ;; their token could not be recorded.
+             (or (null before)
+                 (and after (equal before after)))))))
+
+(defun majutsu-interactive--stale-selection-error ()
+  "Invalidate the current selection and report its stale repository state."
+  (majutsu-interactive-invalidate t)
+  (user-error "Repository changed since this diff was rendered; refresh and select again"))
+
 (defun majutsu-interactive--assert-selection-context (&optional operation)
-  "Signal if current selections belong to a different OPERATION.
+  "Signal if current selections do not belong to OPERATION and this diff.
 
 OPERATION is a transient command symbol such as `majutsu-split'.  A selection
 is deliberately not transferable between jj commands: its patch direction and
 the command's source semantics differ."
+  (when (and (majutsu-interactive--has-selections-p)
+             majutsu-interactive--selection-context
+             (not (majutsu-interactive--context-current-p
+                   majutsu-interactive--selection-context t)))
+    (majutsu-interactive--stale-selection-error))
   (when (and operation
              (majutsu-interactive--has-selections-p)
              (not (eq majutsu-interactive--selection-operation operation)))
@@ -84,23 +164,65 @@ the command's source semantics differ."
                 (or majutsu-interactive--selection-operation "another context")
                 operation)))
 
+
+
 (defun majutsu-interactive--ensure-selection-context ()
   "Bind a new selection to the current transient operation, or validate it."
+  (when (eq majutsu-interactive--render-context 'stale)
+    (majutsu-interactive--stale-selection-error))
   (let ((operation (majutsu-interactive--current-operation)))
     (if (majutsu-interactive--has-selections-p)
         (majutsu-interactive--assert-selection-context operation)
-      (setq majutsu-interactive--selection-operation operation))))
+      (let* ((root (majutsu-interactive--repository-root))
+             (render (or majutsu-interactive--render-context
+                         (majutsu-interactive-context-create
+                          :root root
+                          :operation-id
+                          (majutsu-interactive--current-repository-operation
+                           root t)
+                          :buffer-tick (buffer-chars-modified-tick)
+                          :diff-range (copy-tree majutsu-buffer-diff-range)
+                          :diff-filesets
+                          (copy-tree majutsu-buffer-diff-filesets)))))
+        ;; A real refreshed diff has a render token.  If jj advanced before the
+        ;; first selection, do not bind positions from the old tree to the new
+        ;; repository state.
+        (when majutsu-interactive--render-context
+          (unless (majutsu-interactive-context-operation-id render)
+            (user-error "Cannot verify the repository state for this diff; refresh and try again"))
+          (unless (majutsu-interactive--context-current-p render t)
+            (majutsu-interactive--stale-selection-error)))
+        (setq-local majutsu-interactive--selection-operation operation)
+        (setq-local majutsu-interactive--selection-context
+                    (copy-majutsu-interactive-context render))
+        (setf (majutsu-interactive-context-operation
+               majutsu-interactive--selection-context)
+              operation)))))
 
-(defun majutsu-interactive-invalidate ()
+
+(defun majutsu-interactive-invalidate (&optional forget-render-context)
   "Discard selections whose rendered diff is about to be rebuilt.
 
 Interactive selection ranges are buffer positions, so retaining them across a
 diff refresh would make a later patch apply to unrelated text.  This helper is
 quiet on purpose; callers use it as part of refresh lifecycle rather than an
-explicit user action."
+explicit user action.  When FORGET-RENDER-CONTEXT is non-nil, also mark the
+current diff rendering as stale."
   (setq majutsu-interactive--selections nil)
   (setq majutsu-interactive--selection-operation nil)
+  (setq majutsu-interactive--selection-context nil)
+  (when forget-render-context
+    (setq majutsu-interactive--render-context 'stale))
   (majutsu-interactive--clear-overlays))
+
+(defun majutsu-interactive-invalidate-repository (root)
+  "Invalidate patch selections in every Majutsu diff buffer for ROOT."
+  (dolist (buffer (majutsu-mode-get-buffers root))
+    (with-current-buffer buffer
+      (when (derived-mode-p 'majutsu-diff-mode)
+        (majutsu-interactive-invalidate t)))))
+
+
 
 (defun majutsu-interactive--hunk-id (section)
   "Return unique identifier for hunk SECTION."
@@ -955,52 +1077,85 @@ Remove its temporary directory when PROCESS exits or is signaled."
         t)
     nil))
 
-(defun majutsu-interactive--operation-id (root)
-  "Return ROOT's current jj operation id without snapshotting its worktree.
 
-Return nil if the id cannot be read.  Selection positions must be considered
-unsafe in that case, so callers treat nil as an unknown operation result."
-  (condition-case nil
-      (let ((default-directory root))
-        (when-let* ((id (majutsu-jj-string
-                         "--ignore-working-copy" "operation" "log"
-                         "--no-graph" "-n" "1" "-T" "id")))
-          (unless (string-empty-p id)
-            id)))
-    (error nil)))
 
-(defun majutsu-interactive--complete-patch-operation (buffer operation-before)
-  "Refresh BUFFER after a custom patch operation when its repository changed.
-
-When jj reports no new operation, retain BUFFER's Emacs-owned selection so a
-cancelled external editor or failed helper does not discard the user's work.
-An unreadable operation id is handled conservatively: positions are cleared
-before refresh rather than being reused against a different diff."
+(defun majutsu-interactive--refresh-operation-origin (buffer root)
+  "Refresh live Majutsu BUFFER using repository ROOT."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
-      (let ((operation-after
-             (majutsu-interactive--operation-id
-              (majutsu--toplevel-safe default-directory))))
-        (cond
-         ((and operation-before operation-after
-               (equal operation-before operation-after))
-          (message "jj patch selection ended without a repository operation"))
-         (t
-          (majutsu-interactive-invalidate)
-          (majutsu-refresh)
-          (unless (and operation-before operation-after)
-            (message "jj patch selection ended; could not verify its repository result"))))))))
+      (let ((default-directory root))
+        (when (derived-mode-p 'majutsu-mode)
+          (majutsu-refresh))))))
+
+(defun majutsu-interactive-complete-repository-operation
+    (root origin-buffer operation-before &optional unchanged-message)
+  "Complete a repository operation rooted at ROOT.
+
+Compare OPERATION-BEFORE with jj's current operation id.  A changed or
+unreadable id invalidates every patch selection for ROOT before refreshing
+ORIGIN-BUFFER.  An unchanged id preserves selections and optionally displays
+UNCHANGED-MESSAGE.  Return `unchanged', `changed', or `unknown'."
+  (let (completed outcome)
+    (unwind-protect
+        (let ((operation-after (majutsu-jj-operation-id root)))
+          (setq outcome
+                (cond
+                 ((not (and operation-before operation-after)) 'unknown)
+                 ((equal operation-before operation-after) 'unchanged)
+                 (t 'changed)))
+          (pcase outcome
+            ('unchanged
+             (when unchanged-message
+               (message "%s" unchanged-message)))
+            ((or 'changed 'unknown)
+             (majutsu-interactive-invalidate-repository root)
+             (majutsu-interactive--refresh-operation-origin
+              origin-buffer root)
+             (when (eq outcome 'unknown)
+               (message "jj operation ended; could not verify its repository result"))))
+          (setq completed t)
+          outcome)
+      (unless completed
+        ;; `quit' is not an `error'.  If the probe or refresh was interrupted,
+        ;; never leave position-based selections usable against an unknown tree.
+        (let ((inhibit-quit t))
+          (majutsu-interactive-invalidate-repository root)
+          (run-at-time 0 nil
+                       #'majutsu-interactive--refresh-operation-origin
+                       origin-buffer root))))))
+
+(defun majutsu-interactive--complete-patch-operation
+    (buffer root operation-before exit-code)
+  "Complete a custom patch operation from BUFFER after EXIT-CODE."
+  (majutsu-interactive-complete-repository-operation
+   root buffer operation-before
+   (and (integerp exit-code)
+        (zerop exit-code)
+        "jj patch selection ended without a repository operation")))
+
+(defvar majutsu-interactive--replay-in-flight (make-hash-table :test 'equal)
+  "Repository roots whose patch replay is still running.")
+
+(defun majutsu-interactive--release-replay (root)
+  "Allow new patch replays for ROOT."
+  (remhash root majutsu-interactive--replay-in-flight))
 
 (defun majutsu-interactive-run-replay-plan (command args filesets plan)
   "Run jj COMMAND with ARGS and FILESETS using replay PLAN.
 PLAN reconstructs the merge editor's right tree from its selected or
-complemented text and whole-file changes."
-  (let ((directory (majutsu-interactive--make-operation-temp-dir))
-        (origin-buffer (current-buffer))
-        (operation-before
-         (majutsu-interactive--operation-id
-          (majutsu--toplevel-safe default-directory)))
-        retained)
+complemented text and whole-file changes.  Only one replay may run
+per repository at a time: the selection stays valid until the jj
+process commits its operation, so re-running the still-rendered
+selection would apply the same patch twice and diverge the change."
+  (let* ((origin-buffer (current-buffer))
+         (root (file-name-as-directory
+                (majutsu--toplevel-safe default-directory)))
+         (operation-before (majutsu-jj-operation-id root))
+         (directory (majutsu-interactive--make-operation-temp-dir))
+         retained)
+    (when (gethash root majutsu-interactive--replay-in-flight)
+      (user-error "A jj patch operation is already running in this repository"))
+    (puthash root t majutsu-interactive--replay-in-flight)
     (unwind-protect
         (let* ((patch-file (majutsu-interactive--write-patch
                             (or (plist-get plan :patch) "") directory))
@@ -1014,22 +1169,24 @@ complemented text and whole-file changes."
                (process
                 (majutsu-start-jj-with-editor
                  full-args nil
-                 (lambda (_process exit-code)
-                   ;; Process sentinels run with quitting inhibited.  Defer
-                   ;; refresh and selection invalidation until it is safe to
-                   ;; rebuild the originating diff buffer.  A reported jj
-                   ;; failure retains the user's selection.
-                   (when (and (integerp exit-code) (zerop exit-code))
+                 (lambda (process exit-code)
+                   (majutsu-interactive--release-replay root)
+                   (when (and (fboundp 'majutsu-process-completion-owned-p)
+                              (majutsu-process-completion-owned-p process))
                      (run-at-time 0 nil
                                   #'majutsu-interactive--complete-patch-operation
-                                  origin-buffer operation-before)))
+                                  origin-buffer root operation-before
+                                  exit-code)))
                  t)))
           (setq retained
                 (majutsu-interactive--retain-temp-dir-for-process
                  process directory))
+          (message "Running jj %s with the patch selection..." command)
           process)
       (unless retained
+        (majutsu-interactive--release-replay root)
         (majutsu-interactive--delete-operation-temp-dir directory)))))
+
 
 ;;; _
 (provide 'majutsu-interactive)

--- a/majutsu-jj.el
+++ b/majutsu-jj.el
@@ -701,8 +701,43 @@ contributes an empty string; callers can distinguish it from an absent option."
          ((and short (stringp arg)
                (string-prefix-p short arg)
                (> (length arg) (length short)))
-          (push (substring arg (length short)) values)))))
+          (let ((value (substring arg (length short))))
+            ;; clap accepts both `-rREV' and `-r=REV'.  Keep the attached
+            ;; equals as syntax instead of returning it as part of REV.
+            (push (if (string-prefix-p "=" value)
+                      (substring value 1)
+                    value)
+                  values))))))
     (nreverse values)))
+
+(defun majutsu-jj-set-option-value (args option value &optional short)
+  "Return ARGS with OPTION replaced by VALUE, also removing SHORT spellings.
+
+Every spelling recognized by `majutsu-jj-option-values' is removed before a
+single =VALUE spelling is inserted.  When VALUE is nil, only remove the
+option.  Preserve arguments at and after `--' unchanged."
+  (let (kept tail)
+    (while args
+      (let ((arg (pop args)))
+        (cond
+         ((equal arg "--")
+          (setq tail (cons arg args)
+                args nil))
+         ((or (equal arg option) (and short (equal arg short)))
+          (when (and args
+                     (stringp (car args))
+                     (not (string-prefix-p "-" (car args))))
+            (pop args)))
+         ((and (stringp arg)
+               (or (string-prefix-p (concat option "=") arg)
+                   (and short
+                        (string-prefix-p short arg)
+                        (> (length arg) (length short))))))
+         (t
+          (push arg kept)))))
+    (append (nreverse kept)
+            (and value (list (concat option "=" value)))
+            tail)))
 
 (defun majutsu--jj-insert (return-error &rest args)
   "Run jj with ARGS and insert output at point.
@@ -785,7 +820,7 @@ Empty items are omitted from the result."
 (defun majutsu-jj--parse-conflicted-file-record (record)
   "Parse one conflicted-file machine RECORD into a plist."
   (let* ((fields (majutsu--split-fields
-                  (or record "") majutsu-jj--conflicted-file-field-separator 2))
+                   (or record "") majutsu-jj--conflicted-file-field-separator 2))
          (sides (string-to-number (or (nth 0 fields) "")))
          (path (nth 1 fields)))
     (when (and (stringp path)
@@ -822,6 +857,21 @@ newline, return an empty string.  This function aligns with
       (unless (bobp)
         (goto-char (point-min))
         (buffer-substring-no-properties (point) (line-end-position))))))
+
+(defun majutsu-jj-operation-id (&optional directory snapshot)
+  "Return DIRECTORY's current jj operation ID.
+
+DIRECTORY defaults to `default-directory'.  Return nil when jj cannot provide
+a nonempty ID.  When SNAPSHOT is nil, do not snapshot the working copy first."
+  (condition-case nil
+      (let ((default-directory (or directory default-directory)))
+        (when-let* ((id (majutsu-jj-string
+                         (unless snapshot "--ignore-working-copy")
+                         "operation" "log"
+                         "--no-graph" "-n" "1" "-T" "id")))
+          (unless (string-empty-p id)
+            id)))
+    (error nil)))
 
 (defun majutsu-jj-resolve-single-commit (revset)
   "Return REVSET's only commit ID, or nil unless it resolves exactly once.

--- a/majutsu-mode.el
+++ b/majutsu-mode.el
@@ -272,9 +272,11 @@ tricking buffer reuse logic into thinking a buffer belongs to a
 repository that it doesn't.")
 (put 'majutsu--default-directory 'permanent-local t)
 
-(defun majutsu-mode-get-buffers ()
-  "Return Majutsu buffers belonging to the current repository."
-  (let ((topdir (majutsu--toplevel-safe)))
+(defun majutsu-mode-get-buffers (&optional root)
+  "Return Majutsu buffers belonging to ROOT.
+When ROOT is nil, use the current repository."
+  (let ((topdir (file-name-as-directory
+                 (or root (majutsu--toplevel-safe)))))
     (seq-filter (lambda (buf)
                   (with-current-buffer buf
                     (and (derived-mode-p 'majutsu-mode)
@@ -492,7 +494,7 @@ CREATED, INITIAL-SECTION, and SELECT-SECTION are for internal use."
     ;; old sections and text disappear.  Keep this dynamic to avoid making the
     ;; base mode depend on the optional interactive-selection feature.
     (when (fboundp 'majutsu-interactive-invalidate)
-      (majutsu-interactive-invalidate))
+      (majutsu-interactive-invalidate t))
     (let ((action (if created "Creating" "Refreshing")))
       (when (eq major-mode 'majutsu-mode)
         (majutsu--debug "%s buffer `%s'..." action (buffer-name)))
@@ -515,6 +517,11 @@ CREATED, INITIAL-SECTION, and SELECT-SECTION are for internal use."
       (let ((magit-section-cache-visibility nil))
         (when (bound-and-true-p magit-root-section)
           (majutsu-section-show magit-root-section)))
+      (when (fboundp 'majutsu-interactive-record-render-context)
+        (majutsu-interactive-record-render-context))
+      ;; User hooks may modify the working copy or perform another jj
+      ;; operation.  Bind the context to the tree just rendered before giving
+      ;; those hooks control, so the next selection detects such changes.
       (run-hooks 'majutsu-refresh-buffer-hook)
       (magit-section-update-highlight)
       (set-buffer-modified-p nil))))

--- a/majutsu-restore.el
+++ b/majutsu-restore.el
@@ -19,7 +19,6 @@
 (require 'majutsu)
 (require 'majutsu-diff-editor)
 
-(declare-function majutsu-diff--revision-metadata "majutsu-diff" ())
 (defvar majutsu-buffer-diff-range)
 
 ;;; Abandon
@@ -40,85 +39,144 @@
 
 ;;; Restore
 
-(defun majutsu-restore--default-args ()
-  "Return default args from diff buffer context.
-Diff =--revisions= / =-r= become Restore =--changes-in=; other range args
-are passed through unchanged."
+(defvar-local majutsu-restore--unsafe-diff-context nil
+  "Diagnostic for a diff that cannot seed `jj restore' safely.")
+
+(defvar-local majutsu-restore--diff-context-cache-key :uncomputed
+  "Diff range and rendered generation for the cached Restore context.")
+
+(defvar-local majutsu-restore--diff-context-cache-value nil
+  "Cached semantic Restore context for the current rendered diff.")
+
+(defun majutsu-restore--only-value (values)
+  "Return the sole nonempty member of VALUES, or nil."
+  (and (= (length values) 1)
+       (not (string-empty-p (car values)))
+       (car values)))
+
+(defun majutsu-restore--endpoint-context (from to)
+  "Return canonical restore endpoint context for FROM and TO."
+  (when-let* ((source (majutsu-jj-resolve-single-commit (or from "@")))
+              (destination (majutsu-jj-resolve-single-commit (or to "@"))))
+    (list :endpoints source destination)))
+
+(defun majutsu-restore--changes-context (revision)
+  "Return canonical `--changes-in' context for REVISION."
+  (when-let* ((commit (majutsu-jj-resolve-single-commit revision)))
+    (list :changes-in commit)))
+
+(defun majutsu-restore--compute-diff-context ()
+  "Compute safe Restore defaults and patch context for the current diff.
+
+The returned plist contains `:args' and `:patch-context'.  A diff for one
+revision maps to `--changes-in'.  An aggregate revision diff is deliberately
+not guessed into a different Restore operation and instead carries `:error'."
   (when (derived-mode-p 'majutsu-diff-mode)
-    (if (and (equal (car majutsu-buffer-diff-range) "-r")
-             (cadr majutsu-buffer-diff-range))
-        (list (concat "--changes-in=" (cadr majutsu-buffer-diff-range)))
-      (mapcar (lambda (arg)
-                (if-let* ((rev (transient-arg-value "--revisions=" (list arg))))
-                    (concat "--changes-in=" rev)
-                  arg))
-              majutsu-buffer-diff-range))))
+    (let* ((range majutsu-buffer-diff-range)
+           (from-values (majutsu-jj-option-values range "--from" "-f"))
+           (to-values (majutsu-jj-option-values range "--to" "-t"))
+           (revisions (majutsu-jj-option-values range "--revisions" "-r")))
+      (cond
+       ((or from-values to-values)
+        (let* ((from (majutsu-restore--only-value from-values))
+               (to (majutsu-restore--only-value to-values))
+               (context (and (or from (null from-values))
+                             (or to (null to-values))
+                             (majutsu-restore--endpoint-context from to))))
+          (if context
+              (list :args (append (and from (list (concat "--from=" from)))
+                                  (and to (list (concat "--to=" to))))
+                    :patch-context context)
+            (list :error "Restore diff endpoints must each resolve to one commit"))))
+       ((null revisions)
+        (let ((context (majutsu-restore--changes-context "@")))
+          (list :args nil :patch-context context)))
+       ((and (= (length revisions) 1)
+             (not (string-empty-p (car revisions))))
+        (if-let* ((context (majutsu-restore--changes-context (car revisions))))
+            (list :args
+                  (list (concat "--changes-in=" (cadr context)))
+                  :patch-context context)
+          (list :error
+                "Restore patch selection requires a diff for exactly one commit")))
+       (t
+        (list :error
+              "Restore patch selection does not support aggregate revision diffs"))))))
 
-(defun majutsu-restore--selector (args)
-  "Return Restore selector canonicalized from ARGS.
-The selector is either (:changes-in REV) or (:from FROM :to TO).
-Missing --from/--to default to @, matching jj restore/diff."
-  (let ((changes-in (transient-arg-value "--changes-in=" args))
-        (from (transient-arg-value "--from=" args))
-        (to (transient-arg-value "--to=" args)))
+(defun majutsu-restore--diff-context ()
+  "Return the cached semantic Restore context for the current diff."
+  (when (derived-mode-p 'majutsu-diff-mode)
+    (let ((key (list (copy-tree majutsu-buffer-diff-range)
+                     (buffer-chars-modified-tick))))
+      (unless (equal key majutsu-restore--diff-context-cache-key)
+        (setq-local majutsu-restore--diff-context-cache-key key)
+        (setq-local majutsu-restore--diff-context-cache-value
+                    (majutsu-restore--compute-diff-context)))
+      majutsu-restore--diff-context-cache-value)))
+
+(defun majutsu-restore--args-context (args)
+  "Return the canonical Restore tree context selected by ARGS."
+  (let* ((changes (majutsu-jj-option-values args "--changes-in" "-c"))
+         (from (majutsu-jj-option-values args "--from" "-f"))
+         (to (append (majutsu-jj-option-values args "--to" "-t")
+                     (majutsu-jj-option-values args "--into"))))
     (cond
-     (changes-in (list :changes-in changes-in))
-     ((or from to) (list :from (or from "@") :to (or to "@")))
-     (t (list :changes-in "@")))))
+     ((not (or changes from to))
+      (majutsu-restore--changes-context "@"))
+     ((and changes (not (or from to)))
+      (when-let* ((revision (majutsu-restore--only-value changes)))
+        (majutsu-restore--changes-context revision)))
+     ((and (not changes)
+           (<= (length from) 1)
+           (<= (length to) 1))
+      (let ((from-value (majutsu-restore--only-value from))
+            (to-value (majutsu-restore--only-value to)))
+        (and (or from-value (null from))
+             (or to-value (null to))
+             (majutsu-restore--endpoint-context
+              from-value to-value)))))))
 
-(defun majutsu-restore--patch-selector (&optional buffer)
-  "Return Restore selector for BUFFER, or nil when patch restore is unsafe.
-Only single-revision diffs (with structured metadata) and explicit
---from/--to ranges can drive patch selection."
-  (with-current-buffer (or buffer (current-buffer))
-    (when (derived-mode-p 'majutsu-diff-mode)
-      (let* ((range majutsu-buffer-diff-range)
-             (from (transient-arg-value "--from=" range))
-             (to (transient-arg-value "--to=" range))
-             (revisions
-              (append
-               (seq-keep (lambda (arg)
-                           (transient-arg-value "--revisions=" (list arg)))
-                         range)
-               (and (equal (car range) "-r") (cadr range)
-                    (list (cadr range))))))
-        (cond
-         ((or from to)
-          (majutsu-restore--selector (majutsu-restore--default-args)))
-         ((null range)
-          (list :changes-in "@"))
-         ((and (= (length revisions) 1)
-               (majutsu-diff--revision-metadata))
-          (list :changes-in (car revisions))))))))
+(defun majutsu-restore--check-patch-context (args context)
+  "Signal unless ARGS select the same Restore tree pair as CONTEXT."
+  (unless context
+    (user-error "Patch selection is not safe for this diff context"))
+  (unless (equal (majutsu-restore--args-context args) context)
+    (user-error "Patch selection requires the source and destination shown by the diff")))
 
-(defun majutsu-restore--check-patch-selector (args selector)
-  "Signal unless ARGS match the displayed diff SELECTOR."
-  (unless selector
-    (user-error
-     "Patch selection for restore requires a single-revision or explicit-range diff"))
-  (unless (equal selector (majutsu-restore--selector args))
-    (user-error
-     "Patch selection for restore requires the displayed diff selector")))
+(defun majutsu-restore--pin-patch-context (args context)
+  "Return ARGS pinned to the canonical Restore CONTEXT."
+  (pcase context
+    (`(:changes-in ,commit)
+     (setq args (majutsu-jj-set-option-value args "--from" nil "-f"))
+     (setq args (majutsu-jj-set-option-value args "--to" nil "-t"))
+     (setq args (majutsu-jj-set-option-value args "--into" nil))
+     (majutsu-jj-set-option-value args "--changes-in" commit "-c"))
+    (`(:endpoints ,source ,destination)
+     (setq args (majutsu-jj-set-option-value args "--changes-in" nil "-c"))
+     (setq args (majutsu-jj-set-option-value args "--into" nil))
+     (setq args (majutsu-jj-set-option-value args "--from" source "-f"))
+     (majutsu-jj-set-option-value args "--to" destination "-t"))
+    (_ args)))
+
+(defun majutsu-restore--explicit-context-p (args)
+  "Return non-nil when ARGS explicitly choose a Restore tree context."
+  (or (majutsu-jj-option-values args "--changes-in" "-c")
+      (majutsu-jj-option-values args "--from" "-f")
+      (majutsu-jj-option-values args "--to" "-t")
+      (majutsu-jj-option-values args "--into")))
 
 (defun majutsu-restore-interactive-selection-available-p ()
-  "Return non-nil when the current diff can safely drive patch Restore."
+  "Return non-nil when this diff has a safe Restore patch context."
   (and (majutsu-interactive-selection-available-p)
-       (majutsu-restore--patch-selector)))
+       (plist-get (majutsu-restore--diff-context) :patch-context)))
 
-(defun majutsu-restore--remove-interactive-tool-args (args)
-  "Return ARGS without native interactive-editor or tool arguments."
-  (let (out)
-    (while args
-      (let ((arg (pop args)))
-        (cond
-         ((member arg '("-i" "--interactive")))
-         ((member arg '("-t" "--tool"))
-          (when args (pop args)))
-         ((and (stringp arg)
-               (or (string-prefix-p "--tool=" arg)
-                   (string-prefix-p "-t=" arg))))
-         (t (push arg out)))))
-    (nreverse out)))
+(defun majutsu-restore--default-args ()
+  "Return default args from diff buffer context."
+  (setq-local majutsu-restore--unsafe-diff-context nil)
+  (when-let* ((context (majutsu-restore--diff-context)))
+    (setq-local majutsu-restore--unsafe-diff-context
+                (plist-get context :error))
+    (plist-get context :args)))
 
 ;;;###autoload
 (defun majutsu-restore-dwim ()
@@ -140,15 +198,20 @@ In diff buffer on a file section, restore only that file."
   (interactive (list (transient-args 'majutsu-restore)))
   (pcase-let* ((`(,args ,filesets) (majutsu-filesets-split-transient-value args))
                (jj-editor-p (majutsu-diff-editor-interactive-arguments-p args))
-               ;; jj presents destination on the left and restore source on
-               ;; the right.  The complement plan keeps that source tree and
-               ;; replays only unselected changes forward from the left.
+               (diff-context (majutsu-restore--diff-context))
                ;; A jj editor does not consume the Emacs selection, so avoid
                ;; validating a possibly different selection owner here.
                (plan (and (not jj-editor-p)
                           (majutsu-interactive-build-replay-plan-if-selected
-                           nil 'complement 'majutsu-restore)))
-               (selector (and plan (majutsu-restore--patch-selector))))
+                           nil 'complement 'majutsu-restore))))
+    (when (and (plist-get diff-context :error)
+               (not (majutsu-restore--explicit-context-p args)))
+      (user-error "%s" (plist-get diff-context :error)))
+    (when plan
+      (majutsu-restore--check-patch-context
+       args (plist-get diff-context :patch-context))
+      (setq args (majutsu-restore--pin-patch-context
+                  args (plist-get diff-context :patch-context))))
     (cond
      ;; Explicit jj editor flags win over an existing Majutsu patch selection.
      ;; Do not clear it: the user may return and apply it later.
@@ -156,11 +219,16 @@ In diff buffer on a file section, restore only that file."
       (majutsu-diff-editor-start
        "restore" args filesets :origin-buffer (current-buffer)))
      (plan
-      (majutsu-restore--check-patch-selector args selector)
+      ;; A transient opened at a file section carries that file as a convenient
+      ;; default for ordinary Restore.  A patch selection instead belongs to
+      ;; the entire rendered diff.  Reuse the diff's own matcher so jj checks
+      ;; out exactly the files represented by the inverse patch.
       (majutsu-interactive-run-replay-plan
        "restore"
        (majutsu-diff-editor-strip-interactive-arguments args)
-       filesets plan))
+       (and (derived-mode-p 'majutsu-diff-mode)
+            (copy-sequence majutsu-buffer-diff-filesets))
+       plan))
      (t
       (let ((exit (apply #'majutsu-run-jj
                          "restore"
@@ -176,7 +244,7 @@ In diff buffer on a file section, restore only that file."
   :selection-label "[FROM]"
   :selection-face '(:background "dark orange" :foreground "black")
   :selection-toggle-key "f"
-  :selection-toggle-if-not #'majutsu-interactive-selection-available-p
+  :selection-toggle-if-not #'majutsu-restore-interactive-selection-available-p
   :shortarg "-f"
   :argument "--from="
   :reader #'majutsu-transient-read-revset)
@@ -187,7 +255,7 @@ In diff buffer on a file section, restore only that file."
   :selection-label "[TO]"
   :selection-face '(:background "dark cyan" :foreground "white")
   :selection-toggle-key "t"
-  :selection-toggle-if-not #'majutsu-interactive-selection-available-p
+  :selection-toggle-if-not #'majutsu-restore-interactive-selection-available-p
   :shortarg "-t"
   :argument "--to="
   :reader #'majutsu-transient-read-revset)
@@ -198,7 +266,7 @@ In diff buffer on a file section, restore only that file."
   :selection-label "[CHANGES-IN]"
   :selection-face '(:background "dark magenta" :foreground "white")
   :selection-toggle-key "c"
-  :selection-toggle-if-not #'majutsu-interactive-selection-available-p
+  :selection-toggle-if-not #'majutsu-restore-interactive-selection-available-p
   :shortarg "-c"
   :argument "--changes-in="
   :reader #'majutsu-transient-read-revset)
@@ -234,7 +302,7 @@ In diff buffer on a file section, restore only that file."
     (majutsu-interactive:select-file)
     (majutsu-interactive:select-region)
     ("C" "Clear patch selections" majutsu-interactive-clear :transient t)]
-   ["Paths" :if-not majutsu-interactive-selection-available-p
+   ["Paths" :if-not majutsu-restore-interactive-selection-available-p
     (majutsu-restore:--)]
    ["Options"
     ("-i" "Interactive" ("-i" "--interactive"))
@@ -254,7 +322,9 @@ In diff buffer on a file section, restore only that file."
     (transient-setup
      'majutsu-restore nil nil
      :scope (majutsu-selection-session-begin)
-     :value value)))
+     :value value)
+    (when majutsu-restore--unsafe-diff-context
+      (message "%s" majutsu-restore--unsafe-diff-context))))
 
 ;;; _
 (provide 'majutsu-restore)

--- a/majutsu-split.el
+++ b/majutsu-split.el
@@ -19,44 +19,61 @@
 (require 'majutsu)
 (require 'majutsu-diff-editor)
 
-(defun majutsu-split--diff-source-revision (&optional buffer)
-  "Return the single Split source represented by diff BUFFER.
-Return the resolved change ID only when the displayed diff represents exactly
-one change."
+(defvar-local majutsu-split--patch-source-cache-key :uncomputed
+  "Diff range and rendered-text tick for the cached split source.")
+
+(defvar-local majutsu-split--patch-source-cache-value nil
+  "Cached canonical commit ID for the rendered split source.")
+
+(defun majutsu-split--diff-source-revset ()
+  "Return the safe single-source revset described by the current diff.
+The default diff range denotes @.  Explicit ranges must use exactly one
+-r/--revisions option; arbitrary from/to ranges are never split sources."
+  (let* ((range majutsu-buffer-diff-range)
+         (from (majutsu-jj-option-values range "--from" "-f"))
+         (to (majutsu-jj-option-values range "--to" "-t"))
+         (revisions (majutsu-jj-option-values range "--revisions" "-r")))
+    (cond
+     ((or from to) nil)
+     ((null range) "@")
+     ((= (length revisions) 1) (car revisions)))))
+
+(defun majutsu-split--patch-source-commit (&optional buffer)
+  "Return BUFFER's canonical commit ID when it is safe for patch split."
   (with-current-buffer (or buffer (current-buffer))
     (when (derived-mode-p 'majutsu-diff-mode)
-      (plist-get (majutsu-diff--revision-metadata) :change-id))))
-
-(defun majutsu-split--default-args ()
-  "Return a safe Split default from the current diff context."
-  (when-let* ((revision (majutsu-split--diff-source-revision)))
-    (list (concat "--revision=" revision))))
+      (let* ((range (copy-tree majutsu-buffer-diff-range))
+             (cache-key (list range (buffer-chars-modified-tick))))
+        (unless (equal cache-key majutsu-split--patch-source-cache-key)
+          (setq-local majutsu-split--patch-source-cache-key cache-key)
+          (setq-local majutsu-split--patch-source-cache-value
+                      (when-let* ((revset (majutsu-split--diff-source-revset)))
+                        (majutsu-jj-resolve-single-commit revset))))
+        majutsu-split--patch-source-cache-value))))
 
 (defun majutsu-split-interactive-selection-available-p ()
-  "Return non-nil when the current diff can safely drive a patch Split."
+  "Return non-nil when split patch selection is safe in the current diff."
   (and (majutsu-interactive-selection-available-p)
-       (majutsu-split--diff-source-revision)))
+       (majutsu-split--patch-source-commit)))
 
 (defun majutsu-split--check-patch-source (args patch-source)
-  "Signal if ARGS select a revision incompatible with PATCH-SOURCE."
+  "Signal when ARGS would split a commit other than PATCH-SOURCE."
   (unless patch-source
-    (user-error "Patch selection for split requires a single-revision diff"))
-  (when-let* ((revision (transient-arg-value "--revision=" args)))
-    (unless (equal revision patch-source)
-      (user-error "Patch selection for split requires the diff source"))))
+    (user-error "Patch selection for split requires a diff for exactly one commit"))
+  (let ((revisions (majutsu-jj-option-values args "--revision" "-r")))
+    (unless (<= (length revisions) 1)
+      (user-error "Patch selection for split requires exactly one revision"))
+    (let ((source (majutsu-jj-resolve-single-commit
+                   (if revisions (car revisions) "@"))))
+      (unless (and source (equal source patch-source))
+        (user-error "Patch selection for split requires the rendered diff source")))))
 
-(defun majutsu-split--remove-interactive-tool-args (args)
-  "Return ARGS without native interactive-editor or tool arguments."
-  (let (result)
-    (while args
-      (let ((arg (pop args)))
-        (cond
-         ((member arg '("-i" "--interactive")) nil)
-         ((member arg '("-t" "--tool")) (pop args))
-         ((or (string-prefix-p "--tool=" arg)
-              (string-prefix-p "-t=" arg)) nil)
-         (t (push arg result)))))
-    (nreverse result)))
+(defun majutsu-split--default-args ()
+  "Return a resolved single-revision default from the diff buffer context."
+  (when (derived-mode-p 'majutsu-diff-mode)
+    (when-let* ((range majutsu-buffer-diff-range)
+                (commit (majutsu-split--patch-source-commit)))
+      (list (concat "--revision=" commit)))))
 
 (transient-define-suffix majutsu-split-execute (args)
   "Execute split with selections recorded in the transient."
@@ -73,10 +90,14 @@ one change."
       (let* (;; Text hunks and hunkless files coexist in one operation.
              (plan (majutsu-interactive-build-replay-plan-if-selected
                     nil nil 'majutsu-split))
-             (patch-source
-              (and plan (majutsu-split--diff-source-revision))))
+             (patch-source (and plan
+                                (majutsu-split--patch-source-commit))))
         (when plan
-          (majutsu-split--check-patch-source args patch-source))
+          (majutsu-split--check-patch-source args patch-source)
+          ;; Execute against the immutable commit which was just validated;
+          ;; a dynamic @/bookmark must not move between the guard and jj.
+          (setq args (majutsu-jj-set-option-value
+                      args "--revision" patch-source "-r")))
         (cond
          (plan
           ;; Reset to the left tree, then replay precisely the selections.
@@ -86,7 +107,7 @@ one change."
            filesets plan))
          ;; `jj split' selects interactively by default when no fileset is given.
          ((null filesets)
-          (majutsu-diff-editor-start
+         (majutsu-diff-editor-start
            "split" args filesets :origin-buffer (current-buffer)))
          (t
           (majutsu-run-jj-with-editor

--- a/majutsu-squash.el
+++ b/majutsu-squash.el
@@ -26,21 +26,7 @@
 
 (defun majutsu-squash--source-values (args)
   "Return --from values in ARGS."
-  (majutsu-jj-option-values args "--from"))
-
-(defun majutsu-squash--remove-interactive-tool-args (args)
-  "Remove native interactive/tool arguments from ARGS."
-  (let (out)
-    (while args
-      (let ((arg (pop args)))
-        (cond
-         ((member arg '("-i" "--interactive")))
-         ((transient-arg-value "--tool=" (list arg)))
-         ((equal arg "--tool")
-          (when args (pop args)))
-         (t
-          (push arg out)))))
-    (nreverse out)))
+  (majutsu-jj-option-values args "--from" "-f"))
 
 (defun majutsu-squash--source-revset (sources)
   "Return a revset union expression for SOURCES."
@@ -66,8 +52,8 @@ The resulting revset is intentionally left for jj to resolve."
 (defun majutsu-squash--diff-default-args ()
   "Return default squash args from a diff buffer context."
   (let* ((range majutsu-buffer-diff-range)
-         (from (majutsu-jj-option-values range "--from"))
-         (to (majutsu-jj-option-values range "--to"))
+         (from (majutsu-jj-option-values range "--from" "-f"))
+         (to (majutsu-jj-option-values range "--to" "-t"))
          (revisions
           (majutsu-jj-option-values range "--revisions" "-r")))
     (cond
@@ -101,10 +87,10 @@ return the same context defaults that execution would use."
   "Diff range and rendered-text tick for the cached patch source.")
 
 (defvar-local majutsu-squash--patch-source-cache-value nil
-  "Cached safe source revset for the current diff range.")
+  "Cached canonical commit ID for the current diff range.")
 
 (defun majutsu-squash--patch-source-revset (&optional buffer)
-  "Return a source revset when BUFFER is a safe squash patch-selection buffer."
+  "Return the canonical source commit for a safe patch-selection BUFFER."
   (with-current-buffer (or buffer (current-buffer))
     (when (derived-mode-p 'majutsu-diff-mode)
       (let* ((range (copy-tree majutsu-buffer-diff-range))
@@ -116,17 +102,17 @@ return the same context defaults that execution would use."
         (unless (equal cache-key majutsu-squash--patch-source-cache-key)
           (setq-local majutsu-squash--patch-source-cache-key cache-key)
           (setq-local majutsu-squash--patch-source-cache-value
-                      (let* ((from (majutsu-jj-option-values range "--from"))
-                             (to (majutsu-jj-option-values range "--to"))
+                      (let* ((from (majutsu-jj-option-values range "--from" "-f"))
+                             (to (majutsu-jj-option-values range "--to" "-t"))
                              (revisions (majutsu-jj-option-values
                                          range "--revisions" "-r")))
                         (cond
                          ((or from to) nil)
-                         ((null range) "@")
-                         ((and (= (length revisions) 1)
-                               (majutsu-jj-resolve-single-commit
-                                (car revisions)))
-                          (car revisions))))))
+                         ((null range)
+                          (majutsu-jj-resolve-single-commit "@"))
+                         ((= (length revisions) 1)
+                          (majutsu-jj-resolve-single-commit
+                           (car revisions)))))))
         majutsu-squash--patch-source-cache-value))))
 
 (defun majutsu-squash-interactive-selection-available-p ()
@@ -139,10 +125,11 @@ return the same context defaults that execution would use."
   (let ((sources (majutsu-squash--source-values args)))
     (unless patch-source
       (user-error "Patch selection for squash requires a diff for exactly one commit"))
-    (unless (or (null sources)
-                (and (= (length sources) 1)
-                     (equal (car sources) patch-source)))
-      (user-error "Patch selection for squash requires the diff source"))))
+    (when sources
+      (let ((source (majutsu-jj-resolve-single-commit
+                     (majutsu-squash--source-revset sources))))
+        (unless (and source (equal source patch-source))
+          (user-error "Patch selection for squash requires the diff source"))))))
 
 ;;; Execution
 
@@ -159,9 +146,8 @@ return the same context defaults that execution would use."
            (plan (and (not jj-editor-p)
                       (majutsu-interactive-build-replay-plan-if-selected
                        nil nil 'majutsu-squash)))
-           (patch-source (and plan (majutsu-squash--patch-source-revset))))
-      (when (and plan (not jj-editor-p))
-        (majutsu-squash--check-patch-source args patch-source))
+           (patch-source (and plan (majutsu-squash--patch-source-revset)))
+           inferred-destination)
       (let* ((explicit-sources (majutsu-squash--source-values args))
              (explicit-destination
               (seq-some (lambda (arg) (transient-arg-value arg args))
@@ -174,13 +160,26 @@ return the same context defaults that execution would use."
         (let ((sources (majutsu-squash--source-values args)))
           (unless (or explicit-destination
                       (majutsu-squash--none-source-p sources))
-            (setq args (append
-                        args
-                        (list (concat
-                               "--into="
-                               (majutsu-squash--destination-revset
-                                (majutsu-squash--source-revset sources)
-                                explicit-sources))))))))
+            (setq inferred-destination
+                  (majutsu-squash--destination-revset
+                   (majutsu-squash--source-revset sources)
+                   explicit-sources))
+            (setq args (append args
+                               (list (concat "--into="
+                                             inferred-destination)))))))
+      ;; Validate after adding the diff-context default.  This both preserves
+      ;; that source when a destination is explicit and detects a dynamic
+      ;; revset that moved since the diff was rendered.
+      (when (and plan (not jj-editor-p))
+        (majutsu-squash--check-patch-source args patch-source)
+        (setq args (majutsu-jj-set-option-value
+                    args "--from" patch-source "-f"))
+        (when inferred-destination
+          (if-let* ((destination
+                     (majutsu-jj-resolve-single-commit inferred-destination)))
+              (setq args (majutsu-jj-set-option-value
+                          args "--into" destination "-t"))
+            (user-error "Patch squash destination must resolve to one commit"))))
       (cond
        ;; Do not replace a user's configured jj editor with Majutsu's patch
        ;; tool.  The selection remains available after the session starts.

--- a/test/majutsu-ediff-test.el
+++ b/test/majutsu-ediff-test.el
@@ -10,6 +10,7 @@
 
 (require 'ert)
 (require 'cl-lib)
+(require 'majutsu-jj-integration)
 
 (defconst majutsu-ediff-test--root
   (file-name-directory
@@ -45,10 +46,28 @@
     (should (equal (cdr result) "@"))))
 
 (ert-deftest majutsu-ediff-test-parse-diff-range-to-only ()
-  "Test parsing --to only."
+  "A lone --to defaults the source revision to @."
   (let ((result (majutsu-jj--parse-diff-range '("--to=bar"))))
     (should (equal (car result) "@"))
     (should (equal (cdr result) "bar"))))
+
+(ert-deftest majutsu-ediff/integration-to-only-range-matches-jj ()
+  "Match jj's working-copy default for an omitted --from."
+  (majutsu-jj-integration-with-repo repo
+    (let ((file (majutsu-jj-integration-file repo "file.txt")))
+      (majutsu-jj-integration-write-text file "base\n")
+      (majutsu-jj-integration-commit repo "base")
+      (majutsu-jj-integration-write-text file "working\n")
+      (let* ((range (majutsu-jj--parse-diff-range '("--to=@-")))
+             (implicit (majutsu-jj-integration-output
+                        repo "diff" "--git" "--to=@-"))
+             (explicit (majutsu-jj-integration-output
+                        repo "diff" "--git"
+                        (concat "--from=" (car range))
+                        (concat "--to=" (cdr range)))))
+        (should (equal range '("@" . "@-")))
+        (should (> (length implicit) 0))
+        (should (equal explicit implicit))))))
 
 (ert-deftest majutsu-ediff-test-parse-diff-range-nil ()
   "Test parsing nil range."

--- a/test/majutsu-interactive-test.el
+++ b/test/majutsu-interactive-test.el
@@ -12,6 +12,13 @@
 
 (require 'ert)
 (require 'majutsu-interactive)
+
+(defun majutsu-interactive-test--overlay-face-p (face)
+  "Return non-nil when a selection overlay uses FACE."
+  (seq-some (lambda (overlay)
+              (eq (overlay-get overlay 'face) face))
+            majutsu-interactive--overlays))
+
 (require 'majutsu-jj-integration)
 
 (defun majutsu-interactive-test--insert-diff (diff &optional file metadata)
@@ -160,26 +167,33 @@ COMMAND identifies the transient whose whole-file selections are toggled."
 (ert-deftest majutsu-interactive-complete-patch-operation/retains-cancelled-selection ()
   "Only a changed or unknown repository operation invalidates a patch selection."
   (with-temp-buffer
+    (majutsu-diff-mode)
     (let ((table (make-hash-table :test 'equal))
           ids refreshed)
       (puthash 'hunk :all table)
       (setq-local majutsu-interactive--selections table)
-      (cl-letf (((symbol-function 'majutsu-interactive--operation-id)
+      (cl-letf (((symbol-function 'majutsu-jj-operation-id)
                  (lambda (&rest _)
                    (pop ids)))
                 ((symbol-function 'majutsu--toplevel-safe)
                  (lambda (&optional _directory) default-directory))
+                ((symbol-function 'majutsu-mode-get-buffers)
+                 (lambda (_root) (list (current-buffer))))
                 ((symbol-function 'majutsu-refresh)
                  (lambda () (setq refreshed (1+ (or refreshed 0)))))
                 ((symbol-function 'message) (lambda (&rest _) nil)))
         (setq ids '("before"))
-        (majutsu-interactive--complete-patch-operation (current-buffer) "before")
+        (majutsu-interactive--complete-patch-operation
+         (current-buffer) default-directory "before" 0)
         (should (eq (gethash 'hunk table) :all))
         (should-not refreshed)
         (setq ids '("after"))
-        (majutsu-interactive--complete-patch-operation (current-buffer) "before")
+        (majutsu-interactive--complete-patch-operation
+         (current-buffer) default-directory "before" 0)
         (should-not majutsu-interactive--selections)
         (should (= refreshed 1))))))
+
+
 
 (ert-deftest majutsu-interactive-run-replay-plan/inserts-tool-before-filesets ()
   "Replay plan should keep jj options before filesets."
@@ -189,6 +203,10 @@ COMMAND identifies the transient whose whole-file selections are toggled."
               ((symbol-function 'majutsu-interactive--build-tool-config)
                (lambda (_patch-file _plan _directory)
                  '("--config" "merge-tools.majutsu-applypatch.program=/tmp/applypatch")))
+              ((symbol-function 'majutsu-jj-operation-id)
+               (lambda (&rest _) "op-before"))
+              ((symbol-function 'majutsu-process-completion-owned-p)
+               (lambda (&rest _) t))
               ((symbol-function 'majutsu-start-jj-with-editor)
                (lambda (&rest args)
                  (setq called args))))
@@ -212,6 +230,10 @@ COMMAND identifies the transient whose whole-file selections are toggled."
               ((symbol-function 'majutsu-interactive--build-tool-config)
                (lambda (_patch-file _plan _directory)
                  '("--config" "tool=config")))
+              ((symbol-function 'majutsu-jj-operation-id)
+               (lambda (&rest _) "op-before"))
+              ((symbol-function 'majutsu-process-completion-owned-p)
+               (lambda (&rest _) t))
               ((symbol-function 'majutsu-start-jj-with-editor)
                (lambda (&rest args)
                  (setq called args))))
@@ -276,6 +298,10 @@ COMMAND identifies the transient whose whole-file selections are toggled."
                (lambda (_patch _plan _directory)
                  (push _directory configs)
                  nil))
+              ((symbol-function 'majutsu-jj-operation-id)
+               (lambda (&rest _) "op-before"))
+              ((symbol-function 'majutsu-process-completion-owned-p)
+               (lambda (&rest _) t))
               ((symbol-function 'majutsu-start-jj-with-editor)
                (lambda (&rest _args) nil))
               ((symbol-function 'majutsu-interactive--delete-operation-temp-dir)
@@ -884,6 +910,230 @@ Selecting only the first added line leaves the unselected line in place."
                            (majutsu-interactive--file-change rename-section))
                           `(:action rename :source ,old :path ,new)))))))))
 
+(ert-deftest majutsu-interactive-complete-operation/quit-invalidates-conservatively ()
+  "A quit in the after-operation probe must invalidate before propagating."
+  (with-temp-buffer
+    (let ((table (make-hash-table :test 'equal)) scheduled)
+      (puthash 'hunk :all table)
+      (setq-local majutsu-interactive--selections table)
+      (cl-letf (((symbol-function 'majutsu-jj-operation-id)
+                 (lambda (&rest _) (signal 'quit nil)))
+                ((symbol-function 'majutsu-interactive-invalidate-repository)
+                 (lambda (&rest _) (majutsu-interactive-invalidate t)))
+                ((symbol-function 'run-at-time)
+                 (lambda (&rest args) (setq scheduled args))))
+        (should
+         (eq (condition-case condition
+                 (progn
+                   (majutsu-interactive-complete-repository-operation "/repo/" (current-buffer) "before")
+                   nil)
+               (quit (car condition)))
+             'quit))
+        (should-not majutsu-interactive--selections)
+        (should scheduled)))))
+(ert-deftest majutsu-interactive-complete-operation/retains-cancelled-selection ()
+  "Only a changed or unknown repository operation invalidates a patch selection."
+  (with-temp-buffer
+    (let ((table (make-hash-table :test 'equal))
+          ids refreshed)
+      (puthash 'hunk :all table)
+      (setq-local majutsu-interactive--selections table)
+      (cl-letf (((symbol-function 'majutsu-jj-operation-id)
+                 (lambda (&rest _)
+                   (pop ids)))
+                ((symbol-function 'majutsu-interactive-invalidate-repository)
+                 (lambda (&rest _) (majutsu-interactive-invalidate t)))
+                ((symbol-function 'majutsu-interactive--refresh-operation-origin)
+                 (lambda (&rest _)
+                   (setq refreshed (1+ (or refreshed 0)))))
+                ((symbol-function 'message) (lambda (&rest _) nil)))
+        (setq ids '("before"))
+        (majutsu-interactive-complete-repository-operation default-directory (current-buffer) "before")
+        (should (eq (gethash 'hunk table) :all))
+        (should-not refreshed)
+        (setq ids '("after"))
+        (majutsu-interactive-complete-repository-operation default-directory (current-buffer) "before")
+        (should-not majutsu-interactive--selections)
+        (should (= refreshed 1))))))
+(ert-deftest majutsu-interactive-invalidate-repository/clears-all-diff-buffers ()
+  "A repository mutation invalidates selections outside the origin buffer."
+  (let ((one (generate-new-buffer " *majutsu-selection-one*"))
+        (two (generate-new-buffer " *majutsu-selection-two*"))
+        (other (generate-new-buffer " *majutsu-selection-other*")))
+    (unwind-protect
+        (progn
+          (dolist (entry `((,one . "/repo/") (,two . "/repo/")
+                           (,other . "/other/")))
+            (with-current-buffer (car entry)
+              (majutsu-diff-mode)
+              (setq-local majutsu--default-directory (cdr entry))
+              (setq-local majutsu-interactive--selections
+                          (let ((table (make-hash-table :test 'equal)))
+                            (puthash 'hunk :all table)
+                            table))))
+          (majutsu-interactive-invalidate-repository "/repo/")
+          (should-not (buffer-local-value
+                       'majutsu-interactive--selections one))
+          (should-not (buffer-local-value
+                       'majutsu-interactive--selections two))
+          (should (buffer-local-value
+                   'majutsu-interactive--selections other)))
+      (mapc (lambda (buffer)
+              (when (buffer-live-p buffer) (kill-buffer buffer)))
+            (list one two other)))))
+(ert-deftest majutsu-interactive-render-context/precedes-refresh-hooks ()
+  "A refresh hook operation must make the just-rendered context stale."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu--default-directory "/repo/")
+    (let ((operation "rendered")
+          snapshots
+          (transient-current-command 'majutsu-split))
+      (setq-local majutsu-refresh-buffer-hook
+                  (list (lambda () (setq operation "after-hook"))))
+      (cl-letf (((symbol-function 'majutsu--refresh-buffer-function)
+                 (lambda ()
+                   (lambda ()
+                     (let ((inhibit-read-only t))
+                       (insert "rendered diff\n")))))
+                ((symbol-function 'majutsu-interactive--repository-root)
+                 (lambda () "/repo/"))
+                ((symbol-function 'majutsu-jj-operation-id)
+                 (lambda (_root &optional snapshot)
+                   (push snapshot snapshots)
+                   operation))
+                ((symbol-function 'magit-section-update-highlight) #'ignore))
+        (majutsu-refresh-buffer-internal)
+        (should
+         (equal (majutsu-interactive-context-operation-id
+                 majutsu-interactive--render-context)
+                "rendered"))
+        (should (equal operation "after-hook"))
+        (should-error (majutsu-interactive--ensure-selection-context)
+                      :type 'user-error)
+        (should (equal (nreverse snapshots) '(nil t)))
+        (should (eq majutsu-interactive--render-context 'stale))))))
+
+(ert-deftest majutsu-interactive-selection-context/stale-diff-requires-refresh ()
+  "Clearing stale selections must not let old text acquire a fresh context."
+  (dolist (invalidate '(repository selection))
+    (with-temp-buffer
+      (majutsu-diff-mode)
+      (setq-local majutsu--default-directory "/repo/")
+      (let ((operation "before")
+            (transient-current-command 'majutsu-split))
+        (cl-letf (((symbol-function 'majutsu-interactive--repository-root)
+                   (lambda () "/repo/"))
+                  ((symbol-function 'majutsu-jj-operation-id)
+                   (lambda (&rest _) operation)))
+          (majutsu-interactive-record-render-context)
+          (setq operation "after")
+          (pcase invalidate
+            ('repository (majutsu-interactive-invalidate-repository "/repo/"))
+            ('selection
+             (should-error (majutsu-interactive--ensure-selection-context)
+                           :type 'user-error)))
+          ;; Clearing selections or retrying must not bypass the stale state.
+          (majutsu-interactive-invalidate)
+          (dotimes (_ 2)
+            (should-error (majutsu-interactive--ensure-selection-context)
+                          :type 'user-error)
+            (should-not majutsu-interactive--selection-context))
+          ;; The refresh lifecycle records a new context after rendering.
+          (majutsu-interactive-record-render-context)
+          (majutsu-interactive--ensure-selection-context)
+          (should (equal (majutsu-interactive-context-operation-id
+                          majutsu-interactive--selection-context)
+                         "after")))))))
+(ert-deftest majutsu-interactive-selection-context/rejects-operation-before-apply ()
+  "An external jj operation after selection must make the patch unusable."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu--default-directory "/repo/")
+    (let ((table (make-hash-table :test 'equal)))
+      (puthash 'hunk :all table)
+      (setq-local majutsu-interactive--selections table)
+      (setq-local majutsu-interactive--selection-operation 'majutsu-split)
+      (setq-local majutsu-interactive--selection-context
+                  (majutsu-interactive-context-create
+                   :operation 'majutsu-split :root "/repo/"
+                   :operation-id "before"
+                   :buffer-tick (buffer-chars-modified-tick)
+                   :diff-range nil :diff-filesets nil))
+      (cl-letf (((symbol-function 'majutsu-interactive--repository-root)
+                 (lambda () "/repo/"))
+                ((symbol-function 'majutsu-jj-operation-id)
+                 (lambda (&rest _) "after")))
+        (should-error
+         (majutsu-interactive-build-patch-if-selected nil nil nil 'majutsu-split)
+         :type 'user-error)
+        (should-not majutsu-interactive--selections)
+        (should-not majutsu-interactive--selection-context)))))
+(ert-deftest majutsu-interactive-selection-context/rejects-post-render-operation ()
+  "An external jj operation after render must block the first selection."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu--default-directory "/repo/")
+    (setq-local majutsu-interactive--render-context
+                (majutsu-interactive-context-create
+                 :root "/repo/" :operation-id "before"
+                 :buffer-tick (buffer-chars-modified-tick)
+                 :diff-range nil :diff-filesets nil))
+    (let ((transient-current-command 'majutsu-split))
+      (cl-letf (((symbol-function 'majutsu-interactive--repository-root)
+                 (lambda () "/repo/"))
+                ((symbol-function 'majutsu-jj-operation-id)
+                 (lambda (&rest _) "after")))
+        (should-error (majutsu-interactive--ensure-selection-context)
+                      :type 'user-error)
+        (should (eq majutsu-interactive--render-context 'stale))
+        (should-not majutsu-interactive--selection-context)))))
+(ert-deftest majutsu-interactive-toggle-hunk/applies-selected-hunk-face ()
+  "A whole-hunk selection is visibly rendered with its documented face."
+  (with-temp-buffer
+    (let* ((diff (concat "diff --git a/a.txt b/a.txt\n"
+                         "index 1111111..2222222 100644\n"
+                         "--- a/a.txt\n+++ b/a.txt\n"
+                         "@@ -1 +1,2 @@\n base\n+added\n"))
+           (file (majutsu-interactive-test--insert-diff diff "a.txt"))
+           (hunk (car (majutsu-interactive--file-section-hunks file)))
+           (transient-current-command 'majutsu-split))
+      (goto-char (oref hunk content))
+      (cl-letf (((symbol-function 'majutsu-interactive--repository-root)
+                 #'ignore))
+        (majutsu-interactive-toggle-hunk))
+      (should
+       (majutsu-interactive-test--overlay-face-p
+        'majutsu-interactive-selected-hunk)))))
+(ert-deftest majutsu-interactive-toggle-region/applies-selected-region-face ()
+  "A sub-hunk region is visibly rendered with its documented face."
+  (with-temp-buffer
+    (let* ((diff (concat "diff --git a/a.txt b/a.txt\n"
+                         "index 1111111..2222222 100644\n"
+                         "--- a/a.txt\n+++ b/a.txt\n"
+                         "@@ -1 +1,2 @@\n base\n+added\n"))
+           (file (majutsu-interactive-test--insert-diff diff "a.txt"))
+           (hunk (car (majutsu-interactive--file-section-hunks file)))
+           (beg (save-excursion
+                  (goto-char (oref hunk content))
+                  (forward-line 1)
+                  (point)))
+           (end (save-excursion
+                  (goto-char beg)
+                  (forward-line 1)
+                  (point)))
+           (transient-current-command 'majutsu-restore)
+           (transient-mark-mode t))
+      (goto-char beg)
+      (set-mark end)
+      (setq mark-active t)
+      (cl-letf (((symbol-function 'majutsu-interactive--repository-root)
+                 #'ignore))
+        (majutsu-interactive-toggle-region))
+      (should
+       (majutsu-interactive-test--overlay-face-p
+        'majutsu-interactive-selected-region)))))
+
 (defun majutsu-interactive-test--hunk-patch (diff select &optional invert)
   "Wash DIFF, then build a patch from its first hunk.
 SELECT is `:all' or a list of hunk body line texts to select."
@@ -996,6 +1246,43 @@ SELECT is `:all' or a list of hunk body line texts to select."
                              "+b\n"
                              " old\n"
                              "\\ No newline at end of file\n"))))))
+
+(ert-deftest majutsu-interactive-run-replay-plan/rejects-concurrent-replay ()
+  "A second patch replay for the same repository is refused while one runs."
+  (let (callback)
+    (cl-letf (((symbol-function 'majutsu--toplevel-safe)
+               (lambda (&optional _) "/tmp/replay-repo/"))
+              ((symbol-function 'majutsu-jj-operation-id)
+               (lambda (&rest _) "op"))
+              ((symbol-function 'majutsu-interactive--make-operation-temp-dir)
+               (lambda () "/tmp/replay-repo-tmp/"))
+              ((symbol-function 'majutsu-interactive--write-patch)
+               (lambda (&rest _) "/tmp/replay-repo-tmp/patch"))
+              ((symbol-function 'majutsu-interactive--build-tool-config)
+               (lambda (&rest _) nil))
+              ((symbol-function 'majutsu-interactive--retain-temp-dir-for-process)
+               (lambda (&rest _) t))
+              ((symbol-function 'majutsu-interactive--delete-operation-temp-dir)
+               (lambda (&rest _) nil))
+              ((symbol-function 'majutsu-start-jj-with-editor)
+               (lambda (_args _env finish &optional _keep)
+                 (setq callback finish)
+                 'fake-process))
+              ((symbol-function 'message) (lambda (&rest _) nil)))
+      (unwind-protect
+          (progn
+            (majutsu-interactive-run-replay-plan "split" nil nil '(:patch "P"))
+            (should callback)
+            (should-error
+             (majutsu-interactive-run-replay-plan "split" nil nil '(:patch "P"))
+             :type 'user-error)
+            ;; Process completion releases the guard.
+            (cl-letf (((symbol-function 'majutsu-process-completion-owned-p)
+                       (lambda (_) nil)))
+              (funcall callback 'fake-process 0))
+            (should (majutsu-interactive-run-replay-plan
+                     "split" nil nil '(:patch "P"))))
+        (majutsu-interactive--release-replay "/tmp/replay-repo/")))))
 
 (provide 'majutsu-interactive-test)
 ;;; majutsu-interactive-test.el ends here

--- a/test/majutsu-jj-test.el
+++ b/test/majutsu-jj-test.el
@@ -54,9 +54,63 @@
 (ert-deftest majutsu-jj-option-values/accepts-all-option-spellings ()
   "Parse long, separate, and short option values before a fileset separator."
   (should (equal (majutsu-jj-option-values
-                  '("--revisions=A" "-r" "B" "-rC" "--" "--revisions=D")
+                  '("--revisions=A" "-r" "B" "-rC" "-r=D"
+                    "--" "--revisions=E")
                   "--revisions" "-r")
-                 '("A" "B" "C"))))
+                 '("A" "B" "C" "D"))))
+
+(ert-deftest majutsu-jj-option-values/strips-attached-short-equals ()
+  "Treat the equals in -r=@ and -f=@ as option syntax."
+  (should (equal (majutsu-jj-option-values
+                  '("-r=@" "-r@-" "-r=" "--" "-r=ignored")
+                  "--revisions" "-r")
+                 '("@" "@-" "")))
+  (should (equal (majutsu-jj-option-values
+                  '("-f=@" "-fmain") "--from" "-f")
+                 '("@" "main"))))
+
+(ert-deftest majutsu-jj-set-option-value/replaces-spellings-before-filesets ()
+  "Canonical options replace long, short, attached, and repeated spellings."
+  (should
+   (equal (majutsu-jj-set-option-value
+           '("--message=x" "--from" "A" "-fB" "--from=C"
+             "--" "--from=fileset")
+           "--from" "commit-id" "-f")
+          '("--message=x" "--from=commit-id"
+            "--" "--from=fileset")))
+  (should
+   (equal (majutsu-jj-set-option-value
+           '("--from=A" "--to=B") "--from" nil "-f")
+          '("--to=B"))))
+
+(ert-deftest majutsu-jj-operation-id/uses-directory-and-no-snapshot-query ()
+  "Read the newest operation in the requested repository directory."
+  (let (called-directory called-args)
+    (cl-letf (((symbol-function 'majutsu-jj-string)
+               (lambda (&rest args)
+                 (setq called-directory default-directory
+                       called-args args)
+                 "operation-id")))
+      (should (equal (majutsu-jj-operation-id "/tmp/repository/")
+                     "operation-id"))
+      (should (equal called-directory "/tmp/repository/"))
+      (should (equal called-args
+                     '("--ignore-working-copy" "operation" "log"
+                       "--no-graph" "-n" "1" "-T" "id")))
+      (should (equal (majutsu-jj-operation-id "/tmp/repository/" t)
+                     "operation-id"))
+      (should (equal called-args
+                     '(nil "operation" "log"
+                       "--no-graph" "-n" "1" "-T" "id"))))))
+
+(ert-deftest majutsu-jj-operation-id/returns-nil-on-empty-or-error ()
+  "An unavailable operation ID is an unknown result, represented by nil."
+  (cl-letf (((symbol-function 'majutsu-jj-string)
+             (lambda (&rest _) "")))
+    (should-not (majutsu-jj-operation-id)))
+  (cl-letf (((symbol-function 'majutsu-jj-string)
+             (lambda (&rest _) (error "unavailable"))))
+    (should-not (majutsu-jj-operation-id))))
 
 (ert-deftest majutsu-jj-resolve-single-commit/requires-exact-cardinality ()
   "A singleton probe must not use `latest' or otherwise reduce a range."
@@ -259,10 +313,10 @@
                  1)))
       (with-temp-buffer
         (should (= 1 (majutsu-jj-wash
-                         (lambda (&rest _)
-                           (setq washed (buffer-string))
-                           (goto-char (point-max)))
-                         'wash-anyway
+                       (lambda (&rest _)
+                         (setq washed (buffer-string))
+                         (goto-char (point-max)))
+                       'wash-anyway
                        "diff")))
         (should (equal washed "diff output\n"))
         (should (string-prefix-p washed (buffer-string)))

--- a/test/majutsu-restore-test.el
+++ b/test/majutsu-restore-test.el
@@ -12,6 +12,125 @@
 (require 'cl-lib)
 (require 'majutsu-restore)
 
+(defun majutsu-restore-test--jj-call (program directory &rest args)
+  "Run PROGRAM with ARGS in DIRECTORY and return its standard output.
+Signal an ERT failure if the command exits unsuccessfully."
+  (with-temp-buffer
+    (let* ((default-directory (file-name-as-directory directory))
+           (exit (apply #'call-process
+                        program nil t nil
+                        (append '("--no-pager" "--color=never"
+                                  "--config" "user.name=\"Majutsu Test\""
+                                  "--config" "user.email=\"majutsu@example.invalid\"")
+                                args))))
+      (unless (zerop exit)
+        (ert-fail (format "jj failed (%d): %s\n%s"
+                          exit (string-join args " ") (buffer-string))))
+      (buffer-string))))
+
+(ert-deftest majutsu-restore-default-args/inherits-diff-endpoints ()
+  "Explicit diff endpoints should remain Restore endpoints in every spelling."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-range '("-f" "A" "--to=C"))
+    (cl-letf (((symbol-function 'majutsu-jj-resolve-single-commit)
+               (lambda (revset) (concat "id-" revset))))
+      (should (equal (majutsu-restore--default-args)
+                     '("--from=A" "--to=C")))
+      (should (equal (plist-get (majutsu-restore--diff-context)
+                                :patch-context)
+                     '(:endpoints "id-A" "id-C"))))))
+
+(ert-deftest majutsu-restore-default-args/maps-single-revision-to-changes-in ()
+  "A singleton revision diff should keep jj's `--changes-in' merge semantics."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-range '("--revisions=mine()"))
+    (let (called)
+      (cl-letf (((symbol-function 'majutsu-jj-resolve-single-commit)
+                 (lambda (revset)
+                   (setq called revset)
+                   "commit-id")))
+        (should (equal (majutsu-restore--default-args)
+                       '("--changes-in=commit-id")))
+        (should (equal called "mine()"))))))
+
+(ert-deftest majutsu-restore-default-args/rejects-aggregate-revision-diff ()
+  "Do not invent Restore endpoints for a revision-range diff."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-range '("--revisions=B::C"))
+    (cl-letf (((symbol-function 'majutsu-jj-resolve-single-commit)
+               (lambda (&rest _) nil)))
+      (should-not (majutsu-restore--default-args))
+      (should (string-match-p
+               "exactly one commit"
+               majutsu-restore--unsafe-diff-context)))))
+
+(ert-deftest majutsu-restore-execute/blocks-implicit-operation-for-aggregate-diff ()
+  "An aggregate diff must not silently fall back to bare `jj restore'."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-range '("--revisions=B::C"))
+    (let (called)
+      (cl-letf (((symbol-function 'majutsu-jj-resolve-single-commit)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'majutsu-run-jj)
+                 (lambda (&rest args)
+                   (setq called args)
+                   0)))
+        (should-not (majutsu-restore--default-args))
+        (should-error (majutsu-restore-execute nil) :type 'user-error)
+        (should-not called)))))
+
+(ert-deftest majutsu-restore-execute/allows-explicit-context-for-aggregate-diff ()
+  "Users can explicitly choose a Restore operation from an aggregate diff."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-range '("--revisions=B::C"))
+    (let (called)
+      (cl-letf (((symbol-function 'majutsu-jj-resolve-single-commit)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'majutsu-run-jj)
+                 (lambda (&rest args)
+                   (setq called args)
+                   0))
+                ((symbol-function 'message)
+                 (lambda (&rest _) nil)))
+        (majutsu-restore-execute '("--from=A" "--to=C"))
+        (should (equal called '("restore" "--from=A" "--to=C")))))))
+
+(ert-deftest majutsu-restore-execute/blocks-editor-with-implicit-aggregate-context ()
+  "A jj editor must not silently operate on @ from an aggregate diff."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-range '("--revisions=B::C"))
+    (let (started)
+      (cl-letf (((symbol-function 'majutsu-jj-resolve-single-commit)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'majutsu-diff-editor-start)
+                 (lambda (&rest args) (setq started args))))
+        (should-error (majutsu-restore-execute '("-i")) :type 'user-error)
+        (should-not started)))))
+
+(ert-deftest majutsu-restore-execute/allows-editor-with-explicit-aggregate-context ()
+  "A jj editor may run after the user chooses explicit Restore endpoints."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-range '("--revisions=B::C"))
+    (let (started)
+      (cl-letf (((symbol-function 'majutsu-jj-resolve-single-commit)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'majutsu-diff-editor-start)
+                 (lambda (&rest args) (setq started args))))
+        (majutsu-restore-execute '("-i" "--from=A" "--to=C"))
+        (should (equal (cl-subseq started 0 3)
+                       '("restore" ("-i" "--from=A" "--to=C") nil)))))))
+
 (ert-deftest majutsu-restore-execute/places-structured-filesets-after-options ()
   "Execute restore with transient filesets after option arguments."
   (let (called)
@@ -28,38 +147,67 @@
                      '("restore" "--from=@-" "--to=@"
                        "--" "src/a.el"))))))
 
-(ert-deftest majutsu-restore-execute/replays-complement-plan ()
-  "Restore replays the complement plan after checking the displayed selector."
-  (let (called cleared stripped)
-    (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
-               (lambda (&rest _)
-                 '(:base right :payload-root left
-                   :patch "PATCH"
-                   :file-ops ((:action add :path "keep.bin")))))
-              ((symbol-function 'majutsu-restore--patch-selector)
-               (lambda (&rest _)
-                 (list :from "@-" :to "@")))
-              ((symbol-function 'majutsu-diff-editor-strip-interactive-arguments)
-               (lambda (args)
-                 (setq stripped args)
-                 args))
-              ((symbol-function 'majutsu-interactive-run-replay-plan)
-               (lambda (&rest args)
-                 (setq called args)))
-              ((symbol-function 'majutsu-interactive-clear)
-               (lambda () (setq cleared t))))
-      (majutsu-restore-execute '(("--" "src/a.el") "--from=@-" "--to=@"))
-      (should (equal called
-                     '("restore"
-                       ("--from=@-" "--to=@")
-                       ("src/a.el")
-                       (:base right
-                        :payload-root left
-                        :patch "PATCH"
-                        :file-ops ((:action add :path "keep.bin"))))))
-      (should (equal stripped '("--from=@-" "--to=@")))
-      (should-not cleared))))
+(ert-deftest majutsu-restore-pin-patch-context/uses-canonical-commits ()
+  "Restore patch execution replaces dynamic context revsets with commit IDs."
+  (should
+   (equal (majutsu-restore--pin-patch-context
+           '("--changes-in=topic" "--restore-descendants")
+           '(:changes-in "commit-id"))
+          '("--restore-descendants" "--changes-in=commit-id")))
+  (should
+   (equal (majutsu-restore--pin-patch-context
+           '("--from=A" "--into=B" "--restore-descendants")
+           '(:endpoints "source-id" "destination-id"))
+          '("--restore-descendants"
+            "--from=source-id" "--to=destination-id"))))
 
+(ert-deftest majutsu-restore-execute/passes-patch-context-and-owner ()
+  "Keep Restore's inverse-patch flags separate from its selection owner."
+  (let (plan-args)
+    (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+               (lambda (&rest args)
+                 (setq plan-args args)
+                 '(:base right :payload-root left :patch "PATCH" :file-ops nil)))
+              ((symbol-function 'majutsu-interactive-run-replay-plan)
+               (lambda (&rest _) nil))
+              ((symbol-function 'majutsu-restore--check-patch-context)
+               (lambda (&rest _) nil)))
+      (majutsu-restore-execute '("--from=@-" "--to=@"))
+      (should (equal plan-args
+                     '(nil complement majutsu-restore))))))
+
+(ert-deftest majutsu-restore-execute/accepts-equivalent-patch-context ()
+  "Equivalent revsets may identify the same rendered Restore source."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-range '("-r" "source"))
+    (let (called)
+      (cl-letf (((symbol-function 'majutsu-jj-resolve-single-commit)
+                 (lambda (revset)
+                   (and (member revset '("source" "equivalent")) "commit")))
+                ((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+                 (lambda (&rest _) '(:base right :payload-root left :patch "PATCH" :file-ops nil)))
+                ((symbol-function 'majutsu-interactive-run-replay-plan)
+                 (lambda (&rest args) (setq called args))))
+        (majutsu-restore-execute '("--changes-in=equivalent"))
+        (should (equal called
+                       '("restore" ("--changes-in=commit") nil (:base right :payload-root left :patch "PATCH" :file-ops nil))))))))
+
+(ert-deftest majutsu-restore-execute/rejects-different-patch-context ()
+  "A patch rendered for one tree pair cannot be applied to another."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-range '("-r" "source"))
+    (cl-letf (((symbol-function 'majutsu-jj-resolve-single-commit)
+               (lambda (revset) (concat "id-" revset)))
+              ((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+               (lambda (&rest _) '(:base right :payload-root left :patch "PATCH" :file-ops nil)))
+              ((symbol-function 'majutsu-interactive-run-replay-plan)
+               (lambda (&rest _)
+                 (ert-fail "Mismatched patch context must not run"))))
+      (should-error
+       (majutsu-restore-execute '("--changes-in=other"))
+       :type 'user-error))))
 
 (ert-deftest majutsu-restore-execute/routes-jj-editor-flags-to-diff-editor ()
   "Restore routes every jj diff-editor spelling without rewriting its tool."
@@ -82,6 +230,7 @@
                                '("src/a.el")
                                :origin-buffer)))
           (should (eq (nth 4 called) origin)))))))
+
 (ert-deftest majutsu-restore-execute/explicit-jj-editor-wins-over-patch-selection ()
   "An explicit jj editor route must leave a Majutsu patch selection intact."
   (let ((origin (current-buffer)) called cleared)
@@ -102,43 +251,10 @@
                        ("src/a.el") :origin-buffer)))
       (should (eq (nth 4 called) origin))
       (should-not cleared))))
+
 (ert-deftest majutsu-restore-transient/exposes-tool-infix ()
   "Restore should expose jj's --tool option."
   (should (transient-get-suffix 'majutsu-restore "=t")))
-
-(ert-deftest majutsu-restore-execute/rejects-mismatched-selector ()
-  "Patch restore refuses when transient selectors leave the displayed diff."
-  (let (cleared)
-    (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
-               (lambda (&rest _)
-                 '(:base right :payload-root left :patch "PATCH" :file-ops nil)))
-              ((symbol-function 'majutsu-restore--patch-selector)
-               (lambda (&rest _)
-                 (list :from "@-" :to "@")))
-              ((symbol-function 'majutsu-interactive-clear)
-               (lambda () (setq cleared t))))
-      (should-error (majutsu-restore-execute '("--from=A" "--to=B"))
-                    :type 'user-error)
-      (should-not cleared))))
-
-(ert-deftest majutsu-restore-default-args/maps-revisions-to-changes-in ()
-  "Diff --revisions becomes restore --changes-in."
-  (with-temp-buffer
-    (majutsu-diff-mode)
-    (setq-local majutsu-buffer-diff-range '("--revisions=abc"))
-    (should (equal (majutsu-restore--default-args)
-                   '("--changes-in=abc")))))
-
-(ert-deftest majutsu-restore-selector/uses-transient-arg-value ()
-  "Selector projection uses transient-arg-value, not a private argv scanner."
-  (should (equal (majutsu-restore--selector '("--changes-in=abc"))
-                 '(:changes-in "abc")))
-  (should (equal (majutsu-restore--selector '("--from=A"))
-                 '(:from "A" :to "@")))
-  (should (equal (majutsu-restore--selector '("--to=B"))
-                 '(:from "@" :to "B")))
-  (should (equal (majutsu-restore--selector nil)
-                 '(:changes-in "@"))))
 
 (provide 'majutsu-restore-test)
 ;;; majutsu-restore-test.el ends here

--- a/test/majutsu-split-test.el
+++ b/test/majutsu-split-test.el
@@ -12,27 +12,6 @@
 (require 'cl-lib)
 (require 'majutsu-split)
 
-(ert-deftest majutsu-split-default-args/inherits-resolved-revision ()
-  "A diff resolving to one revision should become one Split source."
-  (with-temp-buffer
-    (majutsu-diff-mode)
-    (cl-letf (((symbol-function 'majutsu-diff--revision-metadata)
-               (lambda () '(:change-id "resolved"))))
-      (should (equal (majutsu-split--default-args)
-                     '("--revision=resolved"))))))
-
-(ert-deftest majutsu-split-default-args/rejects-incompatible-diff-ranges ()
-  "Split must not inherit diffs which do not resolve to one revision."
-  (with-temp-buffer
-    (majutsu-diff-mode)
-    (dolist (range '(("--from=A" "--to=B")
-                     ("--revisions=B::D")))
-      (setq-local majutsu-buffer-diff-range range)
-      (cl-letf (((symbol-function 'majutsu-diff--revision-metadata)
-                 (lambda () nil)))
-        (should-not (majutsu-split--default-args))
-        (should-not (majutsu-split--diff-source-revision))))))
-
 (ert-deftest majutsu-split-transient/exposes-tool-infix-under-equals-prefix ()
   "The jj tool chooser uses Magit's `=t' convention, not jj's `-t'."
   (should (transient-get-suffix 'majutsu-split "=t"))
@@ -40,6 +19,7 @@
    (condition-case nil
        (transient-get-suffix 'majutsu-split "-t")
      (error nil))))
+
 (ert-deftest majutsu-split-execute/routes-jj-editor-flags-to-diff-editor ()
   "Keep each explicit jj editor flag when routing split to its session."
   (let ((origin (current-buffer)))
@@ -61,6 +41,7 @@
                                '("src/a.el")
                                :origin-buffer)))
           (should (eq (nth 4 called) origin)))))))
+
 (ert-deftest majutsu-split-execute/routes-no-fileset-to-diff-editor ()
   "Let jj perform its default interactive split without a fileset."
   (let ((origin (current-buffer)) called)
@@ -73,6 +54,7 @@
       (should (equal (cl-subseq called 0 4)
                      '("split" ("--revision=@") nil :origin-buffer)))
       (should (eq (nth 4 called) origin)))))
+
 (ert-deftest majutsu-split-execute/explicit-jj-editor-wins-over-patch-selection ()
   "An explicit jj editor request must not consume a Majutsu patch selection."
   (let ((origin (current-buffer)) called cleared)
@@ -106,66 +88,290 @@
       (should (equal called
                      '(("split" "--revision=@" "--" "src/a.el")))))))
 
+(ert-deftest majutsu-split-default-args/resolves-single-diff-revision ()
+  "A single diff revision becomes split's resolved --revision target."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-range '("--revisions=mine()"))
+    (cl-letf (((symbol-function 'majutsu-jj-resolve-single-commit)
+               (lambda (revset)
+                 (should (equal revset "mine()"))
+                 "abc123")))
+      (should (equal (majutsu-split--default-args)
+                     '("--revision=abc123"))))))
+
+(ert-deftest majutsu-split-default-args/accepts-supported-revision-spellings ()
+  "Resolve each supported spelling, including short attached equals."
+  (dolist (range '(("--revisions" "mine()")
+                   ("-r" "mine()")
+                   ("-rmine()")
+                   ("-r=mine()")))
+    (with-temp-buffer
+      (majutsu-diff-mode)
+      (setq-local majutsu-buffer-diff-range range)
+      (cl-letf (((symbol-function 'majutsu-jj-resolve-single-commit)
+                 (lambda (revset)
+                   (should (equal revset "mine()"))
+                   "abc123")))
+        (should (equal (majutsu-split--default-args)
+                       '("--revision=abc123")))))))
+
+(ert-deftest majutsu-split-default-args/drops-arbitrary-diff-ranges ()
+  "Never pass a diff --from/--to range to jj split."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-range '("--from=A" "--to=B"))
+    (cl-letf (((symbol-function 'majutsu-jj-resolve-single-commit)
+               (lambda (&rest _)
+                 (ert-fail "Should not resolve an arbitrary diff range"))))
+      (should-not (majutsu-split--default-args)))))
+
+(ert-deftest majutsu-split-default-args/rejects-ambiguous-or-missing-revisions ()
+  "Only a resolvable singleton --revisions context can seed split."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-range
+                '("--revisions=A" "--revisions=B"))
+    (should-not (majutsu-split--default-args))
+    (setq-local majutsu-buffer-diff-range '("--revisions=A"))
+    (cl-letf (((symbol-function 'majutsu-jj-resolve-single-commit)
+               (lambda (&rest _) nil)))
+      (should-not (majutsu-split--default-args)))))
+
+(ert-deftest majutsu-split-patch-source/default-range-is-canonical-and-cached ()
+  "The default diff renders @, whose canonical ID is cached per rendering."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-range nil)
+    (let (calls)
+      (cl-letf (((symbol-function 'majutsu-jj-resolve-single-commit)
+                 (lambda (revset)
+                   (push revset calls)
+                   "commit-id")))
+        (should (equal (majutsu-split--patch-source-commit) "commit-id"))
+        (should (equal (majutsu-split--patch-source-commit) "commit-id")))
+      (should (equal calls '("@"))))))
+
+(ert-deftest majutsu-split-patch-source/rejects-unsafe-diff-ranges ()
+  "Reject from/to, repeated revisions, and a revset resolving to a range."
+  (dolist (range '(("--from=A" "--to=B")
+                   ("-f=@" "-t=@-")
+                   ("--revisions=A" "-r=B")))
+    (with-temp-buffer
+      (majutsu-diff-mode)
+      (setq-local majutsu-buffer-diff-range range)
+      (cl-letf (((symbol-function 'majutsu-jj-resolve-single-commit)
+                 (lambda (&rest _)
+                   (ert-fail "Unsafe option shape must not be resolved"))))
+        (should-not (majutsu-split--patch-source-commit)))))
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-range '("--revisions=A::B"))
+    (let (resolved)
+      (cl-letf (((symbol-function 'majutsu-jj-resolve-single-commit)
+                 (lambda (revset)
+                   (setq resolved revset)
+                   nil)))
+        (should-not (majutsu-split--patch-source-commit)))
+      (should (equal resolved "A::B")))))
+
+(ert-deftest majutsu-split-interactive-selection-available/requires-safe-source ()
+  "The transient predicate combines general diff support with source safety."
+  (cl-letf (((symbol-function 'majutsu-interactive-selection-available-p)
+             (lambda () t))
+            ((symbol-function 'majutsu-split--patch-source-commit)
+             (lambda (&rest _) "commit-id")))
+    (should (equal (majutsu-split-interactive-selection-available-p)
+                   "commit-id")))
+  (cl-letf (((symbol-function 'majutsu-interactive-selection-available-p)
+             (lambda () t))
+            ((symbol-function 'majutsu-split--patch-source-commit)
+             (lambda (&rest _) nil)))
+    (should-not (majutsu-split-interactive-selection-available-p))))
+
+(ert-deftest majutsu-split-execute/patch-rejects-different-or-unsafe-source ()
+  "The execution guard preserves a selection when its source is unsafe."
+  (let (ran)
+    (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+               (lambda (&rest _) '(:base left :payload-root right :patch "PATCH" :file-ops nil)))
+              ((symbol-function 'majutsu-split--patch-source-commit)
+               (lambda (&rest _) "rendered-id"))
+              ((symbol-function 'majutsu-jj-resolve-single-commit)
+               (lambda (&rest _) "different-id"))
+              ((symbol-function 'majutsu-interactive-run-replay-plan)
+               (lambda (&rest _) (setq ran t))))
+      (should-error (majutsu-split-execute '("--revision=other"))
+                    :type 'user-error)
+      (should-not ran)))
+  (let (ran)
+    (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+               (lambda (&rest _) '(:base left :payload-root right :patch "PATCH" :file-ops nil)))
+              ((symbol-function 'majutsu-split--patch-source-commit)
+               (lambda (&rest _) nil))
+              ((symbol-function 'majutsu-interactive-run-replay-plan)
+               (lambda (&rest _) (setq ran t))))
+      (should-error (majutsu-split-execute '("--revision=@"))
+                    :type 'user-error)
+      (should-not ran)))
+  (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+             (lambda (&rest _) '(:base left :payload-root right :patch "PATCH" :file-ops nil)))
+            ((symbol-function 'majutsu-split--patch-source-commit)
+             (lambda (&rest _) "rendered-id")))
+    (should-error
+     (majutsu-split-execute '("--revision=A" "--revision=B"))
+     :type 'user-error)))
+
 (ert-deftest majutsu-split-execute/patch-keeps-filesets-after-options ()
   "Patch split should still pass transient filesets after option arguments."
   (let (called cleared stripped)
     (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
-               (lambda (&rest _) '(:base left :payload-root right
-                                   :patch "PATCH" :file-ops nil)))
+               (lambda (&rest _) '(:base left :payload-root right :patch "PATCH" :file-ops nil)))
               ((symbol-function 'majutsu-diff-editor-strip-interactive-arguments)
                (lambda (args)
                  (setq stripped args)
                  args))
+              ((symbol-function 'majutsu-split--patch-source-commit)
+               (lambda (&rest _) "commit-id"))
+              ((symbol-function 'majutsu-jj-resolve-single-commit)
+               (lambda (&rest _) "commit-id"))
               ((symbol-function 'majutsu-interactive-run-replay-plan)
                (lambda (&rest args)
                  (setq called args)))
-              ((symbol-function 'majutsu-split--diff-source-revision)
-               (lambda (&rest _) "@"))
               ((symbol-function 'majutsu-interactive-clear)
                (lambda () (setq cleared t))))
       (majutsu-split-execute '(("--" "src/a.el") "--revision=@"))
       (should (equal called
-                     '("split" ("--revision=@") ("src/a.el")
-                       (:base left :payload-root right
-                        :patch "PATCH" :file-ops nil))))
-      (should (equal stripped '("--revision=@")))
+                     '("split" ("--revision=commit-id")
+                       ("src/a.el") (:base left :payload-root right :patch "PATCH" :file-ops nil))))
+      (should (equal stripped '("--revision=commit-id")))
       (should-not cleared))))
 
+(defun majutsu-split-test--jj-call (program directory &rest args)
+  "Run PROGRAM with ARGS in DIRECTORY and return standard output."
+  (with-temp-buffer
+    (let* ((default-directory (file-name-as-directory directory))
+           (exit (apply #'call-process
+                        program nil t nil
+                        (append '("--no-pager" "--color=never"
+                                  "--config" "user.name=Majutsu Test"
+                                  "--config" "user.email=majutsu@example.invalid")
+                                args))))
+      (unless (zerop exit)
+        (ert-fail (format "jj failed (%d): %s\n%s"
+                          exit (string-join args " ") (buffer-string))))
+      (buffer-string))))
 
-(ert-deftest majutsu-split-execute/file-op-only-forwards-filesets ()
-  "File-op-only splits use the custom tool and preserve current filesets."
-  (let ((ops '((:action delete :path "gone.bin"))) called cleared stripped)
-    (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
-               (lambda (&rest _) (list :base 'left :payload-root 'right
-                                       :patch nil :file-ops ops)))
-              ((symbol-function 'majutsu-diff-editor-strip-interactive-arguments)
-               (lambda (args)
-                 (setq stripped args)
-                 args))
-              ((symbol-function 'majutsu-interactive-run-replay-plan)
-               (lambda (&rest args) (setq called args)))
-              ((symbol-function 'majutsu-split--diff-source-revision)
-               (lambda (&rest _) "@"))
-              ((symbol-function 'majutsu-interactive-clear)
-               (lambda () (setq cleared t))))
-      (majutsu-split-execute
-       '(("--" "bin/gone.bin") "--revision=@"))
-      (should (equal called
-                     (list "split" '("--revision=@") '("bin/gone.bin")
-                           (list :base 'left :payload-root 'right
-                                 :patch nil :file-ops ops))))
-      (should (equal stripped '("--revision=@")))
-      (should-not cleared))))
-
-(ert-deftest majutsu-split-execute/patch-rejects-different-source ()
-  "Patch mode must not apply the displayed diff to another revision."
-  (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
-             (lambda (&rest _) '(:base left :payload-root right
-                                 :patch "PATCH" :file-ops nil)))
-            ((symbol-function 'majutsu-split--diff-source-revision)
-             (lambda (&rest _) "B")))
-    (should-error (majutsu-split-execute '("--revision=C"))
-                  :type 'user-error)))
+(ert-deftest majutsu-split/integration-splits-selected-added-region ()
+  "Split one selected added line from a non-working-copy source."
+  (let ((jj (or (let ((configured (getenv "MAJUTSU_TEST_JJ")))
+                  (and configured (file-executable-p configured) configured))
+                (executable-find "jj"))))
+    (skip-unless jj)
+    (let* ((parent (make-temp-file "majutsu-split-region-" t))
+           (repo (expand-file-name "repo" parent))
+           source process)
+      (unwind-protect
+          (progn
+            (majutsu-split-test--jj-call jj parent "git" "init" repo)
+            (let ((default-directory (file-name-as-directory repo)))
+              (with-temp-file (expand-file-name "notes.txt" repo)
+                (insert "base\n"))
+              (majutsu-split-test--jj-call jj repo "describe" "-m" "A")
+              (majutsu-split-test--jj-call jj repo "new" "-m" "B")
+              (with-temp-file (expand-file-name "notes.txt" repo)
+                (insert "base\nselected addition\nunselected addition\n"))
+              (setq source
+                    (string-trim
+                     (majutsu-split-test--jj-call
+                      jj repo "log" "-r" "@" "--no-graph" "-T" "change_id")))
+              ;; Render B while the working copy is its child C.  This proves
+              ;; both guards use the rendered source instead of silently
+              ;; falling back to @.
+              (majutsu-split-test--jj-call jj repo "new" "-m" "C")
+              (with-temp-buffer
+                (setq-local default-directory (file-name-as-directory repo))
+                (majutsu-diff-mode)
+                (setq-local majutsu-buffer-diff-range
+                            (list "--revisions" source))
+                (let ((inhibit-read-only t)
+                      (magit-section-inhibit-markers t))
+                  (magit-insert-section (root)
+                    (insert (majutsu-split-test--jj-call
+                             jj repo "diff" "--git" "-r" source))
+                    (save-restriction
+                      (narrow-to-region (point-min) (point-max))
+                      (majutsu-diff-wash-diffs '("--git")))))
+                (let* ((file (majutsu-interactive--file-section-for-file
+                              "notes.txt"))
+                       (hunk (car (majutsu-interactive--file-section-hunks file)))
+                       (beg (save-excursion
+                              (goto-char (oref hunk content))
+                              (forward-line 1)
+                              (point)))
+                       (end (save-excursion
+                              (goto-char beg)
+                              (forward-line 1)
+                              (point))))
+                  (should file)
+                  (should hunk)
+                  (let ((transient-current-command 'majutsu-split)
+                        (transient-mark-mode t))
+                    (goto-char beg)
+                    (set-mark end)
+                    (setq mark-active t)
+                    (majutsu-interactive-toggle-region))
+                  (should (eq majutsu-interactive--selection-operation
+                              'majutsu-split))
+                  (let ((origin (current-buffer))
+                        (majutsu-jj-executable jj)
+                        (majutsu-jj-global-arguments
+                         '("--no-pager" "--color=never"
+                           "--config" "user.name=Majutsu Test"
+                           "--config" "user.email=majutsu@example.invalid"))
+                        (majutsu-process-popup-time -1)
+                        (deadline (+ (float-time) 10)))
+                    (cl-letf (((symbol-function 'majutsu--process-display-buffer)
+                               (lambda (&rest _) nil))
+                              ((symbol-function 'majutsu-refresh)
+                               (lambda () nil))
+                              ((symbol-function 'majutsu-mode-get-buffers)
+                               (lambda (&rest _) (list origin))))
+                      (setq process
+                            (majutsu-split-execute
+                             (list (concat "--revision=" source)
+                                   "--message=selected")))
+                      (should (processp process))
+                      (while (and (process-live-p process)
+                                  (< (float-time) deadline))
+                        (accept-process-output process 0.05))
+                      (when (process-live-p process)
+                        (ignore-errors (delete-process process))
+                        (ert-fail "Timed out waiting for region split"))
+                      (unless (zerop (process-exit-status process))
+                        (ert-fail
+                         (with-current-buffer (process-buffer process)
+                           (buffer-string))))
+                      (while (and (majutsu-interactive-has-selections-p)
+                                  (< (float-time) deadline))
+                        (sit-for 0.01))
+                      (should-not
+                       (majutsu-interactive-has-selections-p)))))))
+            (should (equal (majutsu-split-test--jj-call
+                            jj repo "file" "show" "-r" source "notes.txt")
+                           "base\nselected addition\n"))
+            (should (equal (majutsu-split-test--jj-call
+                            jj repo "file" "show" "-r"
+                            (format "children(%s)" source) "notes.txt")
+                           "base\nselected addition\nunselected addition\n"))
+            (should (equal
+                     (string-trim
+                      (majutsu-split-test--jj-call
+                       jj repo "log" "-r" source "--no-graph" "-T" "description"))
+                     "selected")))
+        (when (and (processp process) (process-live-p process))
+          (ignore-errors (delete-process process)))
+        (when (file-directory-p parent)
+          (delete-directory parent t))))))
 
 (provide 'majutsu-split-test)
 ;;; majutsu-split-test.el ends here

--- a/test/majutsu-squash-test.el
+++ b/test/majutsu-squash-test.el
@@ -24,8 +24,8 @@
 (ert-deftest majutsu-squash-source-values/accepts-separate-arguments ()
   "Parse repeated --from options without consuming fileset values."
   (should (equal (majutsu-squash--source-values
-                  '("--from" "B" "--from=C" "--" "--from=D"))
-                 '("B" "C"))))
+                  '("--from" "B" "--from=C" "-f=D" "--" "--from=E"))
+                 '("B" "C" "D"))))
 
 (ert-deftest majutsu-squash-default-args/from-diff-revisions ()
   "Use diff --revisions context as default squash source."
@@ -48,10 +48,12 @@
 
 (ert-deftest majutsu-squash-default-args/does-not-inherit-diff-from-to ()
   "Do not inherit arbitrary diff --from/--to range for squash."
-  (with-temp-buffer
-    (majutsu-diff-mode)
-    (setq-local majutsu-buffer-diff-range '("--from=A" "--to=D"))
-    (should-not (majutsu-squash--default-args))))
+  (dolist (range '(("--from=A" "--to=D")
+                   ("-f=@" "-t=@-")))
+    (with-temp-buffer
+      (majutsu-diff-mode)
+      (setq-local majutsu-buffer-diff-range range)
+      (should-not (majutsu-squash--default-args)))))
 
 (ert-deftest majutsu-squash-default-args/from-log-region ()
   "Use selected log commits as default sources."
@@ -70,7 +72,8 @@
 (ert-deftest majutsu-squash-patch-source/rejects-arbitrary-from-to-diff ()
   "Squash patch selection is unavailable for arbitrary from/to diff buffers."
   (dolist (range '(("--from=A" "--to=B")
-                   ("--from" "A" "--to" "B")))
+                   ("--from" "A" "--to" "B")
+                   ("-f=@" "-t=@-")))
     (with-temp-buffer
       (majutsu-diff-mode)
       (setq-local majutsu-buffer-diff-range range)
@@ -107,7 +110,21 @@
       (cl-letf (((symbol-function 'majutsu-jj-string)
                  (lambda (&rest _) "commit-id")))
         (should (equal (majutsu-squash--patch-source-revset (current-buffer))
-                       "B"))))))
+                       "commit-id"))))))
+
+(ert-deftest majutsu-squash-patch-source/default-range-resolves-canonical-id ()
+  "The implicit @ diff source is cached as a canonical commit ID."
+  (with-temp-buffer
+    (majutsu-diff-mode)
+    (setq-local majutsu-buffer-diff-range nil)
+    (let (resolved)
+      (cl-letf (((symbol-function 'majutsu-jj-resolve-single-commit)
+                 (lambda (revset)
+                   (setq resolved revset)
+                   "commit-id")))
+        (should (equal (majutsu-squash--patch-source-revset)
+                       "commit-id")))
+      (should (equal resolved "@")))))
 
 (ert-deftest majutsu-squash-patch-source/invalidates-after-diff-refresh ()
   "A dynamic revset is checked again after the rendered diff changes."
@@ -120,7 +137,7 @@
                    (setq calls (1+ (or calls 0)))
                    result)))
         (should (equal (majutsu-squash--patch-source-revset (current-buffer))
-                       "mine()"))
+                       "commit-id"))
         (let ((inhibit-read-only t))
           (insert "refreshed"))
         (setq result nil)
@@ -135,9 +152,9 @@
     (let (applied)
       (cl-letf (((symbol-function 'majutsu-jj-string)
                  (lambda (&rest _) nil))
-                ((symbol-function 'majutsu-interactive-build-patch-if-selected)
-                 (lambda (&rest _) "PATCH"))
-                ((symbol-function 'majutsu-interactive-run-with-patch)
+                ((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+                 (lambda (&rest _) '(:base left :payload-root right :patch "PATCH" :file-ops nil)))
+                ((symbol-function 'majutsu-interactive-run-replay-plan)
                  (lambda (&rest _)
                    (setq applied t))))
         (should-error (majutsu-squash-execute nil) :type 'user-error)
@@ -234,7 +251,7 @@ Signal an ERT failure if the command exits unsuccessfully."
                        (majutsu-squash-interactive-selection-available-p))
                       (cl-letf
                           (((symbol-function
-                             'majutsu-interactive-build-patch-if-selected)
+                             'majutsu-interactive-build-replay-plan-if-selected)
                             (lambda (&rest _) nil))
                            ((symbol-function 'majutsu--process-display-buffer)
                             (lambda (&rest _) nil))
@@ -292,6 +309,119 @@ Signal an ERT failure if the command exits unsuccessfully."
         (when (file-directory-p parent)
           (delete-directory parent t))))))))
 
+(ert-deftest majutsu-squash/integration-squashes-selected-added-region ()
+  "Squash one selected added line from a non-working-copy source."
+  (let ((jj (or (let ((configured (getenv "MAJUTSU_TEST_JJ")))
+                  (and configured (file-executable-p configured) configured))
+                (executable-find "jj"))))
+    (skip-unless jj)
+    (let* ((parent (make-temp-file "majutsu-squash-region-" t))
+           (repo (expand-file-name "repo" parent))
+           source destination process)
+      (unwind-protect
+          (progn
+            (majutsu-squash-test--jj-call jj parent "git" "init" repo)
+            (let ((default-directory (file-name-as-directory repo)))
+              (with-temp-file (expand-file-name "notes.txt" repo)
+                (insert "base\n"))
+              (majutsu-squash-test--jj-call jj repo "describe" "-m" "A")
+              (setq destination
+                    (string-trim
+                     (majutsu-squash-test--jj-call
+                      jj repo "log" "-r" "@" "--no-graph" "-T" "change_id")))
+              (majutsu-squash-test--jj-call jj repo "new" "-m" "B")
+              (with-temp-file (expand-file-name "notes.txt" repo)
+                (insert "base\nselected addition\nunselected addition\n"))
+              (setq source
+                    (string-trim
+                     (majutsu-squash-test--jj-call
+                      jj repo "log" "-r" "@" "--no-graph" "-T" "change_id")))
+              ;; Keep the working copy distinct from the rendered source.  An
+              ;; explicit destination must still preserve SOURCE as --from.
+              (majutsu-squash-test--jj-call jj repo "new" "-m" "C")
+              (with-temp-buffer
+                (setq-local default-directory (file-name-as-directory repo))
+                (majutsu-diff-mode)
+                (setq-local majutsu-buffer-diff-range
+                            (list "--revisions" source))
+                (let ((inhibit-read-only t)
+                      (magit-section-inhibit-markers t))
+                  (magit-insert-section (root)
+                    (insert (majutsu-squash-test--jj-call
+                             jj repo "diff" "--git" "-r" source))
+                    (save-restriction
+                      (narrow-to-region (point-min) (point-max))
+                      (majutsu-diff-wash-diffs '("--git")))))
+                (let* ((file (majutsu-interactive--file-section-for-file
+                              "notes.txt"))
+                       (hunk (car (majutsu-interactive--file-section-hunks file)))
+                       (beg (save-excursion
+                              (goto-char (oref hunk content))
+                              (forward-line 1)
+                              (point)))
+                       (end (save-excursion
+                              (goto-char beg)
+                              (forward-line 1)
+                              (point))))
+                  (should file)
+                  (should hunk)
+                  (let ((transient-current-command 'majutsu-squash)
+                        (transient-mark-mode t))
+                    (goto-char beg)
+                    (set-mark end)
+                    (setq mark-active t)
+                    (majutsu-interactive-toggle-region))
+                  (should (eq majutsu-interactive--selection-operation
+                              'majutsu-squash))
+                  (let ((origin (current-buffer))
+                        (majutsu-jj-executable jj)
+                        (majutsu-jj-global-arguments
+                         '("--no-pager" "--color=never"
+                           "--config" "user.name=Majutsu Test"
+                           "--config" "user.email=majutsu@example.invalid"))
+                        (majutsu-process-popup-time -1)
+                        (deadline (+ (float-time) 10)))
+                    (cl-letf (((symbol-function 'majutsu--process-display-buffer)
+                               (lambda (&rest _) nil))
+                              ((symbol-function 'majutsu-refresh)
+                               (lambda () nil))
+                              ((symbol-function 'majutsu-mode-get-buffers)
+                               (lambda (&rest _) (list origin))))
+                      (setq process
+                            (majutsu-squash-execute
+                             (list (concat "--into=" destination)
+                                   "--use-destination-message")))
+                      (should (processp process))
+                      (while (and (process-live-p process)
+                                  (< (float-time) deadline))
+                        (accept-process-output process 0.05))
+                      (when (process-live-p process)
+                        (ignore-errors (delete-process process))
+                        (ert-fail "Timed out waiting for region squash"))
+                      (unless (zerop (process-exit-status process))
+                        (ert-fail
+                         (with-current-buffer (process-buffer process)
+                           (buffer-string))))
+                      ;; Completion is deferred out of the process sentinel.
+                      (while (and (majutsu-interactive-has-selections-p)
+                                  (< (float-time) deadline))
+                        (sit-for 0.01))
+                      (should-not
+                       (majutsu-interactive-has-selections-p)))))))
+            (should (equal (majutsu-squash-test--jj-call
+                            jj repo "file" "show" "-r" destination "notes.txt")
+                           "base\nselected addition\n"))
+            ;; SOURCE inherits the selected line from its rewritten parent;
+            ;; only the unselected line remains in SOURCE's own diff.
+            (let ((source-diff (majutsu-squash-test--jj-call
+                                jj repo "diff" "--git" "-r" source)))
+              (should (string-match-p "^+unselected addition$" source-diff))
+              (should-not (string-match-p "^+selected addition$" source-diff))))
+        (when (and (processp process) (process-live-p process))
+          (ignore-errors (delete-process process)))
+        (when (file-directory-p parent)
+          (delete-directory parent t))))))
+
 (ert-deftest majutsu-squash-execute/runs-jj-squash-with-inferred-destination ()
   "Execute non-patch squash through `majutsu-run-jj-with-editor'."
   (let (called)
@@ -344,7 +474,7 @@ Signal an ERT failure if the command exits unsuccessfully."
     (majutsu-diff-mode)
     (setq-local majutsu-buffer-diff-range '("--revisions=B::C"))
     (let ((origin (current-buffer)) called)
-      (cl-letf (((symbol-function 'majutsu-interactive-build-patch-if-selected)
+      (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
                  (lambda (&rest _) nil))
                 ((symbol-function 'majutsu-diff-editor-start)
                  (lambda (&rest args)
@@ -440,6 +570,7 @@ Signal an ERT failure if the command exits unsuccessfully."
                                '("src/a.el")
                                :origin-buffer)))
           (should (eq (nth 4 called) origin)))))))
+
 (ert-deftest majutsu-squash-execute/explicit-jj-editor-wins-over-patch-selection ()
   "A requested jj editor bypasses patch-source validation and keeps selection."
   (let ((origin (current-buffer)) called cleared)
@@ -465,21 +596,20 @@ Signal an ERT failure if the command exits unsuccessfully."
                        nil :origin-buffer)))
       (should (eq (nth 4 called) origin))
       (should-not cleared))))
+
 (ert-deftest majutsu-squash-transient/exposes-tool-infix ()
   "Squash should expose the jj --tool option without shadowing --into."
   (should (transient-get-suffix 'majutsu-squash "=t")))
 
-(ert-deftest majutsu-squash-execute/patch-removes-native-interactive-tool-args ()
-  "Patch mode calls the shared jj-editor argument stripper."
+(ert-deftest majutsu-squash-execute/patch-pins-inferred-source-and-destination ()
+  "Patch mode executes with the canonical source and inferred destination."
   (let (called cleared stripped)
     (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
-               (lambda (&rest _)
-                 (list :base 'left :payload-root 'right
-                       :patch "PATCH"
-                       :file-ops
-                       '((:action modify :path "image.bin")))))
+               (lambda (&rest _) '(:base left :payload-root right :patch "PATCH" :file-ops nil)))
               ((symbol-function 'majutsu-squash--patch-source-revset)
-               (lambda (&rest _) "B"))
+               (lambda (&rest _) "commit-id"))
+              ((symbol-function 'majutsu-jj-resolve-single-commit)
+               (lambda (&rest _) "commit-id"))
               ((symbol-function 'majutsu-diff-editor-strip-interactive-arguments)
                (lambda (args)
                  (setq stripped args)
@@ -494,25 +624,83 @@ Signal an ERT failure if the command exits unsuccessfully."
       (majutsu-squash-execute '("--from=B"))
       (should (equal called
                      '("squash"
-                       ("--from=B" "--into=parents(roots((B)))")
-                       nil
-                       (:base left :payload-root right
-                        :patch "PATCH"
-                        :file-ops
-                        ((:action modify :path "image.bin"))))))
+                       ("--from=commit-id" "--into=commit-id")
+                       nil (:base left :payload-root right :patch "PATCH" :file-ops nil))))
       (should (equal stripped
-                     '("--from=B" "--into=parents(roots((B)))")))
+                     '("--from=commit-id" "--into=commit-id")))
       (should-not cleared))))
 
+(ert-deftest majutsu-squash-execute/passes-patch-context-and-owner ()
+  "Pass the patch selection owner through the keyword API."
+  (let (plan-args)
+    (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+               (lambda (&rest args)
+                 (setq plan-args args)
+                 '(:base left :payload-root right :patch "PATCH" :file-ops nil)))
+              ((symbol-function 'majutsu-squash--patch-source-revset)
+               (lambda (&rest _) "commit-id"))
+              ((symbol-function 'majutsu-jj-resolve-single-commit)
+               (lambda (&rest _) "commit-id"))
+              ((symbol-function 'majutsu-interactive-run-replay-plan)
+               (lambda (&rest _) nil))
+              ((symbol-function 'majutsu-squash--point-revision)
+               (lambda () nil)))
+      (majutsu-squash-execute '("--from=B"))
+      (should (equal plan-args
+                     '(nil nil majutsu-squash))))))
+
+(ert-deftest majutsu-squash-execute/patch-allows-equivalent-source-revset ()
+  "Canonical comparison allows a revset naming the rendered source commit."
+  (let (called resolved)
+    (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+               (lambda (&rest _) '(:base left :payload-root right :patch "PATCH" :file-ops nil)))
+              ((symbol-function 'majutsu-squash--patch-source-revset)
+               (lambda (&rest _) "commit-id"))
+              ((symbol-function 'majutsu-jj-resolve-single-commit)
+               (lambda (revset)
+                 (setq resolved revset)
+                 "commit-id"))
+              ((symbol-function 'majutsu-interactive-run-replay-plan)
+               (lambda (&rest args) (setq called args))))
+      (majutsu-squash-execute
+       '("--from=bookmarks(exact:topic)" "--into=destination"))
+      (should (equal resolved "(bookmarks(exact:topic))"))
+      (should (equal called
+                     '("squash"
+                       ("--into=destination" "--from=commit-id")
+                       nil (:base left :payload-root right :patch "PATCH" :file-ops nil)))))))
+
+(ert-deftest majutsu-squash-execute/patch-keeps-diff-source-with-destination ()
+  "An explicit destination still validates and uses the rendered diff source."
+  (let (called resolved)
+    (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
+               (lambda (&rest _) '(:base left :payload-root right :patch "PATCH" :file-ops nil)))
+              ((symbol-function 'majutsu-squash--patch-source-revset)
+               (lambda (&rest _) "commit-id"))
+              ((symbol-function 'majutsu-squash--default-args)
+               (lambda () '("--from=rendered")))
+              ((symbol-function 'majutsu-jj-resolve-single-commit)
+               (lambda (revset)
+                 (setq resolved revset)
+                 "commit-id"))
+              ((symbol-function 'majutsu-interactive-run-replay-plan)
+               (lambda (&rest args) (setq called args))))
+      (majutsu-squash-execute '("--into=destination"))
+      (should (equal resolved "(rendered)"))
+      (should (equal called
+                     '("squash"
+                       ("--into=destination" "--from=commit-id")
+                       nil (:base left :payload-root right :patch "PATCH" :file-ops nil)))))))
 
 (ert-deftest majutsu-squash-execute/patch-rejects-different-source ()
   "Patch mode should not apply the current diff patch to another source."
   (let (cleared)
     (cl-letf (((symbol-function 'majutsu-interactive-build-replay-plan-if-selected)
-               (lambda (&rest _)
-                 '(:base left :payload-root right :patch "PATCH" :file-ops nil)))
+               (lambda (&rest _) '(:base left :payload-root right :patch "PATCH" :file-ops nil)))
               ((symbol-function 'majutsu-squash--patch-source-revset)
-               (lambda (&rest _) "B"))
+               (lambda (&rest _) "rendered-id"))
+              ((symbol-function 'majutsu-jj-resolve-single-commit)
+               (lambda (&rest _) "different-id"))
               ((symbol-function 'majutsu-interactive-clear)
                (lambda () (setq cleared t))))
       (should-error (majutsu-squash-execute '("--from=C")) :type 'user-error)


### PR DESCRIPTION
Track the rendered diff's repository operation and buffer generation when
selections are made.  Reject stale or cross-command selections, invalidate
all diff buffers for a root when an operation completes, and pin Restore
tree contexts to the displayed commit endpoints.  Keep whole-file replay
plans on the Majutsu patch path while routing explicit jj editors through
majutsu-diff-editor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of diff selections and repository state, preventing stale or unsafe operations.
  * Restore, split, and squash now use stable patch sources and reject ambiguous or mismatched contexts.
  * Improved option handling, revision detection, diff-range defaults, conflicted-file display, and operation completion behavior.
  * Restore preserves unrelated file changes when applying partial patches.

* **Tests**
  * Expanded coverage for selection invalidation, operation tracking, option parsing, restore safety, and split/squash workflows.
  * Added integration tests for selected-region operations and resulting repository changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->