### PR TITLE
Harden diff-editor session lifecycle.

### DIFF
--- a/docs/majutsu.org
+++ b/docs/majutsu.org
@@ -1029,7 +1029,7 @@ Transient arguments:
 - Key: -i :: Open jj's configured diff editor for partial selection.
 - Key: ~=t~ :: Choose jj's diff editor with =--tool=NAME=.
 - Key: -c :: Undo changes introduced by a revision (=--changes-in=).
-- Key: -d :: Restore descendants as well.
+- Key: -d :: Preserve descendant content while rebasing (=--restore-descendants=).
 - Key: -- :: Limit restore to selected files or filesets.
 Runs: =jj restore --from REV [FILESETS...]= or
 =jj restore --changes-in REV [FILESETS...]=
@@ -1103,10 +1103,14 @@ When opening Split, Squash, or Restore from a Diff buffer, each transient maps
 the compatible part of the diff context to its own command:
 - Split inherits exactly one resolvable =--revisions= source as =--revision=; it
   never passes a diff's arbitrary =--from= / =--to= range to =jj split=.
-- Squash turns =--revisions= into =--from= sources. An arbitrary =--from= /
-  =--to= tree diff is not treated as a Squash source.
-- Restore turns =--revisions= into =--changes-in= and additionally inherits
-  =--from= / =--to= parameters.
+- Squash turns =--revisions= into =--from= sources and retains those sources
+  when you choose an explicit destination. An arbitrary =--from= / =--to= tree
+  diff is not treated as a Squash source.
+- Restore turns exactly one resolvable =--revisions= source into
+  =--changes-in= and inherits explicit =--from= / =--to= endpoints. An
+  aggregate revision diff is not inferred as a Restore operation; choose an
+  explicit Restore context before using either Majutsu patch selection or
+  jj's own diff editor.
 
 Use a revision diff for Split or Squash. An arbitrary =--from= / =--to= range
 is meaningful as inherited context only for Restore.
@@ -1134,29 +1138,36 @@ Squash and Restore, not a tool abbreviation.
 If an Emacs patch selection is active and you explicitly request a jj editor,
 the jj editor wins and the Emacs selection is retained.  With no explicit jj
 editor flag, =RET= applies the active Majutsu patch selection as before.  A
-selection is retained when an editor is cancelled or fails, and is cleared
-before a successful repository refresh so raw buffer positions cannot apply to
-a different diff.
+selection is retained when an editor ends without changing the repository,
+including an unchanged failure.  Each selection is bound to the operation id,
+source context, and generation of the rendered diff.  A changed or unverifiable
+repository state invalidates selections in every diff buffer for that
+workspace before refresh, so raw positions cannot be applied to another tree.
+Patch execution also replaces validated dynamic source/default revsets with
+their canonical commit ids before jj starts, closing the gap between validation
+and command execution.
 
 The default jj editor, =:builtin=, is a terminal TUI.  Customize
 =majutsu-diff-editor-host= to choose how Majutsu hosts it:
 
-- =auto= (the default) uses Ghostel when available.  Local sessions also need
-  a working =emacsclient=; Ghostel-supported TRAMP sessions use with-editor's
-  remote sleeping-editor bridge instead.
+- =auto= (the default) uses Ghostel when available.  Local commands which may
+  open a later description editor also need a working =emacsclient=; Restore
+  does not.  Ghostel-supported TRAMP sessions use with-editor's remote
+  sleeping-editor bridge instead.
 - =ghostel= requires Ghostel and supports jj's built-in TUI and external
   terminal editors.
 - =process= is for external non-terminal tools only; Majutsu rejects
   =:builtin= rather than trying to render it in a process buffer.
 
-Ghostel is optional.  A local Ghostel session requires a working
-=emacsclient= for jj's later description-editor invocation.  On a
-Ghostel-supported POSIX TRAMP remote, Ghostel starts a remote PTY and
-with-editor uses its sleeping-editor protocol, so no local =emacsclient= is
-needed.  Majutsu associates jj's remote temporary description file with its
-repository before it is visited, keeping description-buffer commands in the
-right repository.  A =WITH-EDITOR= control line may remain visible in the
-Ghostel transcript.
+Ghostel is optional.  A local Split or Squash session needs a working
+=emacsclient= only when its arguments can lead to a description editor;
+explicit message options avoid that phase unless =--editor= is also set.
+Restore has no description-editing phase.  On a Ghostel-supported POSIX TRAMP
+remote, Ghostel starts a remote PTY and with-editor uses its sleeping-editor
+protocol, so no local =emacsclient= is needed.  Majutsu associates jj's remote
+temporary description file with its workspace before it is visited, keeping
+description-buffer commands in the right workspace.  A =WITH-EDITOR= control
+line may remain visible in the Ghostel transcript.
 
 Ghostel's remote PTY path needs a POSIX remote reachable by a supported TRAMP
 method; Windows remotes are not supported.  The ordinary external-editor

--- a/docs/majutsu.texi
+++ b/docs/majutsu.texi
@@ -1888,7 +1888,7 @@ Choose jj's diff editor with @samp{--tool=NAME}.
 Undo changes introduced by a revision (@samp{--changes-in}).
 @item @kbd{-d}
 @kindex -d
-Restore descendants as well.
+Preserve descendant content while rebasing (@samp{--restore-descendants}).
 @item @kbd{--}
 @kindex --
 Limit restore to selected files or filesets.
@@ -2038,11 +2038,15 @@ the compatible part of the diff context to its own command:
 Split inherits exactly one resolvable @samp{--revisions} source as @samp{--revision}; it
 never passes a diff's arbitrary @samp{--from} / @samp{--to} range to @samp{jj split}.
 @item
-Squash turns @samp{--revisions} into @samp{--from} sources. An arbitrary @samp{--from} /
-@samp{--to} tree diff is not treated as a Squash source.
+Squash turns @samp{--revisions} into @samp{--from} sources and retains those sources
+when you choose an explicit destination. An arbitrary @samp{--from} / @samp{--to} tree
+diff is not treated as a Squash source.
 @item
-Restore turns @samp{--revisions} into @samp{--changes-in} and additionally inherits
-@samp{--from} / @samp{--to} parameters.
+Restore turns exactly one resolvable @samp{--revisions} source into
+@samp{--changes-in} and inherits explicit @samp{--from} / @samp{--to} endpoints. An
+aggregate revision diff is not inferred as a Restore operation; choose an
+explicit Restore context before using either Majutsu patch selection or
+jj's own diff editor.
 @end itemize
 
 Use a revision diff for Split or Squash. An arbitrary @samp{--from} / @samp{--to} range
@@ -2081,18 +2085,24 @@ Squash and Restore@comma{} not a tool abbreviation.
 If an Emacs patch selection is active and you explicitly request a jj editor@comma{}
 the jj editor wins and the Emacs selection is retained.  With no explicit jj
 editor flag@comma{} @samp{RET} applies the active Majutsu patch selection as before.  A
-selection is retained when an editor is cancelled or fails@comma{} and is cleared
-before a successful repository refresh so raw buffer positions cannot apply to
-a different diff.
+selection is retained when an editor ends without changing the repository@comma{}
+including an unchanged failure.  Each selection is bound to the operation id@comma{}
+source context@comma{} and generation of the rendered diff.  A changed or unverifiable
+repository state invalidates selections in every diff buffer for that
+workspace before refresh@comma{} so raw positions cannot be applied to another tree.
+Patch execution also replaces validated dynamic source/default revsets with
+their canonical commit ids before jj starts@comma{} closing the gap between validation
+and command execution.
 
 The default jj editor@comma{} @samp{:builtin}@comma{} is a terminal TUI@.  Customize
 @samp{majutsu-diff-editor-host} to choose how Majutsu hosts it:
 
 @itemize
 @item
-@samp{auto} (the default) uses Ghostel when available.  Local sessions also need
-a working @samp{emacsclient}; Ghostel-supported TRAMP sessions use with-editor's
-remote sleeping-editor bridge instead.
+@samp{auto} (the default) uses Ghostel when available.  Local commands which may
+open a later description editor also need a working @samp{emacsclient}; Restore
+does not.  Ghostel-supported TRAMP sessions use with-editor's remote
+sleeping-editor bridge instead.
 @item
 @samp{ghostel} requires Ghostel and supports jj's built-in TUI and external
 terminal editors.
@@ -2101,14 +2111,15 @@ terminal editors.
 @samp{:builtin} rather than trying to render it in a process buffer.
 @end itemize
 
