### PR TITLE
Extract the shared terminal-session lifecycle.

### DIFF
--- a/majutsu-diff-editor.el
+++ b/majutsu-diff-editor.el
@@ -19,9 +19,9 @@
 (require 'majutsu-jj)
 (require 'majutsu-process)
 (require 'majutsu-interactive)
+(require 'majutsu-terminal-session)
 
 (declare-function ghostel-exec "ghostel" (buffer program &optional args))
-(declare-function ghostel-mode "ghostel" ())
 (declare-function majutsu-start-jj-with-editor "majutsu-process"
                   (args &optional success-msg finish-callback inhibit-refresh))
 (declare-function majutsu-process-completion-owned-p "majutsu-process"
@@ -33,14 +33,12 @@
                   (root origin-buffer operation-before
                         &optional unchanged-message))
 
-(defvar ghostel-exit-functions)
-(defvar ghostel-kill-buffer-on-exit)
 (defvar majutsu-process--start-created-callback)
 
 ;;; Customization
 
 (defgroup majutsu-diff-editor nil
-  "jj diff-editor sessions in Majutsu."
+  "Host jj diff-editor sessions in Majutsu."
   :group 'majutsu)
 
 (defcustom majutsu-diff-editor-host 'auto
@@ -159,9 +157,7 @@ Ignore tokens after `--'."
 
 Ghostel remains an optional dependency, so it is only required when a
 diff-editor session needs it."
-  (and (require 'ghostel nil t)
-       (fboundp 'ghostel-exec)
-       (fboundp 'ghostel-mode)))
+  (majutsu-terminal-session-available-p))
 
 (defun majutsu-diff-editor--config-overrides (args)
   "Return global config overrides in ARGS, before its fileset separator."
@@ -265,7 +261,7 @@ only needs emacsclient when it can later request a description editor."
 Signal `user-error' rather than starting a terminal editor in a pipe.
 The return value is either `ghostel' or `process'."
   (when (majutsu-diff-editor--missing-tool-value-p args)
-    (user-error "jj --tool requires a tool name"))
+    (user-error "The jj --tool option requires a tool name"))
   (pcase majutsu-diff-editor-host
     ('ghostel
      (if (majutsu-diff-editor-ghostel-available-p)
@@ -314,59 +310,30 @@ The return value is either `ghostel' or `process'."
 ;;; Sessions
 
 (cl-defstruct (majutsu-diff-editor-session
+               (:include majutsu-terminal-session)
                (:constructor majutsu-diff-editor-session-create))
   "A running jj diff-editor session."
-  command args filesets origin-buffer repository-root
-  host terminal-buffer process
-  operation-id-before completed-p)
+  command args filesets host)
 
-(defvar-local majutsu-diff-editor--session nil
-  "The `majutsu-diff-editor-session' associated with this terminal buffer.")
-
-(defvar majutsu-diff-editor--live-sessions (make-hash-table :test 'equal)
-  "Majutsu-owned diff-editor sessions indexed by workspace root.")
+;; Keep the old private registry name as an alias while the terminal lifecycle
+;; lives in one shared implementation.  Dynamic test isolation therefore still
+;; isolates Arrange and diff-editor sessions together.
+(defvaralias 'majutsu-diff-editor--live-sessions
+  'majutsu-terminal-session--live-sessions)
 
 (defun majutsu-diff-editor--register-session (session)
   "Reserve SESSION's workspace slot, or signal if another session owns it."
-  (let* ((root (majutsu-diff-editor-session-repository-root session))
-         (existing (gethash root majutsu-diff-editor--live-sessions)))
-    (when existing
-      ;; Completion owns the slot even after a child exits, until its deferred
-      ;; freshness check has run and explicitly unregisters the session.
-      (user-error "A jj diff-editor session is already active for this workspace"))
-    (puthash root session majutsu-diff-editor--live-sessions)))
+  (majutsu-terminal-session-register
+   (majutsu-diff-editor-session-repository-root session) session))
 
 (defun majutsu-diff-editor--unregister-session (session)
   "Release SESSION's workspace slot if it is still its owner."
-  (let ((root (majutsu-diff-editor-session-repository-root session)))
-    (when (eq (gethash root majutsu-diff-editor--live-sessions) session)
-      (remhash root majutsu-diff-editor--live-sessions))))
+  (majutsu-terminal-session-unregister
+   (majutsu-diff-editor-session-repository-root session) session))
 
 (defun majutsu-diff-editor--session-lifecycle-process (session)
   "Return SESSION's known lifecycle process, if one has been created."
-  (or (majutsu-diff-editor-session-process session)
-      (when-let* ((buffer (majutsu-diff-editor-session-terminal-buffer session))
-                  ((buffer-live-p buffer)))
-        ;; This is a public Emacs association.  It also covers a non-local
-        ;; exit from `ghostel-exec' after the PTY process exists but before it
-        ;; could return its lifecycle object to us.
-        (get-buffer-process buffer))))
-
-(defun majutsu-diff-editor--cleanup-unstarted-terminal-buffer (session)
-  "Remove SESSION bookkeeping and kill its terminal buffer before spawn.
-
-The function is deliberately quiet and idempotent so it is safe from the
-inner Ghostel startup cleanup and the outer session-start cleanup."
-  (when-let* ((buffer (majutsu-diff-editor-session-terminal-buffer session))
-              ((buffer-live-p buffer)))
-    (let ((inhibit-quit t))
-      (with-current-buffer buffer
-        (setq-local majutsu-diff-editor--session nil)
-        (remove-hook 'kill-buffer-hook
-                     #'majutsu-diff-editor--terminal-buffer-killed t)
-        (remove-hook 'ghostel-exit-functions
-                     #'majutsu-diff-editor--ghostel-exit t))
-      (ignore-errors (kill-buffer buffer)))))
+  (majutsu-terminal-session--lifecycle-process session))
 
 (defun majutsu-diff-editor--abort-session-start (session)
   "Clean up SESSION after a non-local exit during startup.
@@ -374,38 +341,22 @@ inner Ghostel startup cleanup and the outer session-start cleanup."
 If a session-owned child exists, retain its workspace slot until completion:
 it may have exited just before its deferred callback runs.  A child that never
 received a completion owner is stopped and treated as an unknown outcome."
-  (let ((process (majutsu-diff-editor--session-lifecycle-process session)))
-    (when (and process (not (majutsu-diff-editor-session-process session)))
-      (setf (majutsu-diff-editor-session-process session) process))
-    (cond
-     ;; No child exists, so this is a pure setup failure.  The user selection
-     ;; remains valid and the slot can be released immediately.
-     ((not process)
-      (let ((inhibit-quit t))
-        (majutsu-diff-editor--cleanup-unstarted-terminal-buffer session)
-        (majutsu-diff-editor--unregister-session session)))
-     ;; Ghostel installs its exit hook before spawning.  Even a dead lifecycle
-     ;; process may already have queued that hook, so retain the slot.  Queue a
-     ;; duplicate-safe fallback only after the reaper is no longer live.
-     ((eq (majutsu-diff-editor-session-host session) 'ghostel)
-      (unless (and (processp process) (process-live-p process))
-        (run-at-time 0 nil #'majutsu-diff-editor--finish-ghostel-session
-                     session nil)))
-     ;; Only the process layer can publish completion ownership.  A callback
-     ;; property may already exist when filter or sentinel setup fails.
-     ((and (processp process)
-           (majutsu-process-completion-owned-p process))
-      nil)
-     ;; A child was created but setup was interrupted before it gained a
-     ;; completion owner.  It could have mutated the repo, so make selection
-     ;; state conservative before freeing the slot.
-     (t
-      (let ((inhibit-quit t))
-        (when (and (processp process) (process-live-p process))
-          (ignore-errors (delete-process process)))
-        (majutsu-diff-editor--cleanup-unstarted-terminal-buffer session)
-        (majutsu-diff-editor--invalidate-unowned-session session)
-        (majutsu-diff-editor--unregister-session session))))))
+  (if (eq (majutsu-diff-editor-session-host session) 'ghostel)
+      (majutsu-terminal-session--abort-start session)
+    (let ((process (majutsu-diff-editor--session-lifecycle-process session)))
+      (when (and process (not (majutsu-diff-editor-session-process session)))
+        (setf (majutsu-diff-editor-session-process session) process))
+      (cond
+       ((not process)
+        (majutsu-diff-editor--unregister-session session))
+       ((and (processp process)
+             (majutsu-process-completion-owned-p process)))
+       (t
+        (let ((inhibit-quit t))
+          (when (and (processp process) (process-live-p process))
+            (ignore-errors (delete-process process)))
+          (majutsu-diff-editor--invalidate-unowned-session session)
+          (majutsu-diff-editor--unregister-session session)))))))
 
 (defvar majutsu-diff-editor-session-exit-hook nil
   "Functions called after a Ghostel diff-editor session ends.
@@ -413,24 +364,13 @@ received a completion owner is stopped and treated as an unknown outcome."
 Each function receives SESSION and Ghostel's EVENT string.  It runs via a
 zero-delay timer, outside Ghostel's process sentinel.")
 
-(defun majutsu-diff-editor--refresh-origin (session)
-  "Refresh SESSION's live origin buffer after a repository state change."
-  (when-let* ((buffer (majutsu-diff-editor-session-origin-buffer session))
-              ((buffer-live-p buffer)))
-    (with-current-buffer buffer
-      (let ((default-directory
-             (majutsu-diff-editor-session-repository-root session)))
-        (when (derived-mode-p 'majutsu-mode)
-          (majutsu-refresh))))))
-
 (defun majutsu-diff-editor--invalidate-unowned-session (session)
   "Conservatively invalidate SESSION after unowned process setup fails."
-  ;; A child without a completion owner may have mutated the repository.
-  ;; Invalidate every selection for its root before releasing the slot.
-  (let ((inhibit-quit t))
-    (majutsu-interactive-invalidate-repository
-     (majutsu-diff-editor-session-repository-root session))
-    (run-at-time 0 nil #'majutsu-diff-editor--refresh-origin session)))
+  (majutsu-terminal-session--invalidate-unowned session))
+
+(defun majutsu-diff-editor--notify-exit (session event)
+  "Run diff-editor observers for SESSION after Ghostel EVENT."
+  (run-hook-with-args 'majutsu-diff-editor-session-exit-hook session event))
 
 (defun majutsu-diff-editor--complete-session
     (session &optional event unchanged-message)
@@ -438,23 +378,13 @@ zero-delay timer, outside Ghostel's process sentinel.")
 
 UNCHANGED-MESSAGE is displayed by the shared completion helper only when the
 repository operation id is unchanged."
-  (unless (majutsu-diff-editor-session-completed-p session)
-    (setf (majutsu-diff-editor-session-completed-p session) t)
-    (let (outcome)
-      (unwind-protect
-          (setq outcome
-                (majutsu-interactive-complete-repository-operation
-                 (majutsu-diff-editor-session-repository-root session)
-                 (majutsu-diff-editor-session-origin-buffer session)
-                 (majutsu-diff-editor-session-operation-id-before session)
-                 unchanged-message))
-        (majutsu-diff-editor--unregister-session session))
-      ;; Hooks are observers, not part of the transactional completion path.
-      ;; In particular they may immediately start another session for ROOT.
-      (when event
-        (run-hook-with-args 'majutsu-diff-editor-session-exit-hook
-                            session event))
-      outcome)))
+  (setf (majutsu-diff-editor-session-unchanged-message session)
+        unchanged-message)
+  (unless (or (majutsu-diff-editor-session-exit-function session)
+              (null event))
+    (setf (majutsu-diff-editor-session-exit-function session)
+          #'majutsu-diff-editor--notify-exit))
+  (majutsu-terminal-session--complete session event))
 
 (defun majutsu-diff-editor--finish-process-session (session exit-code)
   "Finish process-hosted SESSION after EXIT-CODE outside its sentinel."
@@ -470,45 +400,6 @@ repository operation id is unchanged."
         (majutsu-jj-append-filesets
          (majutsu-diff-editor-session-args session)
          (majutsu-diff-editor-session-filesets session))))
-
-(defun majutsu-diff-editor--terminal-buffer-name (session)
-  "Return a fresh Ghostel terminal buffer name for SESSION."
-  (format "*majutsu %s diff editor: %s*"
-          (majutsu-diff-editor-session-command session)
-          (abbreviate-file-name
-           (directory-file-name
-            (majutsu-diff-editor-session-repository-root session)))))
-
-(defun majutsu-diff-editor--finish-ghostel-session (session event)
-  "Run SESSION's Ghostel exit hook after EVENT outside its sentinel."
-  (majutsu-diff-editor--complete-session
-   session event "jj diff editor ended without a repository operation"))
-
-(defun majutsu-diff-editor--ghostel-exit (buffer event)
-  "Defer completion of BUFFER's diff-editor session after Ghostel EVENT."
-  (when (buffer-live-p buffer)
-    (when-let* ((session
-                 (buffer-local-value 'majutsu-diff-editor--session buffer)))
-      (run-at-time 0 nil #'majutsu-diff-editor--finish-ghostel-session
-                   session event))))
-
-(defun majutsu-diff-editor--terminal-buffer-killed ()
-  "Finish the session associated with a manually killed Ghostel buffer."
-  (when majutsu-diff-editor--session
-    (run-at-time 0 nil #'majutsu-diff-editor--finish-terminal-kill
-                 majutsu-diff-editor--session)))
-
-(defun majutsu-diff-editor--finish-terminal-kill (session)
-  "Complete SESSION after its Ghostel lifecycle process has stopped.
-
-Killing the terminal buffer first closes its display.  Ghostel's native
-reaper may still be waiting for jj to finish and record an operation, so do
-not compare operation ids until that lifecycle process has exited."
-  (let ((process (majutsu-diff-editor-session-process session)))
-    (if (and (processp process) (process-live-p process))
-        (run-at-time 0.05 nil #'majutsu-diff-editor--finish-terminal-kill
-                     session)
-      (majutsu-diff-editor--finish-ghostel-session session nil))))
 
 (defun majutsu-diff-editor--assert-ghostel-editor-support (root command args)
   "Signal unless Ghostel can support COMMAND with ARGS under ROOT.
@@ -550,7 +441,7 @@ filter."
       (process-put process 'majutsu-with-editor-tracker-installed t))))
 
 (defun majutsu-diff-editor--remote-ghostel-exec (buffer program args root)
-  "Run remote Ghostel in BUFFER and track editor packets from its first byte.
+  "Run remote PROGRAM with ARGS in Ghostel BUFFER under ROOT.
 
 Ghostel currently exposes the lifecycle process only after `ghostel-exec'
 returns.  Temporarily decorate the one remote PTY `make-process' call targeting
@@ -581,7 +472,7 @@ processes, is delegated untouched."
       (ghostel-exec buffer program args))))
 
 (defun majutsu-diff-editor--ghostel-exec (session buffer program args)
-  "Run Ghostel for SESSION and compose its remote editor tracker.
+  "Run PROGRAM with ARGS in Ghostel BUFFER for SESSION.
 
 Use Ghostel's returned public lifecycle process.  Its existing filter already
 combines Ghostel rendering with with-editor, so wrapping that filter preserves
@@ -598,6 +489,18 @@ their order while putting Majutsu's tracker first."
       (majutsu-diff-editor--install-remote-with-editor-tracker process root))
     process))
 
+(defun majutsu-diff-editor--terminal-exec (session buffer program args)
+  "Run diff-editor SESSION in BUFFER with PROGRAM and ARGS.
+
+Install with-editor before constructing Majutsu's process environment so both
+JJ_EDITOR and the user's jj environment reach the Ghostel child."
+  (let ((root (majutsu-diff-editor-session-repository-root session)))
+    (let ((default-directory root))
+      (majutsu-with-editor
+        (let ((process-environment (majutsu-process-environment args)))
+          (majutsu-diff-editor--ghostel-exec
+           session buffer program args))))))
+
 (defun majutsu-diff-editor--start-ghostel (session)
   "Start SESSION through Ghostel's public API and return SESSION."
   (let ((root (majutsu-diff-editor-session-repository-root session)))
@@ -605,49 +508,19 @@ their order while putting Majutsu's tracker first."
      root
      (majutsu-diff-editor-session-command session)
      (majutsu-diff-editor-session-args session))
-    (let* ((buffer (generate-new-buffer
-                    (majutsu-diff-editor--terminal-buffer-name session)))
-           (command (majutsu-diff-editor--session-jj-arguments session))
-           (args (let ((default-directory root))
-                   (majutsu-process-jj-arguments command)))
-           (program (let ((default-directory root))
-                      (majutsu-jj--executable))))
-      (let ((started nil))
-        (unwind-protect
-            (progn
-              (setf (majutsu-diff-editor-session-terminal-buffer session) buffer)
-              (with-current-buffer buffer
-                (setq default-directory root)
-                ;; `ghostel-exec' initializes a non-Ghostel buffer by enabling
-                ;; its major mode.  Major-mode activation clears ordinary
-                ;; buffer-local variables, so do that public initialization
-                ;; first; the session hook and retained transcript settings must
-                ;; be installed afterwards.
-                (ghostel-mode)
-                (setq default-directory root)
-                (setq-local majutsu-diff-editor--session session)
-                (add-hook 'kill-buffer-hook
-                          #'majutsu-diff-editor--terminal-buffer-killed nil t)
-                ;; Preserve the transcript, and install the hook before the child exists.
-                (setq-local ghostel-kill-buffer-on-exit nil)
-                (add-hook 'ghostel-exit-functions
-                          #'majutsu-diff-editor--ghostel-exit nil t))
-              ;; `ghostel-exec' uses an undisplayed buffer's 80x24 fallback,
-              ;; which is unsuitable for jj's full-screen built-in editor.
-              (majutsu-display-buffer buffer)
-              (let ((default-directory root))
-                (majutsu-with-editor
-                  ;; `majutsu-with-editor' has installed JJ_EDITOR in the dynamic
-                  ;; environment.  Build Majutsu's normal jj environment after
-                  ;; that, so Ghostel inherits both JJ_EDITOR and user overrides.
-                  (let ((process-environment (majutsu-process-environment args)))
-                    (setf (majutsu-diff-editor-session-process session)
-                          (majutsu-diff-editor--ghostel-exec
-                           session buffer program args))))
-                (setq started t)
-                session))
-          (unless started
-            (majutsu-diff-editor--abort-session-start session)))))))
+    (setf (majutsu-diff-editor-session-argv session)
+          (majutsu-diff-editor--session-jj-arguments session)
+          (majutsu-diff-editor-session-title session)
+          (format "%s diff editor"
+                  (majutsu-diff-editor-session-command session))
+          (majutsu-diff-editor-session-unchanged-message session)
+          "jj diff editor ended without a repository operation"
+          (majutsu-diff-editor-session-exec-function session)
+          #'majutsu-diff-editor--terminal-exec
+          (majutsu-diff-editor-session-exit-function session)
+          #'majutsu-diff-editor--notify-exit
+          (majutsu-diff-editor-session-terminal-p session) t)
+    (majutsu-terminal-session--start session)))
 
 (defun majutsu-diff-editor--start-process (session)
   "Start SESSION in Majutsu's ordinary asynchronous process buffer."
@@ -696,17 +569,19 @@ current buffer does.  Return a `majutsu-diff-editor-session'."
            :origin-buffer origin-buffer
            :repository-root (file-name-as-directory root)
            :host (let ((default-directory (file-name-as-directory root)))
-                   (majutsu-diff-editor-select-host command args))
-           :operation-id-before
-           (majutsu-jj-operation-id (file-name-as-directory root)))))
+                   (majutsu-diff-editor-select-host command args)))))
     (majutsu-diff-editor--register-session session)
     (let ((started nil))
       (unwind-protect
-          (prog1
-              (pcase (majutsu-diff-editor-session-host session)
-                ('ghostel (majutsu-diff-editor--start-ghostel session))
-                ('process (majutsu-diff-editor--start-process session)))
-            (setq started t))
+          (progn
+            (setf (majutsu-diff-editor-session-operation-id-before session)
+                  (majutsu-jj-operation-id
+                   (majutsu-diff-editor-session-repository-root session)))
+            (prog1
+                (pcase (majutsu-diff-editor-session-host session)
+                  ('ghostel (majutsu-diff-editor--start-ghostel session))
+                  ('process (majutsu-diff-editor--start-process session)))
+              (setq started t)))
         (unless started
           (majutsu-diff-editor--abort-session-start session))))))
 

--- a/majutsu-terminal-session.el
+++ b/majutsu-terminal-session.el
@@ -1,0 +1,294 @@
+;;; majutsu-terminal-session.el --- Host interactive jj terminal sessions  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 0WD0
+
+;; Author: 0WD0 <me@0wd0.com>
+;; Maintainer: 0WD0 <me@0wd0.com>
+;; Keywords: tools, vc
+;; URL: https://github.com/0WD0/majutsu
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; Shared Ghostel hosting and repository completion for interactive jj
+;; terminal sessions.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'majutsu-jj)
+(require 'majutsu-process)
+(require 'majutsu-interactive)
+
+(declare-function ghostel-exec "ghostel" (buffer program &optional args))
+(declare-function ghostel-mode "ghostel" ())
+(declare-function majutsu-interactive-complete-repository-operation
+                  "majutsu-interactive"
+                  (root origin-buffer operation-before
+                        &optional unchanged-message))
+
+(defvar ghostel-exit-functions)
+(defvar ghostel-kill-buffer-on-exit)
+
+(cl-defstruct (majutsu-terminal-session
+               (:constructor majutsu-terminal-session-create))
+  "A running interactive jj terminal session."
+  argv origin-buffer repository-root title
+  terminal-buffer process operation-id-before completed-p
+  unchanged-message exec-function exit-function terminal-p)
+
+(defvar-local majutsu-terminal-session--session nil
+  "The `majutsu-terminal-session' associated with this terminal buffer.")
+
+(defvar majutsu-terminal-session--live-sessions (make-hash-table :test 'equal)
+  "Majutsu-owned interactive sessions indexed by workspace root.")
+
+(defvar majutsu-terminal-session-exit-hook nil
+  "Functions called after a Ghostel terminal session completes.
+
+Each function receives the completed SESSION and Ghostel EVENT.  EVENT is nil
+when completion follows a manual buffer kill or a startup fallback.  The hook
+runs via a zero-delay timer, outside Ghostel's process sentinel.")
+
+(defun majutsu-terminal-session-available-p ()
+  "Return non-nil when Ghostel's public execution API is available."
+  (and (require 'ghostel nil t)
+       (fboundp 'ghostel-exec)
+       (fboundp 'ghostel-mode)))
+
+(defun majutsu-terminal-session-register (root owner)
+  "Reserve ROOT for OWNER, or signal when another session owns it."
+  (when (gethash root majutsu-terminal-session--live-sessions)
+    (user-error "An interactive jj session is already active for this workspace"))
+  (puthash root owner majutsu-terminal-session--live-sessions))
+
+(defun majutsu-terminal-session-unregister (root owner)
+  "Release ROOT when OWNER still owns its interactive-session slot."
+  (when (eq (gethash root majutsu-terminal-session--live-sessions) owner)
+    (remhash root majutsu-terminal-session--live-sessions)))
+
+(defun majutsu-terminal-session--unregister (session)
+  "Release SESSION's workspace slot if SESSION still owns it."
+  (majutsu-terminal-session-unregister
+   (majutsu-terminal-session-repository-root session) session))
+
+(defun majutsu-terminal-session--lifecycle-process (session)
+  "Return SESSION's known lifecycle process, if one has been created."
+  (or (majutsu-terminal-session-process session)
+      (when-let* ((buffer (majutsu-terminal-session-terminal-buffer session))
+                  ((buffer-live-p buffer)))
+        (get-buffer-process buffer))))
+
+(defun majutsu-terminal-session--cleanup-unstarted-buffer (session)
+  "Quietly remove SESSION's terminal buffer before its child starts."
+  (when-let* ((buffer (majutsu-terminal-session-terminal-buffer session))
+              ((buffer-live-p buffer)))
+    (let ((inhibit-quit t))
+      (with-current-buffer buffer
+        (setq-local majutsu-terminal-session--session nil)
+        (remove-hook 'kill-buffer-hook
+                     #'majutsu-terminal-session--buffer-killed t)
+        (remove-hook 'ghostel-exit-functions
+                     #'majutsu-terminal-session--ghostel-exit t))
+      (ignore-errors (kill-buffer buffer)))))
+
+(defun majutsu-terminal-session--refresh-origin (session)
+  "Refresh SESSION's live origin buffer after a repository state change."
+  (when-let* ((buffer (majutsu-terminal-session-origin-buffer session))
+              ((buffer-live-p buffer)))
+    (with-current-buffer buffer
+      (let ((default-directory
+             (majutsu-terminal-session-repository-root session)))
+        (when (derived-mode-p 'majutsu-mode)
+          (majutsu-refresh))))))
+
+(defun majutsu-terminal-session--invalidate-unowned (session)
+  "Conservatively invalidate SESSION after an unowned child setup failure."
+  (let ((inhibit-quit t))
+    (majutsu-interactive-invalidate-repository
+     (majutsu-terminal-session-repository-root session))
+    (run-at-time 0 nil #'majutsu-terminal-session--refresh-origin session)))
+
+(defun majutsu-terminal-session--abort-start (session)
+  "Clean up SESSION after a non-local exit during startup.
+
+If a child exists, retain its workspace slot until its lifecycle process has
+finished because it may already have changed the repository."
+  (let ((process (majutsu-terminal-session--lifecycle-process session)))
+    (when (and process (not (majutsu-terminal-session-process session)))
+      (setf (majutsu-terminal-session-process session) process))
+    (cond
+     ((not process)
+      (let ((inhibit-quit t))
+        (majutsu-terminal-session--cleanup-unstarted-buffer session)
+        (majutsu-terminal-session--unregister session)))
+     ((and (processp process) (process-live-p process)))
+     (t
+      ;; The Ghostel exit hook may already be queued.  This duplicate-safe
+      ;; fallback also covers a non-local exit after a fast child termination.
+      (run-at-time 0 nil #'majutsu-terminal-session--finish session nil)))))
+
+(defun majutsu-terminal-session--complete (session &optional event)
+  "Complete SESSION once after Ghostel EVENT using repository freshness."
+  (unless (majutsu-terminal-session-completed-p session)
+    (setf (majutsu-terminal-session-completed-p session) t)
+    (let (outcome)
+      (unwind-protect
+          (setq outcome
+                (majutsu-interactive-complete-repository-operation
+                 (majutsu-terminal-session-repository-root session)
+                 (majutsu-terminal-session-origin-buffer session)
+                 (majutsu-terminal-session-operation-id-before session)
+                 (majutsu-terminal-session-unchanged-message session)))
+        (majutsu-terminal-session--unregister session)
+        ;; Completion observers run after releasing the slot, so they may
+        ;; start the next session immediately.  They stay in the cleanup:
+        ;; the completion probe can fail (a TRAMP refresh error, say), the
+        ;; completed-p latch means nothing retries this session, and the
+        ;; hooks promise to run once per session either way.
+        (with-demoted-errors "majutsu-terminal-session exit function: %S"
+          (when-let* ((function
+                       (majutsu-terminal-session-exit-function session)))
+            (funcall function session event)))
+        (when (majutsu-terminal-session-terminal-p session)
+          (with-demoted-errors "majutsu-terminal-session exit hook: %S"
+            (run-hook-with-args 'majutsu-terminal-session-exit-hook
+                                session event))))
+      outcome)))
+
+(defun majutsu-terminal-session--finish (session event)
+  "Finish SESSION after Ghostel EVENT outside its process sentinel."
+  (majutsu-terminal-session--complete session event))
+
+(defun majutsu-terminal-session--ghostel-exit (buffer event)
+  "Defer completion of BUFFER's terminal session after Ghostel EVENT."
+  (when (buffer-live-p buffer)
+    (when-let* ((session
+                 (buffer-local-value 'majutsu-terminal-session--session
+                                     buffer)))
+      (run-at-time 0 nil #'majutsu-terminal-session--finish session event))))
+
+(defun majutsu-terminal-session--buffer-killed ()
+  "Finish the session associated with a manually killed terminal buffer."
+  (when majutsu-terminal-session--session
+    (run-at-time 0 nil #'majutsu-terminal-session--finish-after-kill
+                 majutsu-terminal-session--session)))
+
+(defun majutsu-terminal-session--finish-after-kill (session)
+  "Complete SESSION once its Ghostel lifecycle process has stopped."
+  (let ((process (majutsu-terminal-session-process session)))
+    (if (and (processp process) (process-live-p process))
+        (run-at-time 0.05 nil #'majutsu-terminal-session--finish-after-kill
+                     session)
+      (majutsu-terminal-session--finish session nil))))
+
+(defun majutsu-terminal-session--buffer-name (session)
+  "Return a fresh Ghostel buffer name for SESSION."
+  (format "*majutsu %s: %s*"
+          (majutsu-terminal-session-title session)
+          (abbreviate-file-name
+           (directory-file-name
+            (majutsu-terminal-session-repository-root session)))))
+
+(defun majutsu-terminal-session--default-exec
+    (_session buffer program args)
+  "Run PROGRAM with ARGS in BUFFER through Ghostel."
+  (let ((process-environment (majutsu-process-environment args)))
+    (ghostel-exec buffer program args)))
+
+(defun majutsu-terminal-session--start (session)
+  "Start SESSION through Ghostel's public API and return SESSION."
+  (let* ((root (majutsu-terminal-session-repository-root session))
+         (buffer (generate-new-buffer
+                  (majutsu-terminal-session--buffer-name session)))
+         (argv (majutsu-terminal-session-argv session))
+         (args (let ((default-directory root))
+                 (majutsu-process-jj-arguments argv)))
+         (program (let ((default-directory root))
+                    (majutsu-jj--executable))))
+    (setf (majutsu-terminal-session-terminal-buffer session) buffer)
+    (with-current-buffer buffer
+      (setq default-directory root)
+      ;; Major-mode activation clears ordinary buffer-local values.
+      (ghostel-mode)
+      (setq default-directory root)
+      (setq-local majutsu-terminal-session--session session)
+      (add-hook 'kill-buffer-hook
+                #'majutsu-terminal-session--buffer-killed nil t)
+      (setq-local ghostel-kill-buffer-on-exit nil)
+      (add-hook 'ghostel-exit-functions
+                #'majutsu-terminal-session--ghostel-exit nil t))
+    ;; Ghostel sizes an undisplayed buffer as 80x24.  Display it before
+    ;; spawning full-screen TUIs so their first frame has real geometry.
+    (majutsu-display-buffer buffer)
+    (let* ((default-directory root)
+           (candidate
+            (funcall
+             (or (majutsu-terminal-session-exec-function session)
+                 #'majutsu-terminal-session--default-exec)
+             session buffer program args))
+           (process (or (and (processp candidate) candidate)
+                        (get-buffer-process buffer))))
+      (unless (processp process)
+        (error "Terminal execution did not create a lifecycle process"))
+      (setf (majutsu-terminal-session-process session) process))
+    session))
+
+(defun majutsu-terminal-session--repository-root (origin-buffer)
+  "Return the repository root associated with ORIGIN-BUFFER."
+  (if (buffer-live-p origin-buffer)
+      (with-current-buffer origin-buffer
+        (or (majutsu--buffer-root origin-buffer)
+            (majutsu--toplevel-safe default-directory)))
+    (majutsu--toplevel-safe default-directory)))
+
+;;;###autoload
+(cl-defun majutsu-terminal-session-start-jj
+    (argv &key origin-buffer title unchanged-message exec-function
+          exit-function)
+  "Start interactive jj ARGV in a Ghostel terminal.
+
+ORIGIN-BUFFER supplies the repository context and is refreshed when jj records
+an operation.  TITLE names the terminal buffer.  UNCHANGED-MESSAGE is shown
+only when the repository operation id remains unchanged.  EXEC-FUNCTION, when
+non-nil, is called with SESSION, BUFFER, PROGRAM, and fully prepared ARGS.
+EXIT-FUNCTION receives SESSION and Ghostel's EVENT after completion; EVENT can
+be nil when no exit event is available."
+  (unless (and (proper-list-p argv)
+               argv
+               (cl-every #'stringp argv))
+    (user-error "A nonempty jj argument list is required"))
+  ;; Refuse before probing jj or creating a terminal buffer.  A pipe is not a
+  ;; safe fallback for full-screen commands such as `jj arrange'.
+  (unless (majutsu-terminal-session-available-p)
+    (user-error "Ghostel is required for interactive jj terminal sessions"))
+  (let* ((origin-buffer (or origin-buffer (current-buffer)))
+         (root (file-name-as-directory
+                (majutsu-terminal-session--repository-root origin-buffer)))
+         (session
+          (majutsu-terminal-session-create
+           :argv (copy-sequence argv)
+           :origin-buffer origin-buffer
+           :repository-root root
+           :title (or title (car argv))
+           :unchanged-message unchanged-message
+           :exec-function exec-function
+           :exit-function exit-function
+           :terminal-p t)))
+    (majutsu-terminal-session-register root session)
+    (let ((started nil))
+      (unwind-protect
+          (progn
+            ;; Capture this only after owning the workspace slot and before jj's
+            ;; workspace helper gets a chance to snapshot the working copy.
+            (setf (majutsu-terminal-session-operation-id-before session)
+                  (majutsu-jj-operation-id root))
+            (prog1 (majutsu-terminal-session--start session)
+              (setq started t)))
+        (unless started
+          (majutsu-terminal-session--abort-start session))))))
+
+;;; _
+(provide 'majutsu-terminal-session)
+;;; majutsu-terminal-session.el ends here

--- a/test/majutsu-diff-editor-test.el
+++ b/test/majutsu-diff-editor-test.el
@@ -411,6 +411,8 @@
                     ((symbol-function 'majutsu-display-buffer)
                      (lambda (buffer)
                        (set-window-buffer (selected-window) buffer)))
+                    ((symbol-function 'processp)
+                     (lambda (value) (eq value 'ghostel-process)))
                     ((symbol-function 'ghostel-exec)
                      (lambda (buffer program args)
                        (with-current-buffer buffer
@@ -423,7 +425,7 @@
                                      :environment process-environment
                                      :kill-on-exit ghostel-kill-buffer-on-exit
                                      :exit-hook
-                                     (memq #'majutsu-diff-editor--ghostel-exit
+                                     (memq #'majutsu-terminal-session--ghostel-exit
                                            ghostel-exit-functions))))
                        'ghostel-process)))
             (let ((session
@@ -446,12 +448,12 @@
               (should-not (plist-get seen :kill-on-exit))
               (should (plist-get seen :exit-hook))
               (with-current-buffer terminal
-                (should (eq majutsu-diff-editor--session session)))))
+                (should (eq majutsu-terminal-session--session session)))))
           (when (buffer-live-p terminal)
             (with-current-buffer terminal
-              (setq-local majutsu-diff-editor--session nil)
+              (setq-local majutsu-terminal-session--session nil)
               (remove-hook 'kill-buffer-hook
-                           #'majutsu-diff-editor--terminal-buffer-killed t))
+                           #'majutsu-terminal-session--buffer-killed t))
             (kill-buffer terminal)))))))
 
 (ert-deftest majutsu-diff-editor-start/process-uses-session-aware-runner ()
@@ -610,67 +612,9 @@
                  (gethash root majutsu-diff-editor--live-sessions))
                 (should (equal invalidated root))
                 (should (equal (nth 2 scheduled)
-                               #'majutsu-diff-editor--refresh-origin)))))
+                               #'majutsu-terminal-session--refresh-origin)))))
         (when (and (processp process) (process-live-p process))
           (delete-process process))))))
-
-(ert-deftest majutsu-diff-editor-finish-terminal-kill/waits-for-live-reaper ()
-  "Do not compare operation ids until Ghostel's reaper has exited."
-  (let ((session (majutsu-diff-editor-session-create :process 'reaper))
-        scheduled completed)
-    (cl-letf (((symbol-function 'processp) (lambda (_process) t))
-              ((symbol-function 'process-live-p) (lambda (_process) t))
-              ((symbol-function 'run-at-time)
-               (lambda (&rest args) (setq scheduled args)))
-              ((symbol-function 'majutsu-diff-editor--complete-session)
-               (lambda (&rest _) (setq completed t))))
-      (majutsu-diff-editor--finish-terminal-kill session)
-      (should-not completed)
-      (should (equal scheduled
-                     (list 0.05 nil
-                           #'majutsu-diff-editor--finish-terminal-kill
-                           session))))))
-
-(ert-deftest majutsu-diff-editor-finish-terminal-kill/completes-after-reaper ()
-  "A stopped lifecycle process completes the session immediately."
-  (let ((session (majutsu-diff-editor-session-create :process 'reaper))
-        completed)
-    (cl-letf (((symbol-function 'processp) (lambda (_process) t))
-              ((symbol-function 'process-live-p) (lambda (_process) nil))
-              ((symbol-function 'majutsu-diff-editor--complete-session)
-               (lambda (value &rest _) (setq completed value))))
-      (majutsu-diff-editor--finish-terminal-kill session)
-      (should (eq completed session)))))
-
-(ert-deftest majutsu-diff-editor-ghostel-exit/defers-event-without-exit-status ()
-  "Ghostel completion uses its event and never interprets a process status."
-  (let* ((buffer (generate-new-buffer " *majutsu-ghostel-exit*"))
-         (session (majutsu-diff-editor-session-create
-                   :repository-root "/repo/"))
-         scheduled
-         completed)
-    (unwind-protect
-        (progn
-          (with-current-buffer buffer
-            (setq-local majutsu-diff-editor--session session))
-          (cl-letf (((symbol-function 'run-at-time)
-                     (lambda (&rest args) (setq scheduled args))))
-            (majutsu-diff-editor--ghostel-exit buffer "finished\n"))
-          (should (equal scheduled
-                         (list 0 nil
-                               #'majutsu-diff-editor--finish-ghostel-session
-                               session "finished\n")))
-          (cl-letf (((symbol-function 'process-exit-status)
-                     (lambda (&rest _)
-                       (ert-fail "Ghostel completion read process status")))
-                    ((symbol-function 'majutsu-diff-editor--complete-session)
-                     (lambda (&rest args) (setq completed args))))
-            (apply (nth 2 scheduled) (nthcdr 3 scheduled)))
-          (should (equal completed
-                         (list session "finished\n"
-                               "jj diff editor ended without a repository operation"))))
-      (when (buffer-live-p buffer)
-        (kill-buffer buffer)))))
 
 (ert-deftest majutsu-diff-editor-complete-session/delegates-repository-freshness ()
   "Use the shared repository-wide completion contract."

--- a/test/majutsu-terminal-session-test.el
+++ b/test/majutsu-terminal-session-test.el
@@ -1,0 +1,454 @@
+;;; majutsu-terminal-session-test.el --- Tests for jj terminal sessions  -*- lexical-binding: t; -*-
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; Focused tests for Ghostel hosting, repository locking, and completion.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'majutsu-terminal-session)
+(require 'majutsu-diff-editor)
+
+(ert-deftest majutsu-terminal-session-struct/exposes-lifecycle-state ()
+  "The generic session records all state needed by terminal adapters."
+  (let* ((origin (current-buffer))
+         (exec #'ignore)
+         (exit #'ignore)
+         (session
+          (majutsu-terminal-session-create
+           :argv '("arrange" "mine()")
+           :origin-buffer origin
+           :repository-root "/repo/"
+           :title "arrange"
+           :terminal-buffer origin
+           :process 'process
+           :operation-id-before "before"
+           :completed-p t
+           :unchanged-message "unchanged"
+           :exec-function exec
+           :exit-function exit
+           :terminal-p t)))
+    (should (equal (majutsu-terminal-session-argv session)
+                   '("arrange" "mine()")))
+    (should (eq (majutsu-terminal-session-origin-buffer session) origin))
+    (should (equal (majutsu-terminal-session-repository-root session)
+                   "/repo/"))
+    (should (equal (majutsu-terminal-session-title session) "arrange"))
+    (should (eq (majutsu-terminal-session-terminal-buffer session) origin))
+    (should (eq (majutsu-terminal-session-process session) 'process))
+    (should (equal (majutsu-terminal-session-operation-id-before session)
+                   "before"))
+    (should (majutsu-terminal-session-completed-p session))
+    (should (equal (majutsu-terminal-session-unchanged-message session)
+                   "unchanged"))
+    (should (eq (majutsu-terminal-session-exec-function session) exec))
+    (should (eq (majutsu-terminal-session-exit-function session) exit))
+    (should (majutsu-terminal-session-terminal-p session))))
+
+(ert-deftest majutsu-terminal-session-available-p/requires-public-ghostel-api ()
+  "Availability depends on Ghostel and both public entry points."
+  (cl-letf (((symbol-function 'require)
+             (lambda (feature &optional _filename _noerror)
+               (eq feature 'ghostel)))
+            ((symbol-function 'ghostel-exec) #'ignore)
+            ((symbol-function 'ghostel-mode) #'ignore))
+    (should (majutsu-terminal-session-available-p)))
+  (cl-letf (((symbol-function 'require) (lambda (&rest _) nil)))
+    (should-not (majutsu-terminal-session-available-p))))
+
+(ert-deftest majutsu-terminal-session-start-jj/rejects-before-repository-probe ()
+  "Missing Ghostel fails before probing jj or creating a terminal buffer."
+  (let ((before (buffer-list)))
+    (cl-letf (((symbol-function 'majutsu-terminal-session-available-p)
+               (lambda () nil))
+              ((symbol-function 'majutsu--toplevel-safe)
+               (lambda (&rest _)
+                 (ert-fail "Repository root was probed")))
+              ((symbol-function 'majutsu-jj-operation-id)
+               (lambda (&rest _)
+                 (ert-fail "Operation id was probed"))))
+      (should-error
+       (majutsu-terminal-session-start-jj '("arrange"))
+       :type 'user-error))
+    (should (equal (buffer-list) before))))
+
+(ert-deftest majutsu-terminal-session-start-jj/rejects-invalid-argv ()
+  "Only a nonempty proper list of jj argument strings is accepted."
+  (dolist (argv '(nil "arrange" ("arrange" 1) ("arrange" . "@")))
+    (should-error
+     (majutsu-terminal-session-start-jj argv)
+     :type 'user-error)))
+
+(ert-deftest majutsu-terminal-session-start-jj/preserves-tramp-root-and-argv ()
+  "Remote roots stay remote and jj arguments remain separate tokens."
+  (let ((root "/ssh:guix:/tmp/majutsu-arrange/")
+        (majutsu-terminal-session--live-sessions
+         (make-hash-table :test 'equal))
+        terminal session seen)
+    (unwind-protect
+        (with-temp-buffer
+          (let ((origin (current-buffer))
+                (default-directory "/ssh:guix:/tmp/majutsu-arrange/subdir/"))
+            (cl-letf
+                (((symbol-function 'majutsu-terminal-session-available-p)
+                  (lambda () t))
+                 ((symbol-function 'majutsu--buffer-root)
+                  (lambda (&optional _buffer) root))
+                 ((symbol-function 'majutsu-jj-operation-id)
+                  (lambda (directory &optional _snapshot)
+                    (should (equal directory root))
+                    (should
+                     (gethash root majutsu-terminal-session--live-sessions))
+                    "before"))
+                 ((symbol-function 'majutsu-jj--executable)
+                  (lambda () "jj"))
+                 ((symbol-function 'majutsu-process-jj-arguments)
+                  (lambda (args) (cons "--global" args)))
+                 ((symbol-function 'ghostel-mode)
+                  (lambda ()
+                    (kill-all-local-variables)
+                    (setq major-mode 'ghostel-mode)
+                    (setq-local ghostel-exit-functions nil)
+                    (setq-local ghostel-kill-buffer-on-exit t)))
+                 ((symbol-function 'majutsu-display-buffer) #'ignore)
+                 ((symbol-function 'processp)
+                  (lambda (value) (eq value 'ghostel-process))))
+              (setq
+               session
+               (majutsu-terminal-session-start-jj
+                '("arrange" "roots(foo)" "bar | baz")
+                :origin-buffer origin
+                :title "arrange"
+                :unchanged-message "unchanged"
+                :exec-function
+                (lambda (value buffer program args)
+                  (setq terminal buffer
+                        seen (list value program args default-directory))
+                  'ghostel-process)))
+              (should (eq (car seen) session))
+              (should (equal (nth 1 seen) "jj"))
+              (should (equal (nth 2 seen)
+                             '("--global" "arrange" "roots(foo)"
+                               "bar | baz")))
+              (should (equal (nth 3 seen) root))
+              (should (equal (majutsu-terminal-session-argv session)
+                             '("arrange" "roots(foo)" "bar | baz")))
+              (should (equal
+                       (majutsu-terminal-session-repository-root session)
+                       root))
+              (should (equal
+                       (buffer-local-value 'default-directory terminal)
+                       root))
+              (should (equal
+                       (majutsu-terminal-session-operation-id-before session)
+                       "before"))
+              (should (eq (majutsu-terminal-session-process session)
+                          'ghostel-process)))))
+      (when session
+        (majutsu-terminal-session-unregister root session))
+      (when (buffer-live-p terminal)
+        (with-current-buffer terminal
+          (setq-local majutsu-terminal-session--session nil)
+          (setq-local kill-buffer-hook nil)
+          (setq-local ghostel-exit-functions nil))
+        (kill-buffer terminal)))))
+
+(ert-deftest majutsu-terminal-session-default-exec/does-not-install-jj-editor ()
+  "A generic TUI inherits Majutsu's environment without with-editor setup."
+  (let (seen-environment seen-args)
+    (cl-letf (((symbol-function 'majutsu-process-environment)
+               (lambda (args)
+                 (should (equal args '("arrange")))
+                 '("INSIDE_EMACS=test" "TERM=xterm-ghostel")))
+              ((symbol-function 'ghostel-exec)
+               (lambda (_buffer _program args)
+                 (setq seen-environment process-environment
+                       seen-args args)
+                 'process)))
+      (should
+       (eq (majutsu-terminal-session--default-exec
+            (majutsu-terminal-session-create)
+            (current-buffer) "jj" '("arrange"))
+           'process))
+      (should (equal seen-args '("arrange")))
+      (should (equal seen-environment
+                     '("INSIDE_EMACS=test" "TERM=xterm-ghostel")))
+      (should-not
+       (seq-some (lambda (entry) (string-prefix-p "JJ_EDITOR=" entry))
+                 seen-environment)))))
+
+(ert-deftest majutsu-terminal-session-start-jj/default-path-does-not-install-jj-editor ()
+  "The public generic start path does not opt into the editor protocol."
+  (let ((majutsu-terminal-session--live-sessions
+         (make-hash-table :test 'equal))
+        terminal session seen-environment)
+    (unwind-protect
+        (with-temp-buffer
+          (let ((origin (current-buffer)))
+            (cl-letf
+                (((symbol-function 'majutsu-terminal-session-available-p)
+                  (lambda () t))
+                 ((symbol-function 'majutsu--buffer-root)
+                  (lambda (&optional _buffer) "/repo/"))
+                 ((symbol-function 'majutsu-jj-operation-id)
+                  (lambda (&rest _) "before"))
+                 ((symbol-function 'majutsu-jj--executable)
+                  (lambda () "jj"))
+                 ((symbol-function 'majutsu-process-jj-arguments)
+                  (lambda (args) args))
+                 ((symbol-function 'majutsu-process-environment)
+                  (lambda (_args)
+                    '("INSIDE_EMACS=test" "TERM=xterm-ghostel")))
+                 ((symbol-function 'ghostel-mode)
+                  (lambda ()
+                    (kill-all-local-variables)
+                    (setq major-mode 'ghostel-mode)
+                    (setq-local ghostel-exit-functions nil)
+                    (setq-local ghostel-kill-buffer-on-exit t)))
+                 ((symbol-function 'majutsu-display-buffer) #'ignore)
+                 ((symbol-function 'ghostel-exec)
+                  (lambda (buffer _program _args)
+                    (setq terminal buffer
+                          seen-environment process-environment)
+                    'ghostel-process))
+                 ((symbol-function 'processp)
+                  (lambda (value) (eq value 'ghostel-process))))
+              (setq session
+                    (majutsu-terminal-session-start-jj
+                     '("arrange") :origin-buffer origin))
+              (should (equal seen-environment
+                             '("INSIDE_EMACS=test" "TERM=xterm-ghostel")))
+              (should-not
+               (seq-some
+                (lambda (entry) (string-prefix-p "JJ_EDITOR=" entry))
+                seen-environment)))))
+      (when session
+        (majutsu-terminal-session-unregister "/repo/" session))
+      (when (buffer-live-p terminal)
+        (with-current-buffer terminal
+          (setq-local majutsu-terminal-session--session nil)
+          (setq-local kill-buffer-hook nil)
+          (setq-local ghostel-exit-functions nil))
+        (kill-buffer terminal)))))
+
+(ert-deftest majutsu-terminal-session-register/is-an-owner-aware-workspace-mutex ()
+  "Only the current owner can release a workspace's shared terminal slot."
+  (let ((majutsu-terminal-session--live-sessions
+         (make-hash-table :test 'equal))
+        (first (list 'first))
+        (second (list 'second)))
+    (majutsu-terminal-session-register "/repo/" first)
+    (should-error
+     (majutsu-terminal-session-register "/repo/" second)
+     :type 'user-error)
+    (majutsu-terminal-session-unregister "/repo/" second)
+    (should (eq (gethash "/repo/"
+                         majutsu-terminal-session--live-sessions)
+                first))
+    (majutsu-terminal-session-unregister "/repo/" first)
+    (should-not (gethash "/repo/"
+                         majutsu-terminal-session--live-sessions))))
+
+(ert-deftest majutsu-terminal-session-register/is-shared-with-diff-editor ()
+  "Arrange and diff-editor sessions contend for the same workspace slot."
+  (let ((majutsu-terminal-session--live-sessions
+         (make-hash-table :test 'equal))
+        ;; If the legacy table still exists, isolate it so this test cannot
+        ;; accidentally pass due to state left by another test.
+        (majutsu-diff-editor--live-sessions
+         (make-hash-table :test 'equal))
+        (terminal-owner (list 'arrange))
+        (diff-owner
+         (majutsu-diff-editor-session-create :repository-root "/repo/")))
+    (majutsu-terminal-session-register "/repo/" terminal-owner)
+    (should-error
+     (majutsu-diff-editor--register-session diff-owner)
+     :type 'user-error)
+    (majutsu-terminal-session-unregister "/repo/" terminal-owner)
+    (majutsu-diff-editor--register-session diff-owner)
+    (should (eq (gethash "/repo/"
+                         majutsu-terminal-session--live-sessions)
+                diff-owner))
+    (majutsu-diff-editor--unregister-session diff-owner)
+    (should-not (gethash "/repo/"
+                         majutsu-terminal-session--live-sessions))))
+
+(ert-deftest majutsu-terminal-session-complete/is-atomic-and-releases-before-observers ()
+  "Freshness is checked once and observers run after mutex release."
+  (let* ((majutsu-terminal-session--live-sessions
+          (make-hash-table :test 'equal))
+         (completion-count 0)
+         (exit-count 0)
+         observer-owner
+         (session
+          (majutsu-terminal-session-create
+           :repository-root "/repo/"
+           :operation-id-before "before"
+           :unchanged-message "unchanged"
+           :exit-function
+           (lambda (_session _event)
+             (setq exit-count (1+ exit-count)
+                   observer-owner
+                   (gethash "/repo/"
+                            majutsu-terminal-session--live-sessions))))))
+    (majutsu-terminal-session-register "/repo/" session)
+    (cl-letf (((symbol-function
+                'majutsu-interactive-complete-repository-operation)
+               (lambda (&rest args)
+                 (setq completion-count (1+ completion-count))
+                 (should (equal args
+                                '("/repo/" nil "before" "unchanged")))
+                 'unchanged)))
+      (should (eq (majutsu-terminal-session--complete session "finished")
+                  'unchanged))
+      (should-not (majutsu-terminal-session--complete session "duplicate")))
+    (should (= completion-count 1))
+    (should (= exit-count 1))
+    (should-not observer-owner)
+    (should (majutsu-terminal-session-completed-p session))
+    (should-not (gethash "/repo/"
+                         majutsu-terminal-session--live-sessions))))
+
+(ert-deftest majutsu-terminal-session-complete/notifies-terminal-kill-once ()
+  "Terminal observers run once even when completion has no Ghostel event."
+  (let* ((majutsu-terminal-session--live-sessions
+          (make-hash-table :test 'equal))
+         exit-events hook-events
+         (session
+          (majutsu-terminal-session-create
+           :repository-root "/repo/"
+           :terminal-p t
+           :exit-function
+           (lambda (_session event) (push event exit-events)))))
+    (majutsu-terminal-session-register "/repo/" session)
+    (let ((majutsu-terminal-session-exit-hook
+           (list (lambda (_session event) (push event hook-events)))))
+      (cl-letf (((symbol-function
+                  'majutsu-interactive-complete-repository-operation)
+                 (lambda (&rest _) 'unchanged)))
+        (should (eq (majutsu-terminal-session--complete session nil)
+                    'unchanged))
+        (should-not (majutsu-terminal-session--complete session nil))))
+    (should (equal exit-events '(nil)))
+    (should (equal hook-events '(nil)))))
+
+(ert-deftest majutsu-terminal-session-start-jj/rejects-missing-lifecycle-process ()
+  "A broken exec adapter cannot strand its buffer or workspace mutex."
+  (let ((majutsu-terminal-session--live-sessions
+         (make-hash-table :test 'equal))
+        terminal)
+    (with-temp-buffer
+      (let ((origin (current-buffer)))
+        (cl-letf (((symbol-function 'majutsu-terminal-session-available-p)
+                   (lambda () t))
+                  ((symbol-function 'majutsu--buffer-root)
+                   (lambda (&optional _buffer) "/repo/"))
+                  ((symbol-function 'majutsu-jj-operation-id)
+                   (lambda (&rest _) "before"))
+                  ((symbol-function 'majutsu-jj--executable)
+                   (lambda () "jj"))
+                  ((symbol-function 'majutsu-process-jj-arguments) #'identity)
+                  ((symbol-function 'ghostel-mode)
+                   (lambda ()
+                     (kill-all-local-variables)
+                     (setq major-mode 'ghostel-mode)
+                     (setq-local ghostel-exit-functions nil)))
+                  ((symbol-function 'majutsu-display-buffer)
+                   (lambda (buffer) (setq terminal buffer))))
+          (should-error
+           (majutsu-terminal-session-start-jj
+            '("arrange") :origin-buffer origin
+            :exec-function (lambda (&rest _) nil)))
+          (should-not (gethash "/repo/"
+                               majutsu-terminal-session--live-sessions))
+          (should-not (buffer-live-p terminal)))))))
+
+(ert-deftest majutsu-terminal-session-finish-after-kill/waits-for-live-reaper ()
+  "Do not compare operation ids until Ghostel's reaper has exited."
+  (let ((session (majutsu-terminal-session-create :process 'reaper))
+        scheduled completed)
+    (cl-letf (((symbol-function 'processp) (lambda (_process) t))
+              ((symbol-function 'process-live-p) (lambda (_process) t))
+              ((symbol-function 'run-at-time)
+               (lambda (&rest args) (setq scheduled args)))
+              ((symbol-function 'majutsu-terminal-session--finish)
+               (lambda (&rest _) (setq completed t))))
+      (majutsu-terminal-session--finish-after-kill session)
+      (should-not completed)
+      (should (equal scheduled
+                     (list 0.05 nil
+                           #'majutsu-terminal-session--finish-after-kill
+                           session))))))
+
+(ert-deftest majutsu-terminal-session-finish-after-kill/completes-after-reaper ()
+  "A stopped lifecycle process completes the session immediately."
+  (let ((session (majutsu-terminal-session-create :process 'reaper))
+        completed)
+    (cl-letf (((symbol-function 'processp) (lambda (_process) t))
+              ((symbol-function 'process-live-p) (lambda (_process) nil))
+              ((symbol-function 'majutsu-terminal-session--finish)
+               (lambda (value &rest _) (setq completed value))))
+      (majutsu-terminal-session--finish-after-kill session)
+      (should (eq completed session)))))
+
+(ert-deftest majutsu-terminal-session-ghostel-exit/defers-without-exit-status ()
+  "Ghostel completion uses its event and never interprets a process status."
+  (let* ((buffer (generate-new-buffer " *majutsu-ghostel-exit*"))
+         (session (majutsu-terminal-session-create
+                   :repository-root "/repo/"))
+         scheduled
+         completed)
+    (unwind-protect
+        (progn
+          (with-current-buffer buffer
+            (setq-local majutsu-terminal-session--session session))
+          (cl-letf (((symbol-function 'run-at-time)
+                     (lambda (&rest args) (setq scheduled args))))
+            (majutsu-terminal-session--ghostel-exit buffer "finished\n"))
+          (should (equal scheduled
+                         (list 0 nil
+                               #'majutsu-terminal-session--finish
+                               session "finished\n")))
+          (cl-letf (((symbol-function 'process-exit-status)
+                     (lambda (&rest _)
+                       (ert-fail "Ghostel completion read process status")))
+                    ((symbol-function 'majutsu-terminal-session--complete)
+                     (lambda (&rest args) (setq completed args))))
+            (apply (nth 2 scheduled) (nthcdr 3 scheduled)))
+          (should (equal completed (list session "finished\n"))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest majutsu-terminal-session-complete/observers-survive-probe-failure ()
+  "Exit function and hook run once even when the completion probe errors."
+  (let ((exit-calls 0)
+        (hook-calls 0)
+        (unregistered nil)
+        (session (majutsu-terminal-session-create
+                  :repository-root "/tmp/repo/"
+                  :origin-buffer (current-buffer)
+                  :operation-id-before "op"
+                  :terminal-p t)))
+    (setf (majutsu-terminal-session-exit-function session)
+          (lambda (_session _event) (cl-incf exit-calls)))
+    (cl-letf (((symbol-function 'majutsu-interactive-complete-repository-operation)
+               (lambda (&rest _) (error "probe failed")))
+              ((symbol-function 'majutsu-terminal-session--unregister)
+               (lambda (_) (setq unregistered t))))
+      (let ((majutsu-terminal-session-exit-hook
+             (list (lambda (_session _event) (cl-incf hook-calls)))))
+        (should-error (majutsu-terminal-session--complete session nil))
+        (should unregistered)
+        (should (= exit-calls 1))
+        (should (= hook-calls 1))
+        ;; The completed-p latch keeps later finish paths idempotent.
+        (should-not (majutsu-terminal-session--complete session nil))
+        (should (= exit-calls 1))
+        (should (= hook-calls 1))))))
+
+(provide 'majutsu-terminal-session-test)
+;;; majutsu-terminal-session-test.el ends here


### PR DESCRIPTION
Move Ghostel terminal registration and session bookkeeping out of
majutsu-diff-editor into majutsu-terminal-session so Arrange and other
interactive hosts can reuse the same live-session table and helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared terminal-session support for interactive `jj` operations.
  * Added automatic tracking of active sessions by repository workspace to prevent conflicting operations.
  * Added improved session completion handling, including buffer refreshes and cleanup after terminal closure.
  * Added clearer validation and error handling when starting terminal commands.

* **Bug Fixes**
  * Improved reliability for remote repositories and sessions that are manually closed.
  * Ensured completion actions run consistently, even when refresh checks encounter errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->