-Ghostel is optional.  A local Ghostel session requires a working
-@samp{emacsclient} for jj's later description-editor invocation.  On a
-Ghostel-supported POSIX TRAMP remote@comma{} Ghostel starts a remote PTY and
-with-editor uses its sleeping-editor protocol@comma{} so no local @samp{emacsclient} is
-needed.  Majutsu associates jj's remote temporary description file with its
-repository before it is visited@comma{} keeping description-buffer commands in the
-right repository.  A @samp{WITH-EDITOR} control line may remain visible in the
-Ghostel transcript.
+Ghostel is optional.  A local Split or Squash session needs a working
+@samp{emacsclient} only when its arguments can lead to a description editor;
+explicit message options avoid that phase unless @samp{--editor} is also set.
+Restore has no description-editing phase.  On a Ghostel-supported POSIX TRAMP
+remote@comma{} Ghostel starts a remote PTY and with-editor uses its sleeping-editor
+protocol@comma{} so no local @samp{emacsclient} is needed.  Majutsu associates jj's remote
+temporary description file with its workspace before it is visited@comma{} keeping
+description-buffer commands in the right workspace.  A @samp{WITH-EDITOR} control
+line may remain visible in the Ghostel transcript.
 
 Ghostel's remote PTY path needs a POSIX remote reachable by a supported TRAMP
 method; Windows remotes are not supported.  The ordinary external-editor

--- a/majutsu-diff-editor.el
+++ b/majutsu-diff-editor.el
@@ -24,8 +24,14 @@
 (declare-function ghostel-mode "ghostel" ())
 (declare-function majutsu-start-jj-with-editor "majutsu-process"
                   (args &optional success-msg finish-callback inhibit-refresh))
+(declare-function majutsu-process-completion-owned-p "majutsu-process"
+                  (process))
 (declare-function majutsu-process-track-with-editor-output "majutsu-process"
                   (process output))
+(declare-function majutsu-interactive-complete-repository-operation
+                  "majutsu-interactive"
+                  (root origin-buffer operation-before
+                        &optional unchanged-message))
 
 (defvar ghostel-exit-functions)
 (defvar ghostel-kill-buffer-on-exit)
@@ -40,9 +46,9 @@
 (defcustom majutsu-diff-editor-host 'auto
   "How Majutsu hosts jj diff-editor sessions.
 
-`auto' uses Ghostel when it is available.  Local sessions also need a
-working `emacsclient' for jj's later description-editor invocation;
-remote Ghostel sessions use with-editor's TRAMP sleeping-editor bridge.
+`auto' uses Ghostel when it is available.  Local commands which can later
+invoke jj's description editor also need a working `emacsclient'; remote
+Ghostel sessions use with-editor's TRAMP sleeping-editor bridge.
 Without a suitable terminal host, `auto' permits an ordinary process only
 for a known external editor.  `ghostel' requires Ghostel.  `process' always
 uses an ordinary process, which cannot host jj's built-in terminal editor."
@@ -62,6 +68,11 @@ uses an ordinary process, which cannot host jj's built-in terminal editor."
   "Return non-nil when ARG is a supported explicit tool option."
   (or (equal arg "--tool")
       (majutsu-diff-editor--inline-tool-value arg)))
+
+(defun majutsu-diff-editor--tool-value-token-p (arg)
+  "Return non-nil when ARG can be the value following `--tool'."
+  (and (stringp arg)
+       (not (string-prefix-p "-" arg))))
 
 (defun majutsu-diff-editor-interactive-arguments-p (args)
   "Return non-nil when ARGS request jj's diff-editor.
@@ -93,8 +104,9 @@ Remove `-i', `--interactive', `--tool VALUE', and `--tool=VALUE' before
           (push arg result))
          ((member arg '("-i" "--interactive")))
          ((equal arg "--tool")
-          ;; Do not swallow the fileset separator when the option is malformed.
-          (when (and args (not (equal (car args) "--")))
+          ;; Do not swallow another option when the tool value is malformed.
+          (when (and args
+                     (majutsu-diff-editor--tool-value-token-p (car args)))
             (pop args)))
          ((majutsu-diff-editor--inline-tool-value arg))
          (t
@@ -113,7 +125,8 @@ Ignore tokens after `--'."
          ((equal arg "--")
           (setq filesets t))
          ((equal arg "--tool")
-          (when (and args (not (equal (car args) "--")))
+          (when (and args
+                     (majutsu-diff-editor--tool-value-token-p (car args)))
             (setq tool (pop args))))
          ((let ((value (majutsu-diff-editor--inline-tool-value arg)))
             (when value
@@ -130,7 +143,8 @@ Ignore tokens after `--'."
          ((equal arg "--")
           (setq filesets t))
          ((equal arg "--tool")
-          (if (and args (not (equal (car args) "--")))
+          (if (and args
+                   (majutsu-diff-editor--tool-value-token-p (car args)))
               (pop args)
             (setq missing t)))
          ((let ((value (majutsu-diff-editor--inline-tool-value arg)))
@@ -197,6 +211,44 @@ has jj's documented `:builtin' default."
   "Return non-nil when TOOL is jj's built-in terminal editor."
   (equal tool ":builtin"))
 
+(defun majutsu-diff-editor--argument-present-p (args options)
+  "Return non-nil when ARGS contain a member of OPTIONS before `--'."
+  (catch 'present
+    (dolist (arg args)
+      (when (equal arg "--")
+        (throw 'present nil))
+      (when (member arg options)
+        (throw 'present t)))
+    nil))
+
+(defun majutsu-diff-editor--description-editor-required-p (command args)
+  "Return non-nil when jj COMMAND with ARGS may invoke a text editor.
+
+Restore cannot edit a description.  Split with an explicit message and Squash
+with an explicit message policy avoid that phase unless `--editor' is set."
+  (let ((editor (majutsu-diff-editor--argument-present-p
+                 args '("--editor"))))
+    (pcase command
+      ("restore" nil)
+      ("split"
+       (or editor
+           (null (majutsu-jj-option-values args "--message" "-m"))))
+      ("squash"
+       (or editor
+           (not (or (majutsu-jj-option-values args "--message" "-m")
+                    (majutsu-diff-editor--argument-present-p
+                     args '("--use-destination-message" "-u"))))))
+      (_ t))))
+
+(defun majutsu-diff-editor--ghostel-editor-supported-p (command args root)
+  "Return non-nil when Ghostel can host COMMAND with ARGS under ROOT.
+
+Remote processes use with-editor's sleeping-editor bridge.  A local command
+only needs emacsclient when it can later request a description editor."
+  (or (file-remote-p root)
+      (not (majutsu-diff-editor--description-editor-required-p command args))
+      with-editor-emacsclient-executable))
+
 (defvar majutsu-diff-editor--process-fallback-noticed nil
   "Whether this Emacs session has explained the external process fallback.")
 
@@ -207,8 +259,8 @@ has jj's documented `:builtin' default."
     (message (concat "Using an ordinary process for the external jj diff "
                      "editor. Terminal editors require Ghostel."))))
 
-(defun majutsu-diff-editor-select-host (args)
-  "Return the host symbol to use for a jj diff-editor session with ARGS.
+(defun majutsu-diff-editor-select-host (command args)
+  "Return the host symbol for jj COMMAND's diff-editor session with ARGS.
 
 Signal `user-error' rather than starting a terminal editor in a pipe.
 The return value is either `ghostel' or `process'."
@@ -228,17 +280,24 @@ The return value is either `ghostel' or `process'."
         ;; handler.  with-editor observes that path and installs its sleeping
         ;; editor filter, so unlike the local native PTY path it needs no
         ;; emacsclient.
-        ((and ghostel-p (or remote-p with-editor-emacsclient-executable))
+        ((and ghostel-p
+              (majutsu-diff-editor--ghostel-editor-supported-p
+               command args default-directory))
          'ghostel)
         ((majutsu-diff-editor--builtin-tool-p tool)
          (user-error
-          (if remote-p
-              (concat "jj's :builtin diff editor requires Ghostel for this "
-                      "TRAMP repository; install Ghostel or configure an "
-                      "external editor")
-            (concat "jj's :builtin diff editor requires Ghostel and a working "
-                    "emacsclient; configure an external editor or set "
-                    "`with-editor-emacsclient-executable'"))))
+          (cond
+           (remote-p
+            (concat "jj's :builtin diff editor requires Ghostel for this "
+                    "TRAMP repository; install Ghostel or configure an "
+                    "external editor"))
+           (ghostel-p
+            (concat "jj " command " may invoke a description editor after its "
+                    ":builtin diff editor; configure a working emacsclient or "
+                    "an external editor"))
+           (t
+            (concat "jj's :builtin diff editor requires Ghostel; install "
+                    "Ghostel or configure an external editor")))))
         (t
          (majutsu-diff-editor--note-process-fallback)
          'process))))
@@ -259,33 +318,26 @@ The return value is either `ghostel' or `process'."
   "A running jj diff-editor session."
   command args filesets origin-buffer repository-root
   host terminal-buffer process
-  operation-id-before selection-context started-at completed-p)
+  operation-id-before completed-p)
 
 (defvar-local majutsu-diff-editor--session nil
   "The `majutsu-diff-editor-session' associated with this terminal buffer.")
 
 (defvar majutsu-diff-editor--live-sessions (make-hash-table :test 'equal)
-  "Majutsu-owned diff-editor sessions indexed by repository root.")
-
-(defun majutsu-diff-editor--session-active-p (_session)
-  "Return non-nil while SESSION still owns its repository interaction slot."
-  ;; Do not use `process-live-p' here.  A child may have exited while its
-  ;; zero-delay completion timer has not yet run; releasing the slot in that
-  ;; window would allow a second history rewrite to overlap completion.
-  t)
+  "Majutsu-owned diff-editor sessions indexed by workspace root.")
 
 (defun majutsu-diff-editor--register-session (session)
-  "Reserve SESSION's repository slot, or signal if another session owns it."
+  "Reserve SESSION's workspace slot, or signal if another session owns it."
   (let* ((root (majutsu-diff-editor-session-repository-root session))
          (existing (gethash root majutsu-diff-editor--live-sessions)))
     (when existing
-      (if (majutsu-diff-editor--session-active-p existing)
-          (user-error "A jj diff-editor session is already active for this repository")
-        (remhash root majutsu-diff-editor--live-sessions)))
+      ;; Completion owns the slot even after a child exits, until its deferred
+      ;; freshness check has run and explicitly unregisters the session.
+      (user-error "A jj diff-editor session is already active for this workspace"))
     (puthash root session majutsu-diff-editor--live-sessions)))
 
 (defun majutsu-diff-editor--unregister-session (session)
-  "Release SESSION's repository slot if it is still its owner."
+  "Release SESSION's workspace slot if it is still its owner."
   (let ((root (majutsu-diff-editor-session-repository-root session)))
     (when (eq (gethash root majutsu-diff-editor--live-sessions) session)
       (remhash root majutsu-diff-editor--live-sessions))))
@@ -319,7 +371,7 @@ inner Ghostel startup cleanup and the outer session-start cleanup."
 (defun majutsu-diff-editor--abort-session-start (session)
   "Clean up SESSION after a non-local exit during startup.
 
-If a session-owned child exists, retain its repository slot until completion:
+If a session-owned child exists, retain its workspace slot until completion:
 it may have exited just before its deferred callback runs.  A child that never
 received a completion owner is stopped and treated as an unknown outcome."
   (let ((process (majutsu-diff-editor--session-lifecycle-process session)))
@@ -337,11 +389,12 @@ received a completion owner is stopped and treated as an unknown outcome."
      ;; duplicate-safe fallback only after the reaper is no longer live.
      ((eq (majutsu-diff-editor-session-host session) 'ghostel)
       (unless (and (processp process) (process-live-p process))
-        (run-at-time 0 nil #'majutsu-diff-editor--complete-session session)))
-     ;; The ordinary runner's callback is installed before its sentinel.  Keep
-     ;; its slot even after the child exits: that callback alone has the real
-     ;; exit status needed to distinguish failure from a clean editor cancel.
-     ((and (processp process) (process-get process 'finish-callback))
+        (run-at-time 0 nil #'majutsu-diff-editor--finish-ghostel-session
+                     session nil)))
+     ;; Only the process layer can publish completion ownership.  A callback
+     ;; property may already exist when filter or sentinel setup fails.
+     ((and (processp process)
+           (majutsu-process-completion-owned-p process))
       nil)
      ;; A child was created but setup was interrupted before it gained a
      ;; completion owner.  It could have mutated the repo, so make selection
@@ -351,7 +404,7 @@ received a completion owner is stopped and treated as an unknown outcome."
         (when (and (processp process) (process-live-p process))
           (ignore-errors (delete-process process)))
         (majutsu-diff-editor--cleanup-unstarted-terminal-buffer session)
-        (majutsu-diff-editor--abort-session-completion session)
+        (majutsu-diff-editor--invalidate-unowned-session session)
         (majutsu-diff-editor--unregister-session session))))))
 
 (defvar majutsu-diff-editor-session-exit-hook nil
@@ -359,28 +412,6 @@ received a completion owner is stopped and treated as an unknown outcome."
 
 Each function receives SESSION and Ghostel's EVENT string.  It runs via a
 zero-delay timer, outside Ghostel's process sentinel.")
-
-(defun majutsu-diff-editor--operation-id (root)
-  "Return ROOT's current jj operation id without snapshotting its working copy.
-
-Return nil when jj cannot provide an id.  Callers must treat that result as an
-unknown session outcome rather than as success or cancellation."
-  (condition-case nil
-      (let ((default-directory root))
-        (when-let* ((id (majutsu-jj-string
-                         "--ignore-working-copy" "operation" "log"
-                         "--no-graph" "-n" "1" "-T" "id")))
-          (unless (string-empty-p id)
-            id)))
-    (error nil)))
-
-(defun majutsu-diff-editor--invalidate-origin-selection (session)
-  "Invalidate SESSION's origin-buffer patch selection, if it is still live."
-  (when-let* ((buffer (majutsu-diff-editor-session-origin-buffer session))
-              ((buffer-live-p buffer)))
-    (with-current-buffer buffer
-      (when (fboundp 'majutsu-interactive-invalidate)
-        (majutsu-interactive-invalidate)))))
 
 (defun majutsu-diff-editor--refresh-origin (session)
   "Refresh SESSION's live origin buffer after a repository state change."
@@ -392,54 +423,31 @@ unknown session outcome rather than as success or cancellation."
         (when (derived-mode-p 'majutsu-mode)
           (majutsu-refresh))))))
 
-(defun majutsu-diff-editor--abort-session-completion (session)
-  "Conservatively invalidate SESSION when its completion is interrupted."
-  ;; A quit during the operation-id probe leaves the repository outcome
-  ;; unknown.  Never leave position-based selections usable in that state.
+(defun majutsu-diff-editor--invalidate-unowned-session (session)
+  "Conservatively invalidate SESSION after unowned process setup fails."
+  ;; A child without a completion owner may have mutated the repository.
+  ;; Invalidate every selection for its root before releasing the slot.
   (let ((inhibit-quit t))
-    (majutsu-diff-editor--invalidate-origin-selection session)
-    ;; Refresh later, outside the interrupted synchronous probe.  The origin
-    ;; may already be gone; `majutsu-diff-editor--refresh-origin' handles it.
+    (majutsu-interactive-invalidate-repository
+     (majutsu-diff-editor-session-repository-root session))
     (run-at-time 0 nil #'majutsu-diff-editor--refresh-origin session)))
 
-(defun majutsu-diff-editor--complete-session (session &optional event)
-  "Complete SESSION after EVENT, conservatively handling unknown outcomes.
+(defun majutsu-diff-editor--complete-session
+    (session &optional event unchanged-message)
+  "Complete SESSION after EVENT using repository freshness.
 
-Ghostel's lifecycle process does not expose jj's child exit status.  The
-operation id therefore determines whether rendered selections remain safe.
-For process-hosted sessions it also avoids treating a zero-status cancel as a
-successful history rewrite."
+UNCHANGED-MESSAGE is displayed by the shared completion helper only when the
+repository operation id is unchanged."
   (unless (majutsu-diff-editor-session-completed-p session)
     (setf (majutsu-diff-editor-session-completed-p session) t)
-    (let (outcome completed-normally)
-      ;; Include the operation-id probe in the protected form.  `quit' is not
-      ;; an `error', and must not leave a completed session registered forever.
+    (let (outcome)
       (unwind-protect
-          (let* ((before (majutsu-diff-editor-session-operation-id-before session))
-                 (after (majutsu-diff-editor--operation-id
-                         (majutsu-diff-editor-session-repository-root session))))
-            (setq outcome
-                  (cond
-                   ((and before after (equal before after)) 'unchanged)
-                   ((and before after) 'changed)
-                   (t 'unknown)))
-            (pcase outcome
-              ('unchanged
-               (message "jj diff editor ended without a repository operation"))
-              ('changed
-               (majutsu-diff-editor--invalidate-origin-selection session)
-               (majutsu-diff-editor--refresh-origin session))
-              ('unknown
-               ;; A failed probe is not evidence that the old buffer positions
-               ;; are still valid.  Clear and refresh rather than risking the
-               ;; wrong patch.
-               (majutsu-diff-editor--invalidate-origin-selection session)
-               (majutsu-diff-editor--refresh-origin session)
-               (message "jj diff editor ended; could not verify its repository result")))
-            (setq completed-normally t)
-            outcome)
-        (unless completed-normally
-          (majutsu-diff-editor--abort-session-completion session))
+          (setq outcome
+                (majutsu-interactive-complete-repository-operation
+                 (majutsu-diff-editor-session-repository-root session)
+                 (majutsu-diff-editor-session-origin-buffer session)
+                 (majutsu-diff-editor-session-operation-id-before session)
+                 unchanged-message))
         (majutsu-diff-editor--unregister-session session))
       ;; Hooks are observers, not part of the transactional completion path.
       ;; In particular they may immediately start another session for ROOT.
@@ -450,11 +458,11 @@ successful history rewrite."
 
 (defun majutsu-diff-editor--finish-process-session (session exit-code)
   "Finish process-hosted SESSION after EXIT-CODE outside its sentinel."
-  (if (and (integerp exit-code) (zerop exit-code))
-      (majutsu-diff-editor--complete-session session)
-    ;; The process runner has reported the failure.  jj's transaction is
-    ;; expected to be atomic, so retain the user's patch selection.
-    (majutsu-diff-editor--unregister-session session)))
+  (majutsu-diff-editor--complete-session
+   session nil
+   (and (integerp exit-code)
+        (zerop exit-code)
+        "jj diff editor ended without a repository operation")))
 
 (defun majutsu-diff-editor--session-jj-arguments (session)
   "Return jj argv, after the executable, for SESSION."
@@ -473,7 +481,8 @@ successful history rewrite."
 
 (defun majutsu-diff-editor--finish-ghostel-session (session event)
   "Run SESSION's Ghostel exit hook after EVENT outside its sentinel."
-  (majutsu-diff-editor--complete-session session event))
+  (majutsu-diff-editor--complete-session
+   session event "jj diff editor ended without a repository operation"))
 
 (defun majutsu-diff-editor--ghostel-exit (buffer event)
   "Defer completion of BUFFER's diff-editor session after Ghostel EVENT."
@@ -499,65 +508,103 @@ not compare operation ids until that lifecycle process has exited."
     (if (and (processp process) (process-live-p process))
         (run-at-time 0.05 nil #'majutsu-diff-editor--finish-terminal-kill
                      session)
-      (majutsu-diff-editor--complete-session session))))
+      (majutsu-diff-editor--finish-ghostel-session session nil))))
 
-(defun majutsu-diff-editor--assert-ghostel-editor-support (root)
-  "Signal unless Ghostel can support jj's later `JJ_EDITOR' invocation.
+(defun majutsu-diff-editor--assert-ghostel-editor-support (root command args)
+  "Signal unless Ghostel can support COMMAND with ARGS under ROOT.
 
 Remote Ghostel sessions use Emacs `make-process' with a TRAMP file handler.
 with-editor observes that path and supplies its sleeping-editor protocol.
-Local native Ghostel PTYs do not pass through that path, so they require
-emacsclient."
-  (unless (or (file-remote-p root) with-editor-emacsclient-executable)
-    (user-error (concat "Ghostel jj diff-editor sessions require emacsclient for "
-                        "JJ_EDITOR; configure `with-editor-emacsclient-executable'"))))
+Local native Ghostel PTYs require emacsclient only if COMMAND may invoke jj's
+description editor."
+  (unless (majutsu-diff-editor--ghostel-editor-supported-p command args root)
+    (user-error
+     (concat "jj " command " may invoke a description editor after its diff "
+             "editor; configure `with-editor-emacsclient-executable'"))))
+
+(defun majutsu-diff-editor--remote-with-editor-filter (filter root)
+  "Return a process filter which tracks OPEN packets before FILTER under ROOT."
+  (lambda (process output)
+    ;; with-editor normally publishes this after `make-process' returns.  A
+    ;; remote child can produce its first packet during process creation, so
+    ;; make the workspace identity available at the start of the filter too.
+    (process-put process 'default-dir root)
+    (majutsu-process-track-with-editor-output process output)
+    (funcall filter process output)))
 
 (defun majutsu-diff-editor--install-remote-with-editor-tracker (process root)
-  "Track remote with-editor packets from PROCESS for repository ROOT.
+  "Track remote with-editor packets from PROCESS for workspace ROOT.
 
 Ghostel's filter must continue to receive every byte.  The wrapper records a
 sleeping-editor OPEN packet before with-editor visits jj's temporary
 description file, then delegates unchanged to Ghostel's existing composite
 filter."
-  (when (processp process)
+  (when (and (processp process)
+             (not (process-get process 'majutsu-with-editor-tracker-installed)))
     ;; with-editor sets this itself for a remote `make-process', but it is the
-    ;; protocol's authoritative repository context, so retain it explicitly.
+    ;; protocol's authoritative workspace context, so retain it explicitly.
     (process-put process 'default-dir root)
     (when-let* ((filter (process-filter process)))
       (set-process-filter
-       process
-       (lambda (proc output)
-         (majutsu-process-track-with-editor-output proc output)
-         (funcall filter proc output))))))
+       process (majutsu-diff-editor--remote-with-editor-filter filter root))
+      (process-put process 'majutsu-with-editor-tracker-installed t))))
+
+(defun majutsu-diff-editor--remote-ghostel-exec (buffer program args root)
+  "Run remote Ghostel in BUFFER and track editor packets from its first byte.
+
+Ghostel currently exposes the lifecycle process only after `ghostel-exec'
+returns.  Temporarily decorate the one remote PTY `make-process' call targeting
+BUFFER so a fast JJ_EDITOR request is associated with workspace ROOT before
+with-editor handles it.  Other process creation, including TRAMP connection
+processes, is delegated untouched."
+  (let ((make-process-function (symbol-function 'make-process)))
+    (cl-letf
+        (((symbol-function 'make-process)
+          (lambda (&rest keys)
+            (if (and (eq (plist-get keys :buffer) buffer)
+                     (eq (plist-get keys :connection-type) 'pty)
+                     (plist-get keys :file-handler)
+                     (functionp (plist-get keys :filter)))
+                (let* ((filter (plist-get keys :filter))
+                       (tracked-filter
+                        (majutsu-diff-editor--remote-with-editor-filter
+                         filter root))
+                       (process
+                        (apply make-process-function
+                               (plist-put keys :filter tracked-filter))))
+                  (when (processp process)
+                    (process-put process 'default-dir root)
+                    (process-put process
+                                 'majutsu-with-editor-tracker-installed t))
+                  process)
+              (apply make-process-function keys)))))
+      (ghostel-exec buffer program args))))
 
 (defun majutsu-diff-editor--ghostel-exec (session buffer program args)
-  "Run Ghostel for SESSION and install its remote editor tracker atomically.
+  "Run Ghostel for SESSION and compose its remote editor tracker.
 
-The tracker has to be installed before `make-process' returns: a later wrapper
-could miss a fast `WITH-EDITOR' OPEN packet and leave the description buffer
-without its repository association."
-  (let ((root (majutsu-diff-editor-session-repository-root session)))
-    (if (not (file-remote-p root))
-        (ghostel-exec buffer program args)
-      (let ((make-process-function (symbol-function 'make-process))
-            (installed nil))
-        (cl-letf
-            (((symbol-function 'make-process)
-              (lambda (&rest keys)
-                (let ((process (apply make-process-function keys)))
-                  (when (and (not installed)
-                             (eq (plist-get keys :buffer) buffer)
-                             (plist-get keys :file-handler))
-                    (setq installed t)
-                    (majutsu-diff-editor--install-remote-with-editor-tracker
-                     process root))
-                  process))))
-          (ghostel-exec buffer program args))))))
+Use Ghostel's returned public lifecycle process.  Its existing filter already
+combines Ghostel rendering with with-editor, so wrapping that filter preserves
+their order while putting Majutsu's tracker first."
+  (let* ((root (majutsu-diff-editor-session-repository-root session))
+         (remote (file-remote-p root))
+         (process (if remote
+                      (majutsu-diff-editor--remote-ghostel-exec
+                       buffer program args root)
+                    (ghostel-exec buffer program args))))
+    (when remote
+      ;; This is a fallback for a Ghostel implementation whose public spawn
+      ;; path did not use the expected remote PTY process constructor.
+      (majutsu-diff-editor--install-remote-with-editor-tracker process root))
+    process))
 
 (defun majutsu-diff-editor--start-ghostel (session)
   "Start SESSION through Ghostel's public API and return SESSION."
   (let ((root (majutsu-diff-editor-session-repository-root session)))
-    (majutsu-diff-editor--assert-ghostel-editor-support root)
+    (majutsu-diff-editor--assert-ghostel-editor-support
+     root
+     (majutsu-diff-editor-session-command session)
+     (majutsu-diff-editor-session-args session))
     (let* ((buffer (generate-new-buffer
                     (majutsu-diff-editor--terminal-buffer-name session)))
            (command (majutsu-diff-editor--session-jj-arguments session))
@@ -607,35 +654,32 @@ without its repository association."
   (let ((args (majutsu-diff-editor--session-jj-arguments session))
         (root (majutsu-diff-editor-session-repository-root session)))
     (setf (majutsu-diff-editor-session-process session)
-          ;; The process API records these properties before installing its
-          ;; sentinel.  The callback then decides refresh from the operation
-          ;; id, so a normal editor cancel cannot discard Emacs selections.
+          ;; The creation callback retains the child during setup.  The process
+          ;; layer publishes completion ownership only after installing both
+          ;; its filter and sentinel.
           (let ((default-directory root)
                 (majutsu-process--start-created-callback
                  (lambda (process)
                    (setf (majutsu-diff-editor-session-process session) process))))
-            (if (fboundp 'majutsu-start-jj-with-editor)
-                (majutsu-start-jj-with-editor
-                 args nil
-                 (lambda (_process exit-code)
-                   ;; Defer both the jj probe and refresh out of the process
-                   ;; sentinel.  A failed process leaves the selection intact.
-                   (run-at-time 0 nil
-                                #'majutsu-diff-editor--finish-process-session
-                                session exit-code))
-                 t)
-              (majutsu-run-jj-with-editor args))))
+            (majutsu-start-jj-with-editor
+             args nil
+             (lambda (_process exit-code)
+               ;; Defer the operation-id probe and any refresh out of the
+               ;; process sentinel.  Every exit status needs a freshness check.
+               (run-at-time 0 nil
+                            #'majutsu-diff-editor--finish-process-session
+                            session exit-code))
+             t)))
     session))
 
 ;;;###autoload
 (cl-defun majutsu-diff-editor-start
-    (command args filesets &key origin-buffer selection-context)
+    (command args filesets &key origin-buffer)
   "Start jj COMMAND's configured diff-editor session.
 
 ARGS are command options and FILESETS are already separated fileset values.
 When ORIGIN-BUFFER is supplied it supplies the repository root; otherwise the
-current buffer does.  SELECTION-CONTEXT is retained for a later session owner
-to validate on completion.  Return a `majutsu-diff-editor-session'."
+current buffer does.  Return a `majutsu-diff-editor-session'."
   (unless (and (stringp command) (not (string-empty-p command)))
     (user-error "A jj diff-editor command is required"))
   (let* ((origin-buffer (or origin-buffer (current-buffer)))
@@ -652,11 +696,9 @@ to validate on completion.  Return a `majutsu-diff-editor-session'."
            :origin-buffer origin-buffer
            :repository-root (file-name-as-directory root)
            :host (let ((default-directory (file-name-as-directory root)))
-                   (majutsu-diff-editor-select-host args))
+                   (majutsu-diff-editor-select-host command args))
            :operation-id-before
-           (majutsu-diff-editor--operation-id (file-name-as-directory root))
-           :selection-context selection-context
-           :started-at (current-time))))
+           (majutsu-jj-operation-id (file-name-as-directory root)))))
     (majutsu-diff-editor--register-session session)
     (let ((started nil))
       (unwind-protect

--- a/test/majutsu-diff-editor-test.el
+++ b/test/majutsu-diff-editor-test.el
@@ -56,11 +56,22 @@
   (should-not
    (majutsu-diff-editor-tool-from-arguments '("-t" "destination"))))
 
+(ert-deftest majutsu-diff-editor-tool-arguments/do-not-consume-another-option ()
+  "A missing `--tool' value must leave the following option parseable."
+  (should-not
+   (majutsu-diff-editor-tool-from-arguments
+    '("--tool" "--interactive")))
+  (should-not
+   (majutsu-diff-editor-strip-interactive-arguments
+    '("--tool" "--interactive"))))
+
 (ert-deftest majutsu-diff-editor-missing-tool-value-p/rejects-only-malformed-tools ()
   "A fileset separator cannot supply `--tool'."
   (should (majutsu-diff-editor--missing-tool-value-p '("--tool")))
   (should (majutsu-diff-editor--missing-tool-value-p
            '("--tool" "--" "literal")))
+  (should (majutsu-diff-editor--missing-tool-value-p
+           '("--tool" "--interactive")))
   (should (majutsu-diff-editor--missing-tool-value-p '("--tool=")))
   (should-not (majutsu-diff-editor--missing-tool-value-p
                '("--tool" "meld" "--" "literal"))))
@@ -73,7 +84,8 @@
                (lambda () t))
               ((symbol-function 'majutsu-diff-editor--effective-tool)
                (lambda (_args) ":builtin")))
-      (should (eq (majutsu-diff-editor-select-host '("--interactive"))
+      (should (eq (majutsu-diff-editor-select-host
+                   "split" '("--interactive"))
                   'ghostel)))))
 
 (ert-deftest majutsu-diff-editor-select-host/auto-falls-back-without-emacsclient ()
@@ -85,7 +97,8 @@
               ((symbol-function 'majutsu-diff-editor--effective-tool)
                (lambda (_args) "meld"))
               ((symbol-function 'message) (lambda (&rest _) nil)))
-      (should (eq (majutsu-diff-editor-select-host '("--tool" "meld"))
+      (should (eq (majutsu-diff-editor-select-host
+                   "split" '("--tool" "meld"))
                   'process)))))
 
 (ert-deftest majutsu-diff-editor-select-host/auto-rejects-builtin-without-emacsclient ()
@@ -97,7 +110,38 @@
               ((symbol-function 'majutsu-diff-editor--effective-tool)
                (lambda (_args) ":builtin")))
       (should-error
-       (majutsu-diff-editor-select-host '("--interactive"))
+       (majutsu-diff-editor-select-host "split" '("--interactive"))
+       :type 'user-error))))
+
+(ert-deftest majutsu-diff-editor-select-host/auto-restores-without-emacsclient ()
+  "Restore uses Ghostel because it cannot invoke a description editor."
+  (let ((majutsu-diff-editor-host 'auto)
+        (with-editor-emacsclient-executable nil))
+    (cl-letf (((symbol-function 'majutsu-diff-editor-ghostel-available-p)
+               (lambda () t))
+              ((symbol-function 'majutsu-diff-editor--effective-tool)
+               (lambda (_args) ":builtin")))
+      (should (eq (majutsu-diff-editor-select-host
+                   "restore" '("--interactive"))
+                  'ghostel)))))
+
+(ert-deftest majutsu-diff-editor-select-host/explicit-message-needs-no-emacsclient ()
+  "Description-free Split and Squash paths can use a local Ghostel TUI."
+  (let ((majutsu-diff-editor-host 'auto)
+        (with-editor-emacsclient-executable nil))
+    (cl-letf (((symbol-function 'majutsu-diff-editor-ghostel-available-p)
+               (lambda () t))
+              ((symbol-function 'majutsu-diff-editor--effective-tool)
+               (lambda (_args) ":builtin")))
+      (should (eq (majutsu-diff-editor-select-host
+                   "split" '("--message=first" "--interactive"))
+                  'ghostel))
+      (should (eq (majutsu-diff-editor-select-host
+                   "squash" '("--use-destination-message" "--interactive"))
+                  'ghostel))
+      (should-error
+       (majutsu-diff-editor-select-host
+        "split" '("--message=first" "--editor" "--interactive"))
        :type 'user-error))))
 
 (ert-deftest majutsu-diff-editor-select-host/auto-falls-back-for-external-tool ()
@@ -108,7 +152,8 @@
               ((symbol-function 'majutsu-diff-editor--effective-tool)
                (lambda (_args) "meld"))
               ((symbol-function 'message) (lambda (&rest _) nil)))
-      (should (eq (majutsu-diff-editor-select-host '("--tool" "meld"))
+      (should (eq (majutsu-diff-editor-select-host
+                   "split" '("--tool" "meld"))
                   'process)))))
 
 (ert-deftest majutsu-diff-editor-select-host/auto-remote-prefers-ghostel ()
@@ -120,7 +165,8 @@
                (lambda () t))
               ((symbol-function 'majutsu-diff-editor--effective-tool)
                (lambda (_args) "meld")))
-      (should (eq (majutsu-diff-editor-select-host '("--tool" "meld"))
+      (should (eq (majutsu-diff-editor-select-host
+                   "split" '("--tool" "meld"))
                   'ghostel)))))
 
 (ert-deftest majutsu-diff-editor-select-host/auto-remote-hosts-builtin ()
@@ -132,7 +178,8 @@
                (lambda () t))
               ((symbol-function 'majutsu-diff-editor--effective-tool)
                (lambda (_args) ":builtin")))
-      (should (eq (majutsu-diff-editor-select-host '("--interactive"))
+      (should (eq (majutsu-diff-editor-select-host
+                   "split" '("--interactive"))
                   'ghostel)))))
 
 (ert-deftest majutsu-diff-editor-select-host/auto-remote-falls-back-without-ghostel ()
@@ -145,7 +192,8 @@
               ((symbol-function 'majutsu-diff-editor--effective-tool)
                (lambda (_args) "meld"))
               ((symbol-function 'message) (lambda (&rest _) nil)))
-      (should (eq (majutsu-diff-editor-select-host '("--tool" "meld"))
+      (should (eq (majutsu-diff-editor-select-host
+                   "split" '("--tool" "meld"))
                   'process)))))
 
 (ert-deftest majutsu-diff-editor-configured-tool/preserves-global-then-local-order ()
@@ -178,7 +226,8 @@
                 ((symbol-function 'majutsu-diff-editor--effective-tool)
                  (lambda (_args) ":builtin")))
         (should-error
-         (majutsu-diff-editor-select-host '("--tool=:builtin"))
+         (majutsu-diff-editor-select-host
+          "split" '("--tool=:builtin"))
          :type 'user-error)))))
 
 (ert-deftest majutsu-diff-editor-select-host/explicit-ghostel-needs-package ()
@@ -187,7 +236,7 @@
     (cl-letf (((symbol-function 'majutsu-diff-editor-ghostel-available-p)
                (lambda () nil)))
       (should-error
-       (majutsu-diff-editor-select-host '("--tool" "meld"))
+       (majutsu-diff-editor-select-host "split" '("--tool" "meld"))
        :type 'user-error))))
 
 (ert-deftest majutsu-diff-editor-start/ghostel-rejects-sleeping-editor-before-buffer-creation ()
@@ -199,7 +248,7 @@
                (lambda (&optional _directory) "/repo/"))
               ((symbol-function 'majutsu-diff-editor-ghostel-available-p)
                (lambda () t))
-              ((symbol-function 'majutsu-diff-editor--operation-id)
+              ((symbol-function 'majutsu-jj-operation-id)
                (lambda (&rest _) "before")))
       (should-error
        (majutsu-diff-editor-start "split" '("--tool=:builtin") nil)
@@ -215,13 +264,24 @@
   (let ((with-editor-emacsclient-executable nil))
     (cl-letf (((symbol-function 'file-remote-p) (lambda (&rest _) t)))
       (should-not
-       (majutsu-diff-editor--assert-ghostel-editor-support "/ssh:example:/repo/")))))
+       (majutsu-diff-editor--assert-ghostel-editor-support
+        "/ssh:example:/repo/" "split" nil)))))
 
-(ert-deftest majutsu-diff-editor-ghostel-exec/installs-tracker-before-delegating-output ()
-  "The remote tracker precedes Ghostel's already-installed output filter."
+(ert-deftest majutsu-diff-editor-assert-ghostel-editor-support/restore-needs-no-emacsclient ()
+  "Local restore cannot invoke jj's description editor."
+  (let ((with-editor-emacsclient-executable nil))
+    (cl-letf (((symbol-function 'file-remote-p) (lambda (&rest _) nil)))
+      (should-not
+       (majutsu-diff-editor--assert-ghostel-editor-support
+        "/repo/" "restore" nil)))))
+
+(ert-deftest majutsu-diff-editor-ghostel-exec/tracks-open-during-remote-spawn ()
+  "Track a fast JJ_EDITOR OPEN packet before `ghostel-exec' returns."
   (let ((majutsu-process--with-editor-file-roots (make-hash-table :test #'equal))
         (root "/ssh:example:/repo/")
-        called)
+        spawn-returned
+        seen-before-return
+        seen-root)
     (with-temp-buffer
       (let* ((buffer (current-buffer))
              (session (majutsu-diff-editor-session-create :repository-root root))
@@ -229,37 +289,49 @@
                                  :buffer buffer
                                  :command (list "cat"))))
         (unwind-protect
-            (progn
-              (set-process-filter proc (lambda (&rest _) (setq called t)))
-              (cl-letf (((symbol-function 'file-remote-p)
-                         (lambda (&rest _) "/ssh:example:"))
-                        ;; The outer binding is the pre-existing advised
-                        ;; `make-process' implementation seen by the helper.
-                        ((symbol-function 'make-process)
-                         (lambda (&rest _) proc))
-                        ((symbol-function 'ghostel-exec)
-                         (lambda (target-buffer _program _args)
-                           (make-process :name "ghostel"
-                                         :buffer target-buffer
-                                         :file-handler "/ssh:example:"))))
+            (let ((packet
+                   (format (concat "WITH-EDITOR: 123 OPEN "
+                                   "/tmp/editor.jjdescription%c%c IN /repo\n")
+                           ?\x1f ?\x1f)))
+              (cl-letf
+                  (((symbol-function 'make-process)
+                    (lambda (&rest keys)
+                      (set-process-filter proc (plist-get keys :filter))
+                      ;; Model output delivered synchronously by a TRAMP file
+                      ;; handler before its `make-process' call returns.
+                      (funcall (process-filter proc) proc packet)
+                      proc))
+                   ((symbol-function 'ghostel-exec)
+                    (lambda (target-buffer _program _args)
+                      (should (eq target-buffer buffer))
+                      (prog1
+                          (make-process
+                           :name "ghostel"
+                           :buffer target-buffer
+                           :command '("/bin/sh" "-c" "exec jj split -i")
+                           :connection-type 'pty
+                           :file-handler "/ssh:example:"
+                           :filter
+                           (lambda (&rest _)
+                             (setq seen-before-return (not spawn-returned)
+                                   seen-root
+                                   (majutsu-process-with-editor-file-root
+                                    (concat "/ssh:example:"
+                                            "/tmp/editor.jjdescription")))))
+                        (setq spawn-returned t)))))
                 (should (eq (majutsu-diff-editor--ghostel-exec
                              session buffer "jj" '("split"))
                             proc)))
-              (funcall (process-filter proc) proc
-                       (format "WITH-EDITOR: 123 OPEN /tmp/editor.jjdescription%c IN /repo\n"
-                               ?\x1f))
-              (should called)
-              (should
-               (equal
-                (majutsu-process-with-editor-file-root
-                 "/ssh:example:/tmp/editor.jjdescription")
-                root)))
+              (should seen-before-return)
+              (should (equal seen-root root)))
           (delete-process proc))))))
 
 (ert-deftest majutsu-diff-editor-remote-with-editor-advice/composes-the-tracker ()
   "The real with-editor advice preserves Ghostel after Majutsu tracks output."
   (let ((majutsu-process--with-editor-file-roots (make-hash-table :test #'equal))
         (root "/ssh:example:/repo/")
+        (track-output-function
+         (symbol-function 'majutsu-process-track-with-editor-output))
         command order seen-root)
     (with-temp-buffer
       (let ((terminal (current-buffer))
@@ -276,7 +348,11 @@
                                  order)
                            (setq seen-root
                                  (majutsu-process-with-editor-file-root
-                                  "/ssh:example:/tmp/editor.jjdescription")))))
+                                  "/ssh:example:/tmp/editor.jjdescription"))))
+                        ((symbol-function 'majutsu-process-track-with-editor-output)
+                         (lambda (process output)
+                           (push 'tracker order)
+                           (funcall track-output-function process output))))
                 (majutsu-with-editor
                   (let ((process
                          (make-process@with-editor-process-filter
@@ -293,11 +369,13 @@
                     (majutsu-diff-editor--install-remote-with-editor-tracker
                      process root)
                     (funcall (process-filter process) process
-                             (format "WITH-EDITOR: 123 OPEN /tmp/editor.jjdescription%c IN /repo\n"
-                                     ?\x1f)))))
+                             (format (concat "WITH-EDITOR: 123 OPEN "
+                                             "/tmp/editor.jjdescription%c%c IN /repo\n")
+                                     ?\x1f ?\x1f)))))
               (should (equal (car command) "env"))
               (should (string-prefix-p "JJ_EDITOR=" (cadr command)))
-              (should (equal (nreverse order) '(ghostel with-editor)))
+              (should (equal (nreverse order)
+                             '(tracker ghostel with-editor)))
               (should (equal seen-root root)))
           (delete-process proc))))))
 
@@ -326,7 +404,7 @@
                        (setq-local ghostel-exit-functions nil)))
                     ((symbol-function 'majutsu-jj--executable)
                      (lambda () "jj"))
-                    ((symbol-function 'majutsu-diff-editor--operation-id)
+                    ((symbol-function 'majutsu-jj-operation-id)
                      (lambda (&rest _) "before"))
                     ((symbol-function 'majutsu-process-jj-arguments)
                      (lambda (args) (cons "--global" args)))
@@ -382,12 +460,12 @@
         (majutsu-diff-editor--live-sessions (make-hash-table :test 'equal))
         called host-directory process-directory)
     (cl-letf (((symbol-function 'majutsu--toplevel-safe)
-               (lambda (&optional _directory) "/repo/"))
+              (lambda (&optional _directory) "/repo/"))
               ((symbol-function 'majutsu-diff-editor-select-host)
-               (lambda (_args)
+               (lambda (_command _args)
                  (setq host-directory default-directory)
                  'process))
-              ((symbol-function 'majutsu-diff-editor--operation-id)
+              ((symbol-function 'majutsu-jj-operation-id)
                (lambda (&rest _) "before"))
               ((symbol-function 'majutsu-start-jj-with-editor)
                (lambda (&rest args)
@@ -407,7 +485,7 @@
         (should (equal host-directory "/repo/"))
         (should (equal process-directory "/repo/"))))))
 
-(ert-deftest majutsu-diff-editor-start/allows-one-live-session-per-repository ()
+(ert-deftest majutsu-diff-editor-start/allows-one-live-session-per-workspace ()
   "Reject concurrent rewrite sessions, then release the slot at completion."
   (let ((majutsu-diff-editor-host 'process)
         (majutsu-diff-editor--live-sessions (make-hash-table :test 'equal))
@@ -416,11 +494,12 @@
                (lambda (&optional _directory) "/repo/"))
               ((symbol-function 'majutsu-diff-editor-select-host)
                (lambda (&rest _) 'process))
-              ((symbol-function 'majutsu-diff-editor--operation-id)
+              ((symbol-function 'majutsu-jj-operation-id)
                (lambda (&rest _) "before"))
               ((symbol-function 'majutsu-start-jj-with-editor)
                (lambda (&rest _) 'fake-process))
-              ((symbol-function 'message) (lambda (&rest _) nil)))
+              ((symbol-function 'majutsu-interactive-complete-repository-operation)
+               (lambda (&rest _) 'unchanged)))
       (setq session
             (majutsu-diff-editor-start "split" '("--tool" "meld") nil))
       (should-error
@@ -431,13 +510,13 @@
        (majutsu-diff-editor-start "restore" '("--tool" "meld") nil)))))
 
 (ert-deftest majutsu-diff-editor-start/quit-releases-an-unstarted-session ()
-  "C-g during startup must not leave a repository session lock behind."
+  "C-g during startup must not leave a workspace session lock behind."
   (let ((majutsu-diff-editor--live-sessions (make-hash-table :test 'equal)))
     (cl-letf (((symbol-function 'majutsu--toplevel-safe)
                (lambda (&optional _directory) "/repo/"))
               ((symbol-function 'majutsu-diff-editor-select-host)
                (lambda (&rest _) 'ghostel))
-              ((symbol-function 'majutsu-diff-editor--operation-id)
+              ((symbol-function 'majutsu-jj-operation-id)
                (lambda (&rest _) "before"))
               ((symbol-function 'majutsu-diff-editor--start-ghostel)
                (lambda (&rest _) (signal 'quit nil))))
@@ -457,9 +536,8 @@
     (puthash "/repo/" session majutsu-diff-editor--live-sessions)
     (cl-letf (((symbol-function 'processp) (lambda (_process) t))
               ((symbol-function 'process-live-p) (lambda (_process) nil))
-              ((symbol-function 'process-get)
-               (lambda (_process property)
-                 (and (eq property 'finish-callback) #'ignore)))
+              ((symbol-function 'majutsu-process-completion-owned-p)
+               (lambda (_process) t))
               ((symbol-function 'run-at-time)
                (lambda (&rest args) (setq scheduled args))))
       (majutsu-diff-editor--abort-session-start session)
@@ -470,6 +548,71 @@
       (should-not (and scheduled
                        (eq (nth 2 scheduled)
                            #'majutsu-diff-editor--complete-session))))))
+
+(ert-deftest majutsu-diff-editor-start/process-setup-failures-release-slot ()
+  "Filter and sentinel setup failures cannot strand the workspace slot."
+  (dolist (phase '(filter sentinel))
+    (let ((majutsu-diff-editor--live-sessions (make-hash-table :test 'equal))
+          (with-editor-emacsclient-executable nil)
+          (real-set-process-filter (symbol-function 'set-process-filter))
+          (real-set-process-sentinel (symbol-function 'set-process-sentinel))
+          (root (file-name-as-directory temporary-file-directory))
+          process invalidated scheduled)
+      (unwind-protect
+          (with-temp-buffer
+            (let ((process-buffer (current-buffer))
+                  (default-directory root))
+              (cl-letf (((symbol-function 'majutsu--toplevel-safe)
+                         (lambda (&optional _directory) root))
+                        ((symbol-function 'majutsu-diff-editor-select-host)
+                         (lambda (&rest _) 'process))
+                        ((symbol-function 'majutsu-jj-operation-id)
+                         (lambda (&rest _) "before"))
+                        ((symbol-function 'majutsu-jj--executable)
+                         (lambda () "jj"))
+                        ((symbol-function 'majutsu-process-jj-arguments)
+                         (lambda (args) args))
+                        ((symbol-function 'majutsu-process-buffer)
+                         (lambda (&optional _nodisplay) process-buffer))
+                        ((symbol-function 'majutsu--process-insert-section)
+                         (lambda (&rest _args)
+                           (insert "\n")
+                           'not-a-section))
+                        ((symbol-function 'start-file-process)
+                         (lambda (name buffer _program &rest _args)
+                           (setq process
+                                 (make-process
+                                  :name (format "%s-diff-editor-setup-test"
+                                                name)
+                                  :buffer buffer :command '("cat")
+                                  :noquery t))))
+                        ((symbol-function 'majutsu--process-install-filter)
+                         (lambda (child)
+                           (if (eq phase 'filter)
+                               (error "filter setup failed")
+                             (funcall real-set-process-filter child #'ignore))))
+                        ((symbol-function 'set-process-sentinel)
+                         (lambda (child sentinel)
+                           (if (eq phase 'sentinel)
+                               (error "sentinel setup failed")
+                             (funcall real-set-process-sentinel
+                                      child sentinel))))
+                        ((symbol-function 'majutsu-interactive-invalidate-repository)
+                         (lambda (root) (setq invalidated root)))
+                        ((symbol-function 'run-at-time)
+                         (lambda (&rest args) (setq scheduled args))))
+                (should-error
+                 (majutsu-diff-editor-start
+                  "restore" '("--tool" "meld") nil))
+                (should (process-get process 'finish-callback))
+                (should-not (majutsu-process-completion-owned-p process))
+                (should-not
+                 (gethash root majutsu-diff-editor--live-sessions))
+                (should (equal invalidated root))
+                (should (equal (nth 2 scheduled)
+                               #'majutsu-diff-editor--refresh-origin)))))
+        (when (and (processp process) (process-live-p process))
+          (delete-process process))))))
 
 (ert-deftest majutsu-diff-editor-finish-terminal-kill/waits-for-live-reaper ()
   "Do not compare operation ids until Ghostel's reaper has exited."
@@ -499,71 +642,93 @@
       (majutsu-diff-editor--finish-terminal-kill session)
       (should (eq completed session)))))
 
-(ert-deftest majutsu-diff-editor-complete-session/refreshes-only-after-operation-change ()
-  "Keep a cancelled editor's selection; clear stale selections after a change."
-  (let ((origin (generate-new-buffer " *majutsu-diff-editor-origin*"))
-        invalidated refreshed ids)
+(ert-deftest majutsu-diff-editor-ghostel-exit/defers-event-without-exit-status ()
+  "Ghostel completion uses its event and never interprets a process status."
+  (let* ((buffer (generate-new-buffer " *majutsu-ghostel-exit*"))
+         (session (majutsu-diff-editor-session-create
+                   :repository-root "/repo/"))
+         scheduled
+         completed)
     (unwind-protect
-        (with-current-buffer origin
-          (majutsu-diff-mode)
-          (cl-letf (((symbol-function 'majutsu-diff-editor--operation-id)
+        (progn
+          (with-current-buffer buffer
+            (setq-local majutsu-diff-editor--session session))
+          (cl-letf (((symbol-function 'run-at-time)
+                     (lambda (&rest args) (setq scheduled args))))
+            (majutsu-diff-editor--ghostel-exit buffer "finished\n"))
+          (should (equal scheduled
+                         (list 0 nil
+                               #'majutsu-diff-editor--finish-ghostel-session
+                               session "finished\n")))
+          (cl-letf (((symbol-function 'process-exit-status)
                      (lambda (&rest _)
-                       (pop ids)))
-                    ((symbol-function 'majutsu-interactive-invalidate)
-                     (lambda () (setq invalidated (1+ (or invalidated 0)))))
-                    ((symbol-function 'majutsu-refresh)
-                     (lambda () (setq refreshed (1+ (or refreshed 0)))))
-                    ((symbol-function 'message) (lambda (&rest _) nil)))
-            (setq ids '("before"))
-            (should
-             (eq (majutsu-diff-editor--complete-session
-                  (majutsu-diff-editor-session-create
-                   :origin-buffer origin :repository-root default-directory
-                   :operation-id-before "before"))
-                 'unchanged))
-            (should-not invalidated)
-            (should-not refreshed)
-            (setq ids '("after"))
-            (should
-             (eq (majutsu-diff-editor--complete-session
-                  (majutsu-diff-editor-session-create
-                   :origin-buffer origin :repository-root default-directory
-                   :operation-id-before "before"))
-                 'changed))
-            (should (= invalidated 1))
-            (should (= refreshed 1))
-            (setq ids '(nil))
-            (should
-             (eq (majutsu-diff-editor--complete-session
-                  (majutsu-diff-editor-session-create
-                   :origin-buffer origin :repository-root default-directory
-                   :operation-id-before "before"))
-                 'unknown))
-            (should (= invalidated 2))
-            (should (= refreshed 2))))
-      (when (buffer-live-p origin)
-        (kill-buffer origin)))))
+                       (ert-fail "Ghostel completion read process status")))
+                    ((symbol-function 'majutsu-diff-editor--complete-session)
+                     (lambda (&rest args) (setq completed args))))
+            (apply (nth 2 scheduled) (nthcdr 3 scheduled)))
+          (should (equal completed
+                         (list session "finished\n"
+                               "jj diff editor ended without a repository operation"))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
 
-(ert-deftest majutsu-diff-editor-complete-session/quit-releases-and-invalidates ()
-  "C-g during the operation probe leaves no lock or reusable patch selection."
+(ert-deftest majutsu-diff-editor-complete-session/delegates-repository-freshness ()
+  "Use the shared repository-wide completion contract."
+  (let* ((origin (generate-new-buffer " *majutsu-diff-editor-origin*"))
+         (session (majutsu-diff-editor-session-create
+                   :origin-buffer origin :repository-root "/repo/"
+                   :operation-id-before "before"))
+         called)
+    (unwind-protect
+        (cl-letf (((symbol-function 'majutsu-interactive-complete-repository-operation)
+                   (lambda (&rest args)
+                     (setq called args)
+                     'changed)))
+          (should
+           (eq (majutsu-diff-editor--complete-session
+                session nil "unchanged message")
+               'changed))
+          (should (equal called
+                         (list "/repo/" origin "before"
+                               "unchanged message"))))
+      (kill-buffer origin))))
+
+(ert-deftest majutsu-diff-editor-finish-process-session/checks-every-exit-code ()
+  "Failures still probe freshness, but an unchanged failure stays quiet."
+  (dolist (case '((0 "jj diff editor ended without a repository operation")
+                  (1 nil)
+                  (nil nil)))
+    (let* ((session (majutsu-diff-editor-session-create
+                     :repository-root "/repo/"
+                     :operation-id-before "before"))
+           called)
+      (cl-letf (((symbol-function 'majutsu-interactive-complete-repository-operation)
+                 (lambda (&rest args)
+                   (setq called args)
+                   'unchanged)))
+        (should (eq (majutsu-diff-editor--finish-process-session
+                     session (car case))
+                    'unchanged))
+        (should (equal called
+                       (list "/repo/" nil "before" (cadr case))))))))
+
+(ert-deftest majutsu-diff-editor-complete-session/quit-releases-slot ()
+  "C-g in shared completion leaves no workspace session lock."
   (let* ((majutsu-diff-editor--live-sessions (make-hash-table :test 'equal))
          (session (majutsu-diff-editor-session-create
                    :repository-root "/repo/" :operation-id-before "before"))
-         invalidated scheduled)
+         shared-completion-ran)
     (puthash "/repo/" session majutsu-diff-editor--live-sessions)
-    (cl-letf (((symbol-function 'majutsu-diff-editor--operation-id)
-               (lambda (&rest _) (signal 'quit nil)))
-              ((symbol-function 'majutsu-diff-editor--invalidate-origin-selection)
-               (lambda (_session) (setq invalidated t)))
-              ((symbol-function 'run-at-time)
-               (lambda (&rest args) (setq scheduled args))))
+    (cl-letf (((symbol-function 'majutsu-interactive-complete-repository-operation)
+               (lambda (&rest _)
+                 (setq shared-completion-ran t)
+                 (signal 'quit nil))))
       (let (quit)
         (condition-case nil
             (majutsu-diff-editor--complete-session session)
           (quit (setq quit t)))
         (should quit))
-      (should invalidated)
-      (should scheduled)
+      (should shared-completion-ran)
       (should-not (gethash "/repo/" majutsu-diff-editor--live-sessions)))))
 
 (ert-deftest majutsu-diff-editor-complete-session/releases-before-exit-hook ()
@@ -577,9 +742,8 @@
            (list (lambda (&rest _)
                    (setq hook-saw-slot
                          (gethash "/repo/" majutsu-diff-editor--live-sessions))))))
-      (cl-letf (((symbol-function 'majutsu-diff-editor--operation-id)
-                 (lambda (&rest _) "before"))
-                ((symbol-function 'message) (lambda (&rest _) nil)))
+      (cl-letf (((symbol-function 'majutsu-interactive-complete-repository-operation)
+                 (lambda (&rest _) 'unchanged)))
         (should (eq (majutsu-diff-editor--complete-session session "finished")
                     'unchanged))
         (should-not hook-saw-slot)))))


### PR DESCRIPTION
* majutsu-diff-editor.el
(majutsu-diff-editor--tool-value-token-p,
majutsu-diff-editor-strip-interactive-arguments,
majutsu-diff-editor-tool-from-arguments,
majutsu-diff-editor--missing-tool-value-p): Do not consume another
option as a missing --tool value.
(majutsu-diff-editor--argument-present-p,
majutsu-diff-editor--description-editor-required-p,
majutsu-diff-editor--ghostel-editor-supported-p,
majutsu-diff-editor-select-host): Require emacsclient only when the
selected command and arguments may invoke a description editor.
(majutsu-diff-editor--register-session,
majutsu-diff-editor--unregister-session): Keep one completion-owned
session slot per workspace.
(majutsu-diff-editor--abort-session-start,
majutsu-diff-editor--invalidate-unowned-session): Release failed
startup slots and conservatively invalidate selections left by an
unowned child.
(majutsu-diff-editor--complete-session,
majutsu-diff-editor--finish-process-session,
majutsu-diff-editor--finish-ghostel-session): Delegate every process
and terminal outcome to shared operation-ID freshness handling.
(majutsu-diff-editor--ghostel-exit,
majutsu-diff-editor--finish-terminal-kill): Complete Ghostel sessions
without interpreting the reaper status as the jj child exit status.
(majutsu-diff-editor--assert-ghostel-editor-support): Make local editor
requirements command-aware.
(majutsu-diff-editor--remote-with-editor-filter,
majutsu-diff-editor--install-remote-with-editor-tracker,
majutsu-diff-editor--remote-ghostel-exec,
majutsu-diff-editor--ghostel-exec): Install the remote with-editor
tracker before a Ghostel PTY can emit its first OPEN packet.
(majutsu-diff-editor--start-process): Depend on explicit process
completion ownership.
(majutsu-diff-editor-start): Record freshness with the shared
operation-ID helper and simplify session state.
* test/majutsu-diff-editor-test.el: Test malformed tool arguments,
command-aware editor requirements, workspace ownership, interrupted
startup, remote packet races, and unified freshness completion.
* NEWS.org: Announce rendered selection contexts, canonical revision
pinning, Restore and Squash fixes, and race-safe completion.
* docs/majutsu.org: Document inherited command contexts, selection
freshness, and command-aware Ghostel requirements.
* docs/majutsu.texi: Regenerate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Patch selections now persist across cancelled or unchanged editor sessions.
  * Selection context is validated and cleared when repository state changes.
  * Diff-editor hosting now supports more precise routing for Restore, Split, Squash, and message-based workflows.
  * Remote editing sessions provide improved workspace tracking and cleanup.

* **Bug Fixes**
  * Improved Squash and Restore revision handling, including sub-hunk selections.
  * Prevented selected patches from targeting moved revisions.
  * Require explicit Restore context for aggregate diffs.
  * Fixed race conditions during interactive process startup and completion.
  * Added clearer validation and error handling for tool arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->